### PR TITLE
v0: resumable event-log runner for a single Writer node

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,10 @@ env.local.sh
 .DS_Store
 .idea/
 .vscode/
+
+# Claude Code local worktrees — machine-local scratch, never repo content.
+# A worktree directory is itself a git checkout; adding it from the outer
+# repo (e.g. a stray `git add -A` run from the superproject root) records it
+# as a broken gitlink instead of real content. Keep it ignored so that can't
+# happen again.
+.claude/worktrees/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,113 @@
+# CLAUDE.md — LongHorizon-Harness (this worktree)
+
+## What this repo is
+
+LongHorizon-Harness (`src/lh_harness/`) is an execution/state-management
+harness that shells out to agent CLIs (Claude Code, Codex) to carry
+long-horizon tasks to verified completion. Manager/Executor/Auditor role
+separation, `AgentAdapter` protocol per backend, isolated `runs/<run-id>/`
+directories. See README.md for the shipped product.
+
+This worktree (`rdh-v0-resumability`) is building the **Recursive
+Decomposition Harness** described in `PLAN.md` (repo root, one level up —
+not checked into this worktree's git history; read it directly if it's
+missing here) on top of this codebase. `PLAN.md` §13 defines a build ladder;
+this worktree implements **v0**.
+
+## v0 — resumability (`src/lh_harness/v0/`)
+
+The load-bearing property (`PLAN.md` §10): `events.jsonl` is append-only and
+fsync'd, and replaying it after a `kill -9` at any point converges to exactly
+one artifact and one terminal event per node — no double work, no lost work.
+
+- `v0/events.py` — `EventLog`: `append()` fsyncs every write (not just
+  flush); `read_all()` silently drops a torn trailing line (kill -9 mid
+  `write()` can only corrupt the line being written, and fsync-per-append
+  means that's always the last line at kill time); `last_event()` /
+  `has_terminal()` for querying node state.
+- `v0/run_dir.py` — `create_run_dir(root, run_id)` (idempotent) plus path
+  helpers for `events.jsonl`, `manifest.jsonl`, `scratch/<node>/trace.jsonl`,
+  `out/<node>.md`. A minimal slice of the full `PLAN.md` §5 layout — no
+  `spine.json`/`tree.json`/`contract.md` yet, those come in v1+.
+- `v0/runner.py` — `run_node(run_dir, node_id, prompt, adapter, env, budget)`.
+  One idempotent entrypoint for both first-run and resume: it inspects
+  `events.jsonl` for the node's furthest-reached state (`episode_completed` →
+  no-op replay; `session_captured` → continuation via
+  `resume_session_id` if the adapter supports it, else fresh redispatch;
+  `node_dispatched` only → fresh redispatch; nothing → first dispatch) and
+  proceeds from there. While the episode runs, a concurrent task tails the
+  live trajectory file for the first `session_id` and durably records
+  `session_captured` *before* `run_episode()` returns, since a crash can
+  land any time after that line hits disk. `run`/`resume` are thin aliases
+  of the same function.
+
+Event `type` vocabulary: `node_dispatched`, `session_captured` (carries
+`session_id`), `episode_completed` (carries `status`, `artifact_path`),
+`node_redispatched` (carries `reason`: `resumed_session` |
+`no_session_captured` | `resume_unsupported`).
+
+## Adapter changes (additive, backward compatible)
+
+- `adapters/cli_agent.py` — `CommandAgentAdapter.run_episode` gained a
+  keyword-only `command_override: str | None = None`, and the class gained a
+  `supports_session_resume = False` class attribute. Existing positional/
+  kwarg call sites (`manager.py`, `auditor_agent.py` via `manager.py`'s
+  `_run_role_episode`) are unaffected.
+- `adapters/claude_code.py` — `ClaudeCodeAdapter.supports_session_resume =
+  True`. `run_episode` gained a keyword-only `resume_session_id: str | None
+  = None`; when set, it splices `--resume <id>` into the same command parts
+  used for a fresh dispatch (deny-tools, model, mcp-config all preserved)
+  and passes it as `command_override`.
+- `adapters/codex.py` — untouched. `codex exec` has no session-continuation
+  flag, so `CodexAdapter` inherits `supports_session_resume = False` and
+  `v0/runner.py` falls back to fresh redispatch for it rather than erroring.
+
+## Tests
+
+`tests/test_v0_resume.py` — stdlib `unittest`, no pytest, no network, no
+real `claude`/`codex` binary. Run:
+
+```
+python3 -m unittest discover -s tests -p "test_v0_resume.py" -v
+```
+
+~7s, 4 tests, all passing as of the v0 build:
+
+1. `ResumeAfterSessionCrashTest` — launches `run_node` as a real OS
+   subprocess (`tests/fixtures/run_node_subprocess.py`), polls for
+   `session_captured`, then `SIGKILL`s **both** the runner subprocess *and*
+   the actual fake-CLI child process (they end up in different process
+   groups because `LocalEnvironment.exec` gives the agent CLI its own
+   session — killing only the runner's group would leak the child). Verifies
+   the child pid is actually dead, then resumes in-process and asserts
+   exactly one `episode_completed`, a `resumed_session` redispatch, and the
+   fake CLI's resume-acknowledgment text in the final artifact (proving real
+   continuation, not a lucky fresh run).
+2. `ResumeBeforeSessionCrashTest` — same mechanics, but kills during a
+   `--startup-delay` window before any stdout line exists, so resume must
+   fall back to `no_session_captured`.
+3. `ResumeAfterCompleteIsNoopTest` — calls `run_node` twice to completion;
+   asserts the second call appends zero new events and returns the replayed
+   result without touching the artifact.
+4. `EventLogFsyncTest` — mocks `os.fsync` to confirm `EventLog.append` truly
+   calls it (not just `flush()`), once per append.
+
+Fixtures (`tests/fixtures/`):
+- `fake_stream_agent.py` — standalone script mimicking Claude Code's
+  `stream-json` output: writes its own pid to `--pidfile` immediately (so a
+  test can find and kill it before it emits anything), emits a `session_id`
+  line, sleeps `--work-delay`, emits a completion line; with `--resume <id>`
+  it emits a resume-acknowledgment line and finishes fast instead.
+- `fake_adapter.py` — `FakeStreamAgentAdapter(CommandAgentAdapter)`, the test
+  double for `ClaudeCodeAdapter`: `supports_session_resume = True`, same
+  `resume_session_id` passthrough.
+- `run_node_subprocess.py` — CLI wrapper so `run_node` can be launched as an
+  independently-killable OS process.
+
+## Explicitly out of scope for v0 (do not build here)
+
+Orchestrator/Planner/Reviewer roles, `tree.json`/`spine.json`/
+`contract.md`, per-node tool restriction, gates. `manager.py`,
+`auditor_agent.py`, `cli.py`'s role wiring, and `role_prompts.py` were not
+touched — v0 is additive scaffolding, wiring it into the full CLI loop is a
+later milestone (`PLAN.md` §13 v1+).

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,701 @@
+# PLAN.md — Recursive Decomposition Harness
+
+**Status:** v0 (resumability) implemented and tested. See Progress below.
+**Scope:** general-purpose long-horizon task executor. Not a coding harness.
+
+## Progress
+
+- **v0 — prove resumability (§13): done.** `src/lh_harness/v0/` — fsync'd
+  append-only `EventLog`, idempotent `run_node()` that converges to exactly
+  one artifact/terminal event no matter when a `kill -9` lands, and session
+  continuation for `ClaudeCodeAdapter` via `claude --resume <id>` (Codex has
+  no equivalent, falls back to fresh redispatch). Proven by
+  `tests/test_v0_resume.py`, which SIGKILLs real OS subprocesses (not
+  in-process mocks) — 4/4 passing. Existing role files
+  (`manager.py`/`auditor_agent.py`/`cli.py`/`role_prompts.py`) untouched;
+  this is additive scaffolding. Decision on file placement: build directly
+  inside `src/lh_harness/`, eventually replacing Manager→Orchestrator,
+  Executor→Writer, Auditor→Reviewer in place (not a separate package).
+  See `CLAUDE.md` for the file-by-file breakdown.
+- **v1 — the round loop: not started.** Needs the OpenAI-compatible provider
+  module (§12) for Orchestrator/Planner/Reviewer direct-API calls — model
+  credentials are on hand (OpenCode Zen, `opencode/deepseek-v4-flash-free`)
+  but the provider module itself isn't written yet.
+- **v2–v4:** not started.
+
+---
+
+## 1. Problem
+
+LLMs fail at long-horizon tasks for three reasons: context windows fill, provider
+limits interrupt, and no one verifies that "done" means done. Existing harnesses
+mostly address the first two. This one is built around the third, and around a
+harder constraint: **no task may be attempted at a size the model can't reliably
+handle.**
+
+The framework is corpus-agnostic. It must work on a textbook with a table of
+contents, a folder of unstructured personal lecture notes, a codebase, or a
+research corpus, without special-casing any of them.
+
+---
+
+## 2. Invariants
+
+These are the non-negotiable properties. Every design decision below exists to
+serve one of them.
+
+1. **Nothing declares itself done.** Only the harness writes `status: passed`,
+   and only after gates evaluate.
+2. **Decomposition is unconditional and gated by code**, not by model judgment
+   about whether a task "feels" too big.
+3. **Every context is bounded and constant-size.** No context grows with corpus
+   size or run length — including the orchestrator's.
+4. **The filesystem is the state.** Model contexts are scratch space, rebuilt
+   from disk. Any context can be destroyed and reconstructed.
+5. **Anything a script can compute, a script computes.** Model tokens are spent
+   only on judgment.
+6. **Cross-agent isolation.** No agent sees another agent's reasoning, scratch,
+   or raw tool output.
+7. **Small outputs everywhere.** Every model call — including planning calls —
+   emits a small artifact. Large generations are the observed failure mode.
+
+---
+
+## 3. Roles
+
+Four roles. Three are pure text-in / JSON-out and are called via the API
+directly. Only the Writer needs a full agent loop with file editing.
+
+| Role | Reads | Writes | Loop? |
+|---|---|---|---|
+| **Orchestrator** | `tree.json`, `manifest.jsonl` tail, open gates | dispatch decisions | no — stateless per round |
+| **Planner** | `spine.json`, global rubric, node templates | flat list of child nodes | no |
+| **Writer** | its node brief, declared inputs, contract | one artifact | yes — agent CLI |
+| **Reviewer** | artifact, contract, rubric | structured verdict | no |
+
+**Orchestrator is stateless per round.** Fresh context every round, rebuilt from
+disk: read compact tree, read manifest tail, decide next node, dispatch, discard.
+~2–3K tokens per round regardless of whether the run has 40 nodes or 400.
+
+**Planner never sees source content.** Its context is the spine (unit labels +
+token counts), the global rubric, and node-type templates. Constant size for a
+900-page corpus.
+
+**Reviewer never sees the Writer's reasoning or scratch.** Artifact + contract +
+rubric only. A reviewer that can see the writer's justification talks itself into
+accepting.
+
+**Reviewer cannot write.** Verdicts and scoped defects only. Repairs are separate
+Writer nodes.
+
+---
+
+## 4. Pipeline
+
+```
+intake → survey → plan → pilot → [execute → review → repair]* → assemble
+           ↑                ↑
+      (spine.json)   (user approval → contract.md frozen)
+```
+
+### 4.1 Intake
+
+Elicits the **global rubric** once, through questioning — not assumption.
+Roughly: audience and level; purpose (exam prep / reference / first pass); what
+makes something important here; what to exclude outright; required components per
+unit; target length; fidelity to source wording.
+
+Anything intake can't resolve becomes an explicit **assumption line** in the
+global rubric, surfaced for user review before execution begins. This is how we
+get "no unstated assumptions" without an unbounded interview.
+
+Per-node rubrics are **derived** from the global rubric plus node type via
+templates. Never re-elicited per node.
+
+### 4.2 Survey — structure discovery
+
+Three stages, uniform output regardless of input structure.
+
+1. **Mechanical chunking** (no model). Split on whatever boundaries exist:
+   headings, page breaks, dates, file boundaries, blank-line runs. Compute
+   per-chunk token counts.
+2. **Windowed survey** (model, tiny outputs). Walk chunks in overlapping windows.
+   Each call emits only candidate boundaries:
+   `{"boundary_after": 11, "label": "shift to Lagrangian formulation", "confidence": 0.8}`.
+   Never a summary. Never content. No call ever sees the whole corpus.
+3. **Spine assembly** (harness). Merge boundary votes, apply a minimum-size floor,
+   emit `spine.json`.
+
+A textbook's TOC makes stage 2 nearly free. Lecture notes make it do real work.
+Downstream is identical.
+
+### 4.3 Plan — recursive, one level at a time
+
+The planner is subject to the same small-output rule as everything else.
+
+1. Planner call #1 sees the spine, emits a top-level partition (8–12 children,
+   **flat list**, parent implied by the call — never nested JSON).
+2. Harness runs the leaf gate on each child.
+3. Each child failing the gate gets **its own separate planner call** for its
+   children.
+4. Recurse to depth cap (4) with a node-count cap.
+
+**Leaf gate.** A node may be a leaf only if *all* hold — checked by the harness,
+not asserted by the model:
+
+- produces exactly one named artifact
+- required inputs fit under the node token budget
+- done-condition expressible as one checkable sentence
+- estimated tool calls ≤ K (start K=15)
+
+Fail any → harness rejects the leaf and forces another split.
+
+### 4.4 Pilot — the consistency mechanism
+
+Sizing classifies nodes by **shape** (prose-dominant, derivation-dominant,
+problem-set-dominant, etc.). Run **one pilot per shape**, usually two or three
+total. Not "the first node" — the first chapter of anything is atypical.
+
+For each pilot:
+
+1. Writer produces the artifact.
+2. Run enters `awaiting_approval` (a durable event-log state, not a blocking
+   prompt — the user can return the next morning).
+3. User edits the file **directly on disk** in their own editor.
+4. `harness approve` diffs original vs. edited.
+5. **Contract derivation** reads that diff. The diff is the highest-signal input
+   in the whole system — "user deleted every historical aside," "user cut examples
+   to three lines" — rules that could never be elicited by asking.
+6. `contract.md` is frozen.
+
+Only two things may write to the contract: pilot derivation, and explicit user
+amendment. **Reviewer suggestions must never reach it** — otherwise requirements
+inflate monotonically and node 30 is held to a stricter bar than node 2.
+
+Reviewers get the **contract plus a short excerpt**, with `read_exemplar(section)`
+available as a tool. Always-loading the full exemplar costs its token count on
+every review turn for the rest of the run.
+
+### 4.5 Execute / review / repair
+
+Sequential by default (one node at a time). Nodes carry `depends_on` anyway —
+costs nothing now, unlocks parallelism later. Freezing the contract after the
+pilot makes the remaining leaves genuinely independent, so parallelism is a
+config change rather than a redesign.
+
+A leaf has **no `finish()` tool**. Its terminal action is `submit(artifact_path)`.
+The harness runs gates and either passes the node or returns unmet item IDs with
+one-line reasons. Three failed submits → escalate to the user, don't loop.
+
+Defects are **scoped and located** ("§Worked Examples, example 2 omits the
+intermediate step"). Repair writers are instructed to make the minimal change.
+Freeform prose suggestions get over-applied and drift the artifact away from the
+exemplar in the name of fixing it.
+
+### 4.6 Assemble
+
+Three things, two of which need no model:
+
+1. **Concatenation + index** — script. Generate `main.tex` (or equivalent) with
+   `\input{}` lines ordered from `tree.json`. Zero tokens.
+2. **Cross-cutting checks** — script. Do all `refs_out` resolve? Is every used
+   term in `glossary.json`? Duplicate definitions? Continuous numbering? Empty
+   sections? Emit `assembly/checks.json`.
+3. **Compile + repair** — model. Run `latexmk`; **exit code and log are the gate.**
+
+**Critical guardrail:** the assembler's file tools are **read-only over `out/`**.
+A compile error becomes a repair node scoped to the offending file, which goes
+back through review. Otherwise the assembler "helpfully" edits content to make the
+build green and you ship a passing compile over corrupted content that already
+passed review.
+
+Parse warnings too, not just errors — undefined references, overfull boxes past a
+threshold, missing citations. Free structural checks that catch cross-unit
+breakage per-unit review can't see.
+
+**Holistic gap (accepted deliberately):** because the orchestrator never reads
+content, nobody ever looks at the whole thing. Add an explicit **sampling node**
+near the end — read units 1, 14, 27, check against `spec.md`, report — budgeted
+like any other leaf.
+
+---
+
+## 5. Run directory
+
+Harness-owned. **Code creates it, code enforces it.** If agents choose their own
+paths, the orchestrator can no longer navigate by path without reading.
+
+```
+.harness/runs/<run-id>/
+  spec.md              frozen: goal, global rubric, approved assumptions
+  contract.md          frozen after pilot; hard token ceiling
+  spine.json           discovered structure
+  tree.json            nodes, deps, gates, status
+  manifest.jsonl       one machine-written line per completed leaf
+  events.jsonl         append-only, fsync'd — the resume log
+  glossary.json        append-only, term → defining location
+  orchestrator/
+    round-NN.jsonl     per-round trace (naturally chunked — stateless rounds)
+  scratch/
+    <node>/
+      notes.md         working notes
+      raw/             tool dumps; nothing else ever reads these
+      trace.jsonl      streamed reasoning — write-once, never re-read by any agent
+      promotion.json   ≤300 tokens, the only thing that escapes
+  out/
+    <node>.md          artifacts
+    .versions/         pre-repair snapshots
+  audit/
+    <node>.json        gate results + reviewer verdict
+  assembly/
+    index.md, checks.json, main.tex
+```
+
+**Enforcement, not instruction:** each leaf's file tools are chrooted to its own
+`scratch/<node>/`, its declared inputs, and its artifact path. Not a prompt rule —
+an actual restriction in the tool implementation. That's what guarantees no leaf
+can pull another leaf's raw dumps into context.
+
+`scratch/<node>/` is deletable once the node passes. Keep it for debugging; it's
+never in anyone's context again.
+
+---
+
+## 6. Schemas
+
+### Node (`tree.json`)
+
+```json
+{
+  "id": "ch07",
+  "type": "chapter-summary",
+  "shape": "derivation-dominant",
+  "brief": "…what and why, ~2 sentences…",
+  "inputs": ["source.pdf#pp.184-211"],
+  "artifact": "out/ch07.md",
+  "tools": ["read_span", "write", "glossary_lookup"],
+  "budget": {"tokens": 24000, "calls": 15},
+  "gates": ["headers:std", "problems>=5", "terms_defined", "len:1200-2000"],
+  "judgment": ["R1", "R2", "R3"],
+  "depends_on": ["contract:frozen"],
+  "status": "pending"
+}
+```
+
+`tools` is **per-node**. This is the single biggest token lever and it also
+improves reliability — a surveyor with three read-only tools is both cheaper and
+better than one with fifteen.
+
+### Manifest line (`manifest.jsonl`)
+
+Everything except `promotion` is **derived by the harness from the artifact** —
+no model involvement, no hallucination surface.
+
+```json
+{"node":"ch07","artifact":"out/ch07.md","tokens":1640,
+ "headers":["Overview","Key Terms","Worked Examples","Practice"],
+ "terms_defined":["flux","divergence"],"terms_used_undefined":[],
+ "refs_out":["ch05#gauss"],"problems":6,"gates":"pass",
+ "promotion":"used vector-field notation from ch05; deferred Stokes to ch09"}
+```
+
+This is enough for the orchestrator to plan repairs, order assembly, and answer
+"what's left" without opening a single artifact.
+
+### Reviewer verdict (`audit/<node>.json`)
+
+```json
+{"node":"ch07","contract_version":3,
+ "items":[{"id":"R1","pass":true},
+          {"id":"R2","pass":false,
+           "defect":"§Worked Examples, ex.2 omits intermediate step",
+           "class":"patchable"}],
+ "verdict":"fail"}
+```
+
+---
+
+## 7. Rubrics: gates vs. judgment
+
+Split by checkability. This is how "no room to say I'm done" costs almost no
+context.
+
+**Gates** — machine-checkable, live in the harness, **never enter model context**.
+File exists, required headers present, ≥N practice problems, formulas in LaTeX, no
+undefined glossary terms, length in band, every source section referenced. The
+writer doesn't read "must have ≥5 problems"; it fails the gate and gets
+`unmet: R3 (4 problems, need 5)`.
+
+**Judgment** — terse imperatives in the brief, 3–6 lines max:
+
+```
+R1 define every bolded term from source span
+R2 worked example for each procedure, not each theorem
+R3 exclude historical/biographical material
+```
+
+Twelve invisible gate items + four visible judgment items = full enforcement at
+near-zero prompt cost.
+
+**Calibration risk:** gates too strict → leaves fail three times and escalate on
+trivia → you babysit. Start with gates that are structural and unambiguous; keep
+judgment items genuinely soft. Tighten after seeing where real failures cluster.
+
+---
+
+## 8. Context discipline
+
+Where input tokens actually go, in rough order of waste, for a 15-turn leaf:
+
+1. **Tool schemas** — 15 verbose tools ≈ 3–4K tokens resent every turn ≈ 50K
+   wasted on one leaf. Fixed by per-node `tools`.
+2. **Raw tool results** — `read_file` dumping 800 lines when three functions were
+   needed pollutes every subsequent turn. Use `read_span`, symbol-level reads,
+   grep-with-context. Never cat the whole source.
+3. **Turn history** — grows quadratically in turns. This is the real argument for
+   small leaves: a 6-turn leaf costs far less than a third of an 18-turn leaf.
+   Enforce `budget.calls` as a hard stop that triggers **re-split**, not a warning.
+4. **Restatement** — rubric in system prompt, again in brief, again in a reminder.
+   Say everything once; let position do the work.
+
+**Excluded from every leaf context:** the full task tree (it gets its node plus a
+one-line parent), any other leaf's output, the raw source document, history from
+prior leaves, schemas for tools it can't call.
+
+**Prompt ordering** — most-stable to least-stable, for prefix caching:
+system → tool schemas → frozen contract → node brief → inputs → turn history.
+Never interleave volatile state into the system prompt. If the contract is still
+mutating, place it *after* the tool schemas.
+
+**Instrument it.** Log per-turn input tokens broken down by segment (system /
+tools / contract / brief / inputs / history). Put *mean input tokens per leaf* in
+the eval suite next to correctness — otherwise a prompt tweak that doubles the
+bill looks identical to one that doesn't.
+
+---
+
+## 9. Reasoning traces
+
+**Policy:** thinking is streamed to the user, written once to
+`scratch/<node>/trace.jsonl`, and **never read by any agent.** Not in promotions,
+not in manifest lines, not in reviewer context.
+
+Enforce structurally: put traces in a store the prompt assembler physically cannot
+read from. Discipline fails at 2am; a type error doesn't.
+
+**Within-agent carve-out:** the *current* turn's reasoning must accompany the tool
+result back to the model on the next call, or multi-step reasoning degrades —
+silently. Note that Anthropic's API already strips earlier turns' thinking
+automatically, so effective behavior closely matches the intended policy. Verify
+against current docs for whichever endpoint is in use.
+
+**Retry after failure:**
+- Failure before generation (429, connect error) → nothing produced, plain retry.
+- Stream dies mid-generation → cannot resume; must re-query. Partial reasoning
+  **cannot** be re-sent as a signed reasoning block (truncated → signature fails).
+  Re-inject as labeled plain text with explicit permission to discard:
+  *"Your previous attempt was interrupted. Partial reasoning (unverified, may end
+  mid-thought): … Continue from here or restart if it looks wrong."*
+- Only re-inject above a floor (~1000 tokens of partial reasoning). Below that,
+  regenerating is cheaper than paying to re-read it.
+
+Traces will be large and completely inert. Rotate or compress per node; the viewer
+streams from the tail rather than loading whole files.
+
+---
+
+## 10. Failure, resume, intervention
+
+**Resume.** `events.jsonl` is append-only and fsync'd. Every event carries `ts`,
+`node_id`, `role`, `round`, `type`. Resume replays to the exact tool call. This is
+the load-bearing property — build and test it first.
+
+**Never interrupt mid-turn.** Queue interventions; apply at the next node
+boundary. Killing mid-turn loses the turn's work and can leave a half-written
+artifact.
+
+**Three intervention types, by blast radius:**
+
+| Type | Effect | Radius |
+|---|---|---|
+| **Reopen node** | mark failed with a user-written defect; re-enters queue as repair | one node |
+| **Amend contract** | new rules downstream; completed nodes now `stale` | whole run |
+| **Halt** | stop after current node | — |
+
+**Contract amendment → re-validation pass.** Do *not* blanket-regenerate. Re-run
+the existing **Reviewer** (read-only, stateless, no writers dispatched) against
+the amended contract as review-only nodes. Cost ≈ N × (contract + rubric +
+artifact). Show that estimate before running.
+
+Triage each completed node into three buckets:
+
+- **Clean** — already satisfies the amendment. No action.
+- **Patchable** — small scoped edit. Additive amendments usually land here
+  ("every unit needs a summary box" → append a box).
+- **Regenerate** — the amendment contradicts what was written
+  ("worked solutions → hints-only"). Full re-run.
+
+Present counts, get approval, then execute. Snapshot to `out/.versions/` before
+any repair — if the amendment was itself the mistake, you'll only realize it three
+chapters in.
+
+**Approval-rate tracking, segmented by shape.** A global drop from 90%→60% says
+something is wrong. A rate that's fine for prose units and collapsing on
+derivation-heavy ones says *which exemplar to re-pilot*. Below threshold → halt
+and offer re-pilot rather than grinding out thirty more units that all need
+repair.
+
+---
+
+## 11. Interfaces
+
+**Control surface: CLI.** `harness run`, `status`, `approve`, `amend`, `resume`.
+
+**View surface: local web app.** `harness serve` → localhost, SSE streaming,
+separate process watching the run directory. It can crash without touching the
+run; it can be attached from anywhere.
+
+Rationale for the split: liking the terminal and wanting to review a 2,000-word
+document in it are different preferences. The pilot-approval step is document
+editing plus PDF preview, which terminals are bad at.
+
+**Build neither first.** Structured logs + `tail`/`jq` gets a working harness. The
+web view is additive.
+
+**Default node view** — raw JSONL is unusable; nobody will read it. Show: brief
+given, gate results (pass/fail per item), reviewer verdict lines, artifact diff,
+**input tokens by segment**. Raw trace one keypress away. In practice correction
+happens from the verdict; the trace is for debugging the harness, not the content.
+
+Streaming-reasoning rendering is commodity — lift it from existing work. Writer
+leaves shelled out to an agent CLI get its rendering free; direct-API roles render
+from `trace.jsonl`. Don't build stream rendering twice.
+
+---
+
+## 12. Provider layer
+
+**Scope for v1: OpenAI-compatible only.** Test model: DeepSeek V4 Flash Free via
+OpenCode Zen.
+
+Testing on a weak free model is the correct development target. A frontier model
+compensates for harness defects and everything looks like it works; then you swap
+models and can't tell which of forty design choices was load-bearing. Free-tier
+rate limits also exercise backoff and resume paths continuously, for free.
+
+**Do not build a provider abstraction now.** Keep everything provider-specific in
+**one module** (~200 lines): stream parsing, reasoning extraction, structured
+output, tool-call format. Later portability costs one file instead of a refactor.
+
+Notes for OpenAI-compatible endpoints:
+- Reasoning arrives as `reasoning_content` alongside `content` in the delta.
+- `response_format: json_schema` support varies. **Build the fallback regardless:**
+  schema in prompt → parse → validate → re-prompt with validator error. Catches
+  semantically-invalid-but-syntactically-valid output too.
+- Prefix caching is usually automatic; no explicit breakpoints. Stable-first
+  prompt ordering still pays off, implicitly.
+
+**Role/model routing:** orchestrator, planner, and reviewer are cheap
+structured-output calls and should run on the cheapest capable model. Only the
+writer needs the strong one. This is a config table, not code.
+
+---
+
+## 13. Build ladder
+
+**v0 — prove resumability.** Shell out to an agent CLI headless on a single task.
+Append-only fsync'd event log, run directory. Then `kill -9` mid-task and resume.
+If this isn't perfect, nothing above it works. Everything else is downstream.
+
+**v1 — the round loop.** Orchestrator/Writer/Reviewer with schema-constrained JSON
+returns and per-node tool restriction. Task state in JSON; markdown only as a
+rendered view. No node enters the tree without a machine-checkable exit condition.
+Writer returns capped at ~400 tokens.
+
+**v2 — intake, survey, recursive planning.** Assumptions-list protocol. Mechanical
+chunking + windowed survey → `spine.json`. Level-at-a-time planner with flat child
+lists. Pilot + contract derivation from the user's diff.
+
+**v3 — assembly and repair.** Deterministic concatenation, cross-cutting checks,
+compile gate, scoped repair nodes. Re-validation pass for contract amendments.
+
+**v4 — research tools.** Web search subagent, current-docs retrieval. Lowest
+priority: these are retrieval fixes; everything above is a correctness fix.
+
+---
+
+## 14. Eval
+
+Start at **v1**, not at the end. Five fixed tasks, three runs each. Measure:
+
+- resume correctness after `kill -9` at randomized points
+- does the reviewer catch a deliberately broken node
+- does the orchestrator's context stay bounded as node count grows
+- mean input tokens per leaf
+- planner schema-validity rate and leaf/split gate sanity
+- approval rate by shape
+
+Without this, prompt tuning is vibes, and weak models are noisy enough that vibes
+mislead.
+
+### Pre-implementation spikes (cheap, do first)
+
+1. **Planner conformance.** Synthetic spine of 40 units with sizes → valid
+   top-level partition, 20 runs. Measure schema validity, dependency-edge sanity,
+   and how often it returns `leaf` for something obviously oversized.
+2. **Survey quality on real unstructured input.** Run the windowed survey over
+   actual lecture notes. Do the proposed boundaries match where you'd have drawn
+   them? This is the one that tells you whether the general-purpose ambition holds.
+
+---
+
+## 15. Reuse inventory
+
+### 15.1 Base — clone LongHorizon-Harness and start there
+
+`github.com/AMAP-ML/LongHorizon-Harness` — MIT, Python ≥3.10, `uv tool install
+lh-harness`. **This is the starting point. Clone it, don't reimplement it.**
+
+What it already gives us, matching §3–§5 almost directly:
+
+- Manager / Executor / Auditor role separation with per-role model assignment
+- Fresh-context execution per round (our §3 stateless orchestrator)
+- Only independently-verified results enter persistent task state (our §2.1)
+- Isolated `runs/<run-id>/` with task state, event stream, audit reports, role
+  trajectories, workspace, final report (our §5, nearly one-to-one)
+- Dashboard with human gates on complete / blocked / needs-input / repeated-fail
+  (our §10 intervention model)
+- `AgentAdapter` abstraction preserving each backend's native loop
+- Execution environments: local, `ssh://`, `docker://`
+- `eval/` with frozen reproduction suites — a template for our §14
+
+**First concrete task:** it ships adapters for `claude_code`, `codex`, and
+`openclaw` only. Write an `AgentAdapter` for OpenCode. That single file is the
+whole "orchestration layer on top of existing CLIs" decision made real.
+
+**Our deltas on top** (nothing below exists in it): recursive level-at-a-time
+planner, survey/spine discovery, the leaf gate, gates-vs-judgment rubric split,
+pilot + contract derivation from user diff, per-node tool restriction, the
+derived manifest, deterministic assembly with a read-only assembler.
+
+### 15.2 Tools — commodity, lift wholesale
+
+The set is identical across every harness: `glob`, `grep`, `read`, `edit`,
+`write`, `bash`. Nobody should write these again.
+
+Ranked by ease of extraction into Python:
+
+- **gptme** (MIT, Python, ~4k stars) — deliberately small: shell, Python
+  execution, file editing. Cleanest small donor, scriptable, works with weak
+  models. Probably the first place to look.
+- **Mini-Kode** — explicitly an educational reference implementation. Written to
+  be read, which is exactly what we want from a donor.
+- **Pi / pi-mono** (~83k stars) — minimal adaptable harness with unified LLM API,
+  tools, skills, and MCP. Heavier but the abstractions are good.
+- **OpenHands** (~83k stars) — most battle-tested sandboxed execution if we ever
+  need real isolation. Heavy; take the sandbox, not the framework.
+
+**Do not write web search or fetch.** Use MCP servers. Same for browser work
+(`playwright-mcp` uses accessibility-tree snapshots rather than screenshots,
+which is dramatically cheaper in tokens). §12's rule about keeping
+provider-specific code in one module applies here too — MCP is the seam.
+
+**Expect one modification everywhere:** every harness ships whole-file `read`.
+We need `read_span` (§8.2). Budget time for that; it's the difference between a
+leaf costing 3K and 30K input tokens.
+
+### 15.3 Subagents and delegation
+
+- **LongHorizon-Harness** role split is the base — see 15.1.
+- **statewright** — state-machine guardrails constraining which tools an agent may
+  call per workflow phase. This *is* our per-node `tools` field, already built and
+  benchmarked. Reported result: local models went from 2/10 to 10/10 on a
+  SWE-bench subset purely by shrinking the tool space. Read this before
+  implementing §6's `tools` restriction.
+- **Briefing pattern** — brief each subagent with the *rationale* (why this
+  subtask matters, how it fits the goal), not just the task description.
+  Documented to reduce redundant exploration. Already reflected in our node
+  `brief` field; make sure the template enforces it.
+- **subtask** (zippoxer) — subagents in git worktrees. Only relevant if we ever
+  turn on the parallelism that §4.5 leaves the door open for.
+- Reference datapoint for the architecture: subagents process ~67% fewer tokens
+  than skills in multi-domain scenarios, because context isolation prevents
+  cross-domain bloat.
+
+### 15.4 Skills — adopt the open standard instead of inventing node templates
+
+**This is the biggest find of the reuse pass.** Agent Skills is an open standard
+(`agentskills.io`), released by Anthropic in December 2025, now supported by 26+
+platforms including OpenCode, Codex, Cursor, Gemini CLI, and Copilot.
+
+A skill is a folder:
+
+```
+my-skill/
+  SKILL.md      required — YAML frontmatter (name, description) + markdown body
+  scripts/      optional — executable code
+  references/   optional — docs loaded on demand
+  assets/       optional — templates, examples
+```
+
+Three-tier progressive disclosure, which is precisely our §8 goal:
+
+1. **Advertise** — name + description injected at startup, ~80–100 tokens per
+   skill. Dozens of skills cost less than one activated skill.
+2. **Load** — full `SKILL.md` body on activation, recommended under 5,000 tokens.
+3. **Reference** — bundled files pulled only when actually needed.
+
+**The insight: our node-type templates and per-shape rubrics ARE skills.**
+`chapter-summary`, `derivation-dominant`, `problem-set`, `assembly` — each becomes
+a skill folder whose `SKILL.md` holds the rubric skeleton and judgment items,
+whose `scripts/` holds the gate implementations, and whose `references/` holds the
+approved exemplar. We get progressive disclosure for free, we stop inventing a
+bespoke template format, and the templates stay portable across whatever executor
+we shell out to.
+
+There is a reference Python library (Apache-2.0) that validates skills, reads
+properties, and emits `<available_skills>` prompt blocks. Use it for validation in
+CI; it's documented as demonstration-quality, not production.
+
+Related: **SkillOpt** (Microsoft) treats skills as optimizable parameters improved
+by execution feedback rather than static prompts — relevant much later, once we
+have approval-rate data per shape (§10).
+
+### 15.5 Build ourselves — no good donor exists
+
+- Recursive level-at-a-time planner with flat child lists (§4.3)
+- Survey / spine discovery for unstructured corpora (§4.2)
+- The leaf gate as harness-enforced code (§4.3)
+- Gates-vs-judgment rubric split (§7)
+- Pilot approval → diff → contract derivation (§4.4)
+- Derived manifest (§6)
+- Re-validation triage: clean / patchable / regenerate (§10)
+- Per-segment input-token accounting (§8)
+
+That's the actual project. Everything else is assembly.
+
+### 15.6 Licensing notes
+
+Permissive and safe: LongHorizon-Harness (MIT), OpenCode (MIT), gptme (MIT),
+Grinta (MIT), Agent Skills reference lib (Apache-2.0), OpenHands (MIT),
+playwright-mcp (Apache-2.0).
+
+Watch for: Loki Mode is BUSL-1.1, AgentsMesh is BSL-1.1 — usable to read, not to
+vendor.
+
+**Avoid entirely:** Claude Code is source-available, *not* open source — don't
+copy from it. More importantly, several popular repos (Claw Code, claw-code-agent,
+Free Code) are openly described as deriving from a March 2026 Claude Code source
+leak. Regardless of the license text they carry, that provenance is legally
+unsettled and they should not be a donor for anything intended to be published.
+Read them for ideas if you like; don't lift code.
+
+### 15.7 Also worth reading before writing our own
+
+- **Grinta** (Python, MIT) — event-stream ledger, checkpoint/revert, stuck
+  detection, completion-quality validation. Closest single-agent analogue to
+  what we want the leaf loop to feel like.
+- **Ralph Workflow / agx / AgentPlane** — resume and checkpoint patterns.
+- **Context7** — version-specific library docs via MCP, for the v4 research tools.
+- **headroom** — compresses bulky tool output before it enters context; relevant
+  if `read_span` proves insufficient.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,681 @@
+# PLAN.md — Recursive Decomposition Harness
+
+**Status:** design v0.1, pre-implementation
+**Scope:** general-purpose long-horizon task executor. Not a coding harness.
+
+---
+
+## 1. Problem
+
+LLMs fail at long-horizon tasks for three reasons: context windows fill, provider
+limits interrupt, and no one verifies that "done" means done. Existing harnesses
+mostly address the first two. This one is built around the third, and around a
+harder constraint: **no task may be attempted at a size the model can't reliably
+handle.**
+
+The framework is corpus-agnostic. It must work on a textbook with a table of
+contents, a folder of unstructured personal lecture notes, a codebase, or a
+research corpus, without special-casing any of them.
+
+---
+
+## 2. Invariants
+
+These are the non-negotiable properties. Every design decision below exists to
+serve one of them.
+
+1. **Nothing declares itself done.** Only the harness writes `status: passed`,
+   and only after gates evaluate.
+2. **Decomposition is unconditional and gated by code**, not by model judgment
+   about whether a task "feels" too big.
+3. **Every context is bounded and constant-size.** No context grows with corpus
+   size or run length — including the orchestrator's.
+4. **The filesystem is the state.** Model contexts are scratch space, rebuilt
+   from disk. Any context can be destroyed and reconstructed.
+5. **Anything a script can compute, a script computes.** Model tokens are spent
+   only on judgment.
+6. **Cross-agent isolation.** No agent sees another agent's reasoning, scratch,
+   or raw tool output.
+7. **Small outputs everywhere.** Every model call — including planning calls —
+   emits a small artifact. Large generations are the observed failure mode.
+
+---
+
+## 3. Roles
+
+Four roles. Three are pure text-in / JSON-out and are called via the API
+directly. Only the Writer needs a full agent loop with file editing.
+
+| Role | Reads | Writes | Loop? |
+|---|---|---|---|
+| **Orchestrator** | `tree.json`, `manifest.jsonl` tail, open gates | dispatch decisions | no — stateless per round |
+| **Planner** | `spine.json`, global rubric, node templates | flat list of child nodes | no |
+| **Writer** | its node brief, declared inputs, contract | one artifact | yes — agent CLI |
+| **Reviewer** | artifact, contract, rubric | structured verdict | no |
+
+**Orchestrator is stateless per round.** Fresh context every round, rebuilt from
+disk: read compact tree, read manifest tail, decide next node, dispatch, discard.
+~2–3K tokens per round regardless of whether the run has 40 nodes or 400.
+
+**Planner never sees source content.** Its context is the spine (unit labels +
+token counts), the global rubric, and node-type templates. Constant size for a
+900-page corpus.
+
+**Reviewer never sees the Writer's reasoning or scratch.** Artifact + contract +
+rubric only. A reviewer that can see the writer's justification talks itself into
+accepting.
+
+**Reviewer cannot write.** Verdicts and scoped defects only. Repairs are separate
+Writer nodes.
+
+---
+
+## 4. Pipeline
+
+```
+intake → survey → plan → pilot → [execute → review → repair]* → assemble
+           ↑                ↑
+      (spine.json)   (user approval → contract.md frozen)
+```
+
+### 4.1 Intake
+
+Elicits the **global rubric** once, through questioning — not assumption.
+Roughly: audience and level; purpose (exam prep / reference / first pass); what
+makes something important here; what to exclude outright; required components per
+unit; target length; fidelity to source wording.
+
+Anything intake can't resolve becomes an explicit **assumption line** in the
+global rubric, surfaced for user review before execution begins. This is how we
+get "no unstated assumptions" without an unbounded interview.
+
+Per-node rubrics are **derived** from the global rubric plus node type via
+templates. Never re-elicited per node.
+
+### 4.2 Survey — structure discovery
+
+Three stages, uniform output regardless of input structure.
+
+1. **Mechanical chunking** (no model). Split on whatever boundaries exist:
+   headings, page breaks, dates, file boundaries, blank-line runs. Compute
+   per-chunk token counts.
+2. **Windowed survey** (model, tiny outputs). Walk chunks in overlapping windows.
+   Each call emits only candidate boundaries:
+   `{"boundary_after": 11, "label": "shift to Lagrangian formulation", "confidence": 0.8}`.
+   Never a summary. Never content. No call ever sees the whole corpus.
+3. **Spine assembly** (harness). Merge boundary votes, apply a minimum-size floor,
+   emit `spine.json`.
+
+A textbook's TOC makes stage 2 nearly free. Lecture notes make it do real work.
+Downstream is identical.
+
+### 4.3 Plan — recursive, one level at a time
+
+The planner is subject to the same small-output rule as everything else.
+
+1. Planner call #1 sees the spine, emits a top-level partition (8–12 children,
+   **flat list**, parent implied by the call — never nested JSON).
+2. Harness runs the leaf gate on each child.
+3. Each child failing the gate gets **its own separate planner call** for its
+   children.
+4. Recurse to depth cap (4) with a node-count cap.
+
+**Leaf gate.** A node may be a leaf only if *all* hold — checked by the harness,
+not asserted by the model:
+
+- produces exactly one named artifact
+- required inputs fit under the node token budget
+- done-condition expressible as one checkable sentence
+- estimated tool calls ≤ K (start K=15)
+
+Fail any → harness rejects the leaf and forces another split.
+
+### 4.4 Pilot — the consistency mechanism
+
+Sizing classifies nodes by **shape** (prose-dominant, derivation-dominant,
+problem-set-dominant, etc.). Run **one pilot per shape**, usually two or three
+total. Not "the first node" — the first chapter of anything is atypical.
+
+For each pilot:
+
+1. Writer produces the artifact.
+2. Run enters `awaiting_approval` (a durable event-log state, not a blocking
+   prompt — the user can return the next morning).
+3. User edits the file **directly on disk** in their own editor.
+4. `harness approve` diffs original vs. edited.
+5. **Contract derivation** reads that diff. The diff is the highest-signal input
+   in the whole system — "user deleted every historical aside," "user cut examples
+   to three lines" — rules that could never be elicited by asking.
+6. `contract.md` is frozen.
+
+Only two things may write to the contract: pilot derivation, and explicit user
+amendment. **Reviewer suggestions must never reach it** — otherwise requirements
+inflate monotonically and node 30 is held to a stricter bar than node 2.
+
+Reviewers get the **contract plus a short excerpt**, with `read_exemplar(section)`
+available as a tool. Always-loading the full exemplar costs its token count on
+every review turn for the rest of the run.
+
+### 4.5 Execute / review / repair
+
+Sequential by default (one node at a time). Nodes carry `depends_on` anyway —
+costs nothing now, unlocks parallelism later. Freezing the contract after the
+pilot makes the remaining leaves genuinely independent, so parallelism is a
+config change rather than a redesign.
+
+A leaf has **no `finish()` tool**. Its terminal action is `submit(artifact_path)`.
+The harness runs gates and either passes the node or returns unmet item IDs with
+one-line reasons. Three failed submits → escalate to the user, don't loop.
+
+Defects are **scoped and located** ("§Worked Examples, example 2 omits the
+intermediate step"). Repair writers are instructed to make the minimal change.
+Freeform prose suggestions get over-applied and drift the artifact away from the
+exemplar in the name of fixing it.
+
+### 4.6 Assemble
+
+Three things, two of which need no model:
+
+1. **Concatenation + index** — script. Generate `main.tex` (or equivalent) with
+   `\input{}` lines ordered from `tree.json`. Zero tokens.
+2. **Cross-cutting checks** — script. Do all `refs_out` resolve? Is every used
+   term in `glossary.json`? Duplicate definitions? Continuous numbering? Empty
+   sections? Emit `assembly/checks.json`.
+3. **Compile + repair** — model. Run `latexmk`; **exit code and log are the gate.**
+
+**Critical guardrail:** the assembler's file tools are **read-only over `out/`**.
+A compile error becomes a repair node scoped to the offending file, which goes
+back through review. Otherwise the assembler "helpfully" edits content to make the
+build green and you ship a passing compile over corrupted content that already
+passed review.
+
+Parse warnings too, not just errors — undefined references, overfull boxes past a
+threshold, missing citations. Free structural checks that catch cross-unit
+breakage per-unit review can't see.
+
+**Holistic gap (accepted deliberately):** because the orchestrator never reads
+content, nobody ever looks at the whole thing. Add an explicit **sampling node**
+near the end — read units 1, 14, 27, check against `spec.md`, report — budgeted
+like any other leaf.
+
+---
+
+## 5. Run directory
+
+Harness-owned. **Code creates it, code enforces it.** If agents choose their own
+paths, the orchestrator can no longer navigate by path without reading.
+
+```
+.harness/runs/<run-id>/
+  spec.md              frozen: goal, global rubric, approved assumptions
+  contract.md          frozen after pilot; hard token ceiling
+  spine.json           discovered structure
+  tree.json            nodes, deps, gates, status
+  manifest.jsonl       one machine-written line per completed leaf
+  events.jsonl         append-only, fsync'd — the resume log
+  glossary.json        append-only, term → defining location
+  orchestrator/
+    round-NN.jsonl     per-round trace (naturally chunked — stateless rounds)
+  scratch/
+    <node>/
+      notes.md         working notes
+      raw/             tool dumps; nothing else ever reads these
+      trace.jsonl      streamed reasoning — write-once, never re-read by any agent
+      promotion.json   ≤300 tokens, the only thing that escapes
+  out/
+    <node>.md          artifacts
+    .versions/         pre-repair snapshots
+  audit/
+    <node>.json        gate results + reviewer verdict
+  assembly/
+    index.md, checks.json, main.tex
+```
+
+**Enforcement, not instruction:** each leaf's file tools are chrooted to its own
+`scratch/<node>/`, its declared inputs, and its artifact path. Not a prompt rule —
+an actual restriction in the tool implementation. That's what guarantees no leaf
+can pull another leaf's raw dumps into context.
+
+`scratch/<node>/` is deletable once the node passes. Keep it for debugging; it's
+never in anyone's context again.
+
+---
+
+## 6. Schemas
+
+### Node (`tree.json`)
+
+```json
+{
+  "id": "ch07",
+  "type": "chapter-summary",
+  "shape": "derivation-dominant",
+  "brief": "…what and why, ~2 sentences…",
+  "inputs": ["source.pdf#pp.184-211"],
+  "artifact": "out/ch07.md",
+  "tools": ["read_span", "write", "glossary_lookup"],
+  "budget": {"tokens": 24000, "calls": 15},
+  "gates": ["headers:std", "problems>=5", "terms_defined", "len:1200-2000"],
+  "judgment": ["R1", "R2", "R3"],
+  "depends_on": ["contract:frozen"],
+  "status": "pending"
+}
+```
+
+`tools` is **per-node**. This is the single biggest token lever and it also
+improves reliability — a surveyor with three read-only tools is both cheaper and
+better than one with fifteen.
+
+### Manifest line (`manifest.jsonl`)
+
+Everything except `promotion` is **derived by the harness from the artifact** —
+no model involvement, no hallucination surface.
+
+```json
+{"node":"ch07","artifact":"out/ch07.md","tokens":1640,
+ "headers":["Overview","Key Terms","Worked Examples","Practice"],
+ "terms_defined":["flux","divergence"],"terms_used_undefined":[],
+ "refs_out":["ch05#gauss"],"problems":6,"gates":"pass",
+ "promotion":"used vector-field notation from ch05; deferred Stokes to ch09"}
+```
+
+This is enough for the orchestrator to plan repairs, order assembly, and answer
+"what's left" without opening a single artifact.
+
+### Reviewer verdict (`audit/<node>.json`)
+
+```json
+{"node":"ch07","contract_version":3,
+ "items":[{"id":"R1","pass":true},
+          {"id":"R2","pass":false,
+           "defect":"§Worked Examples, ex.2 omits intermediate step",
+           "class":"patchable"}],
+ "verdict":"fail"}
+```
+
+---
+
+## 7. Rubrics: gates vs. judgment
+
+Split by checkability. This is how "no room to say I'm done" costs almost no
+context.
+
+**Gates** — machine-checkable, live in the harness, **never enter model context**.
+File exists, required headers present, ≥N practice problems, formulas in LaTeX, no
+undefined glossary terms, length in band, every source section referenced. The
+writer doesn't read "must have ≥5 problems"; it fails the gate and gets
+`unmet: R3 (4 problems, need 5)`.
+
+**Judgment** — terse imperatives in the brief, 3–6 lines max:
+
+```
+R1 define every bolded term from source span
+R2 worked example for each procedure, not each theorem
+R3 exclude historical/biographical material
+```
+
+Twelve invisible gate items + four visible judgment items = full enforcement at
+near-zero prompt cost.
+
+**Calibration risk:** gates too strict → leaves fail three times and escalate on
+trivia → you babysit. Start with gates that are structural and unambiguous; keep
+judgment items genuinely soft. Tighten after seeing where real failures cluster.
+
+---
+
+## 8. Context discipline
+
+Where input tokens actually go, in rough order of waste, for a 15-turn leaf:
+
+1. **Tool schemas** — 15 verbose tools ≈ 3–4K tokens resent every turn ≈ 50K
+   wasted on one leaf. Fixed by per-node `tools`.
+2. **Raw tool results** — `read_file` dumping 800 lines when three functions were
+   needed pollutes every subsequent turn. Use `read_span`, symbol-level reads,
+   grep-with-context. Never cat the whole source.
+3. **Turn history** — grows quadratically in turns. This is the real argument for
+   small leaves: a 6-turn leaf costs far less than a third of an 18-turn leaf.
+   Enforce `budget.calls` as a hard stop that triggers **re-split**, not a warning.
+4. **Restatement** — rubric in system prompt, again in brief, again in a reminder.
+   Say everything once; let position do the work.
+
+**Excluded from every leaf context:** the full task tree (it gets its node plus a
+one-line parent), any other leaf's output, the raw source document, history from
+prior leaves, schemas for tools it can't call.
+
+**Prompt ordering** — most-stable to least-stable, for prefix caching:
+system → tool schemas → frozen contract → node brief → inputs → turn history.
+Never interleave volatile state into the system prompt. If the contract is still
+mutating, place it *after* the tool schemas.
+
+**Instrument it.** Log per-turn input tokens broken down by segment (system /
+tools / contract / brief / inputs / history). Put *mean input tokens per leaf* in
+the eval suite next to correctness — otherwise a prompt tweak that doubles the
+bill looks identical to one that doesn't.
+
+---
+
+## 9. Reasoning traces
+
+**Policy:** thinking is streamed to the user, written once to
+`scratch/<node>/trace.jsonl`, and **never read by any agent.** Not in promotions,
+not in manifest lines, not in reviewer context.
+
+Enforce structurally: put traces in a store the prompt assembler physically cannot
+read from. Discipline fails at 2am; a type error doesn't.
+
+**Within-agent carve-out:** the *current* turn's reasoning must accompany the tool
+result back to the model on the next call, or multi-step reasoning degrades —
+silently. Note that Anthropic's API already strips earlier turns' thinking
+automatically, so effective behavior closely matches the intended policy. Verify
+against current docs for whichever endpoint is in use.
+
+**Retry after failure:**
+- Failure before generation (429, connect error) → nothing produced, plain retry.
+- Stream dies mid-generation → cannot resume; must re-query. Partial reasoning
+  **cannot** be re-sent as a signed reasoning block (truncated → signature fails).
+  Re-inject as labeled plain text with explicit permission to discard:
+  *"Your previous attempt was interrupted. Partial reasoning (unverified, may end
+  mid-thought): … Continue from here or restart if it looks wrong."*
+- Only re-inject above a floor (~1000 tokens of partial reasoning). Below that,
+  regenerating is cheaper than paying to re-read it.
+
+Traces will be large and completely inert. Rotate or compress per node; the viewer
+streams from the tail rather than loading whole files.
+
+---
+
+## 10. Failure, resume, intervention
+
+**Resume.** `events.jsonl` is append-only and fsync'd. Every event carries `ts`,
+`node_id`, `role`, `round`, `type`. Resume replays to the exact tool call. This is
+the load-bearing property — build and test it first.
+
+**Never interrupt mid-turn.** Queue interventions; apply at the next node
+boundary. Killing mid-turn loses the turn's work and can leave a half-written
+artifact.
+
+**Three intervention types, by blast radius:**
+
+| Type | Effect | Radius |
+|---|---|---|
+| **Reopen node** | mark failed with a user-written defect; re-enters queue as repair | one node |
+| **Amend contract** | new rules downstream; completed nodes now `stale` | whole run |
+| **Halt** | stop after current node | — |
+
+**Contract amendment → re-validation pass.** Do *not* blanket-regenerate. Re-run
+the existing **Reviewer** (read-only, stateless, no writers dispatched) against
+the amended contract as review-only nodes. Cost ≈ N × (contract + rubric +
+artifact). Show that estimate before running.
+
+Triage each completed node into three buckets:
+
+- **Clean** — already satisfies the amendment. No action.
+- **Patchable** — small scoped edit. Additive amendments usually land here
+  ("every unit needs a summary box" → append a box).
+- **Regenerate** — the amendment contradicts what was written
+  ("worked solutions → hints-only"). Full re-run.
+
+Present counts, get approval, then execute. Snapshot to `out/.versions/` before
+any repair — if the amendment was itself the mistake, you'll only realize it three
+chapters in.
+
+**Approval-rate tracking, segmented by shape.** A global drop from 90%→60% says
+something is wrong. A rate that's fine for prose units and collapsing on
+derivation-heavy ones says *which exemplar to re-pilot*. Below threshold → halt
+and offer re-pilot rather than grinding out thirty more units that all need
+repair.
+
+---
+
+## 11. Interfaces
+
+**Control surface: CLI.** `harness run`, `status`, `approve`, `amend`, `resume`.
+
+**View surface: local web app.** `harness serve` → localhost, SSE streaming,
+separate process watching the run directory. It can crash without touching the
+run; it can be attached from anywhere.
+
+Rationale for the split: liking the terminal and wanting to review a 2,000-word
+document in it are different preferences. The pilot-approval step is document
+editing plus PDF preview, which terminals are bad at.
+
+**Build neither first.** Structured logs + `tail`/`jq` gets a working harness. The
+web view is additive.
+
+**Default node view** — raw JSONL is unusable; nobody will read it. Show: brief
+given, gate results (pass/fail per item), reviewer verdict lines, artifact diff,
+**input tokens by segment**. Raw trace one keypress away. In practice correction
+happens from the verdict; the trace is for debugging the harness, not the content.
+
+Streaming-reasoning rendering is commodity — lift it from existing work. Writer
+leaves shelled out to an agent CLI get its rendering free; direct-API roles render
+from `trace.jsonl`. Don't build stream rendering twice.
+
+---
+
+## 12. Provider layer
+
+**Scope for v1: OpenAI-compatible only.** Test model: DeepSeek V4 Flash Free via
+OpenCode Zen.
+
+Testing on a weak free model is the correct development target. A frontier model
+compensates for harness defects and everything looks like it works; then you swap
+models and can't tell which of forty design choices was load-bearing. Free-tier
+rate limits also exercise backoff and resume paths continuously, for free.
+
+**Do not build a provider abstraction now.** Keep everything provider-specific in
+**one module** (~200 lines): stream parsing, reasoning extraction, structured
+output, tool-call format. Later portability costs one file instead of a refactor.
+
+Notes for OpenAI-compatible endpoints:
+- Reasoning arrives as `reasoning_content` alongside `content` in the delta.
+- `response_format: json_schema` support varies. **Build the fallback regardless:**
+  schema in prompt → parse → validate → re-prompt with validator error. Catches
+  semantically-invalid-but-syntactically-valid output too.
+- Prefix caching is usually automatic; no explicit breakpoints. Stable-first
+  prompt ordering still pays off, implicitly.
+
+**Role/model routing:** orchestrator, planner, and reviewer are cheap
+structured-output calls and should run on the cheapest capable model. Only the
+writer needs the strong one. This is a config table, not code.
+
+---
+
+## 13. Build ladder
+
+**v0 — prove resumability.** Shell out to an agent CLI headless on a single task.
+Append-only fsync'd event log, run directory. Then `kill -9` mid-task and resume.
+If this isn't perfect, nothing above it works. Everything else is downstream.
+
+**v1 — the round loop.** Orchestrator/Writer/Reviewer with schema-constrained JSON
+returns and per-node tool restriction. Task state in JSON; markdown only as a
+rendered view. No node enters the tree without a machine-checkable exit condition.
+Writer returns capped at ~400 tokens.
+
+**v2 — intake, survey, recursive planning.** Assumptions-list protocol. Mechanical
+chunking + windowed survey → `spine.json`. Level-at-a-time planner with flat child
+lists. Pilot + contract derivation from the user's diff.
+
+**v3 — assembly and repair.** Deterministic concatenation, cross-cutting checks,
+compile gate, scoped repair nodes. Re-validation pass for contract amendments.
+
+**v4 — research tools.** Web search subagent, current-docs retrieval. Lowest
+priority: these are retrieval fixes; everything above is a correctness fix.
+
+---
+
+## 14. Eval
+
+Start at **v1**, not at the end. Five fixed tasks, three runs each. Measure:
+
+- resume correctness after `kill -9` at randomized points
+- does the reviewer catch a deliberately broken node
+- does the orchestrator's context stay bounded as node count grows
+- mean input tokens per leaf
+- planner schema-validity rate and leaf/split gate sanity
+- approval rate by shape
+
+Without this, prompt tuning is vibes, and weak models are noisy enough that vibes
+mislead.
+
+### Pre-implementation spikes (cheap, do first)
+
+1. **Planner conformance.** Synthetic spine of 40 units with sizes → valid
+   top-level partition, 20 runs. Measure schema validity, dependency-edge sanity,
+   and how often it returns `leaf` for something obviously oversized.
+2. **Survey quality on real unstructured input.** Run the windowed survey over
+   actual lecture notes. Do the proposed boundaries match where you'd have drawn
+   them? This is the one that tells you whether the general-purpose ambition holds.
+
+---
+
+## 15. Reuse inventory
+
+### 15.1 Base — clone LongHorizon-Harness and start there
+
+`github.com/AMAP-ML/LongHorizon-Harness` — MIT, Python ≥3.10, `uv tool install
+lh-harness`. **This is the starting point. Clone it, don't reimplement it.**
+
+What it already gives us, matching §3–§5 almost directly:
+
+- Manager / Executor / Auditor role separation with per-role model assignment
+- Fresh-context execution per round (our §3 stateless orchestrator)
+- Only independently-verified results enter persistent task state (our §2.1)
+- Isolated `runs/<run-id>/` with task state, event stream, audit reports, role
+  trajectories, workspace, final report (our §5, nearly one-to-one)
+- Dashboard with human gates on complete / blocked / needs-input / repeated-fail
+  (our §10 intervention model)
+- `AgentAdapter` abstraction preserving each backend's native loop
+- Execution environments: local, `ssh://`, `docker://`
+- `eval/` with frozen reproduction suites — a template for our §14
+
+**First concrete task:** it ships adapters for `claude_code`, `codex`, and
+`openclaw` only. Write an `AgentAdapter` for OpenCode. That single file is the
+whole "orchestration layer on top of existing CLIs" decision made real.
+
+**Our deltas on top** (nothing below exists in it): recursive level-at-a-time
+planner, survey/spine discovery, the leaf gate, gates-vs-judgment rubric split,
+pilot + contract derivation from user diff, per-node tool restriction, the
+derived manifest, deterministic assembly with a read-only assembler.
+
+### 15.2 Tools — commodity, lift wholesale
+
+The set is identical across every harness: `glob`, `grep`, `read`, `edit`,
+`write`, `bash`. Nobody should write these again.
+
+Ranked by ease of extraction into Python:
+
+- **gptme** (MIT, Python, ~4k stars) — deliberately small: shell, Python
+  execution, file editing. Cleanest small donor, scriptable, works with weak
+  models. Probably the first place to look.
+- **Mini-Kode** — explicitly an educational reference implementation. Written to
+  be read, which is exactly what we want from a donor.
+- **Pi / pi-mono** (~83k stars) — minimal adaptable harness with unified LLM API,
+  tools, skills, and MCP. Heavier but the abstractions are good.
+- **OpenHands** (~83k stars) — most battle-tested sandboxed execution if we ever
+  need real isolation. Heavy; take the sandbox, not the framework.
+
+**Do not write web search or fetch.** Use MCP servers. Same for browser work
+(`playwright-mcp` uses accessibility-tree snapshots rather than screenshots,
+which is dramatically cheaper in tokens). §12's rule about keeping
+provider-specific code in one module applies here too — MCP is the seam.
+
+**Expect one modification everywhere:** every harness ships whole-file `read`.
+We need `read_span` (§8.2). Budget time for that; it's the difference between a
+leaf costing 3K and 30K input tokens.
+
+### 15.3 Subagents and delegation
+
+- **LongHorizon-Harness** role split is the base — see 15.1.
+- **statewright** — state-machine guardrails constraining which tools an agent may
+  call per workflow phase. This *is* our per-node `tools` field, already built and
+  benchmarked. Reported result: local models went from 2/10 to 10/10 on a
+  SWE-bench subset purely by shrinking the tool space. Read this before
+  implementing §6's `tools` restriction.
+- **Briefing pattern** — brief each subagent with the *rationale* (why this
+  subtask matters, how it fits the goal), not just the task description.
+  Documented to reduce redundant exploration. Already reflected in our node
+  `brief` field; make sure the template enforces it.
+- **subtask** (zippoxer) — subagents in git worktrees. Only relevant if we ever
+  turn on the parallelism that §4.5 leaves the door open for.
+- Reference datapoint for the architecture: subagents process ~67% fewer tokens
+  than skills in multi-domain scenarios, because context isolation prevents
+  cross-domain bloat.
+
+### 15.4 Skills — adopt the open standard instead of inventing node templates
+
+**This is the biggest find of the reuse pass.** Agent Skills is an open standard
+(`agentskills.io`), released by Anthropic in December 2025, now supported by 26+
+platforms including OpenCode, Codex, Cursor, Gemini CLI, and Copilot.
+
+A skill is a folder:
+
+```
+my-skill/
+  SKILL.md      required — YAML frontmatter (name, description) + markdown body
+  scripts/      optional — executable code
+  references/   optional — docs loaded on demand
+  assets/       optional — templates, examples
+```
+
+Three-tier progressive disclosure, which is precisely our §8 goal:
+
+1. **Advertise** — name + description injected at startup, ~80–100 tokens per
+   skill. Dozens of skills cost less than one activated skill.
+2. **Load** — full `SKILL.md` body on activation, recommended under 5,000 tokens.
+3. **Reference** — bundled files pulled only when actually needed.
+
+**The insight: our node-type templates and per-shape rubrics ARE skills.**
+`chapter-summary`, `derivation-dominant`, `problem-set`, `assembly` — each becomes
+a skill folder whose `SKILL.md` holds the rubric skeleton and judgment items,
+whose `scripts/` holds the gate implementations, and whose `references/` holds the
+approved exemplar. We get progressive disclosure for free, we stop inventing a
+bespoke template format, and the templates stay portable across whatever executor
+we shell out to.
+
+There is a reference Python library (Apache-2.0) that validates skills, reads
+properties, and emits `<available_skills>` prompt blocks. Use it for validation in
+CI; it's documented as demonstration-quality, not production.
+
+Related: **SkillOpt** (Microsoft) treats skills as optimizable parameters improved
+by execution feedback rather than static prompts — relevant much later, once we
+have approval-rate data per shape (§10).
+
+### 15.5 Build ourselves — no good donor exists
+
+- Recursive level-at-a-time planner with flat child lists (§4.3)
+- Survey / spine discovery for unstructured corpora (§4.2)
+- The leaf gate as harness-enforced code (§4.3)
+- Gates-vs-judgment rubric split (§7)
+- Pilot approval → diff → contract derivation (§4.4)
+- Derived manifest (§6)
+- Re-validation triage: clean / patchable / regenerate (§10)
+- Per-segment input-token accounting (§8)
+
+That's the actual project. Everything else is assembly.
+
+### 15.6 Licensing notes
+
+Permissive and safe: LongHorizon-Harness (MIT), OpenCode (MIT), gptme (MIT),
+Grinta (MIT), Agent Skills reference lib (Apache-2.0), OpenHands (MIT),
+playwright-mcp (Apache-2.0).
+
+Watch for: Loki Mode is BUSL-1.1, AgentsMesh is BSL-1.1 — usable to read, not to
+vendor.
+
+**Avoid entirely:** Claude Code is source-available, *not* open source — don't
+copy from it. More importantly, several popular repos (Claw Code, claw-code-agent,
+Free Code) are openly described as deriving from a March 2026 Claude Code source
+leak. Regardless of the license text they carry, that provenance is legally
+unsettled and they should not be a donor for anything intended to be published.
+Read them for ideas if you like; don't lift code.
+
+### 15.7 Also worth reading before writing our own
+
+- **Grinta** (Python, MIT) — event-stream ledger, checkpoint/revert, stuck
+  detection, completion-quality validation. Closest single-agent analogue to
+  what we want the leaf loop to feel like.
+- **Ralph Workflow / agx / AgentPlane** — resume and checkpoint patterns.
+- **Context7** — version-specific library docs via MCP, for the v4 research tools.
+- **headroom** — compresses bulky tool output before it enters context; relevant
+  if `read_span` proves insufficient.

--- a/src/lh_harness/adapters/claude_code.py
+++ b/src/lh_harness/adapters/claude_code.py
@@ -25,6 +25,12 @@ from .cli_agent import CommandAgentAdapter
 
 
 class ClaudeCodeAdapter(CommandAgentAdapter):
+    # Claude Code's stream-json first line carries a session_id, and
+    # `claude --resume <id> --print ...` continues that same session — this
+    # is v0's actual resumability mechanism for a Writer node (PLAN.md §3:
+    # the Writer's whole agent-CLI invocation is one opaque unit).
+    supports_session_resume = True
+
     def __init__(
         self,
         *,
@@ -105,6 +111,11 @@ class ClaudeCodeAdapter(CommandAgentAdapter):
 
         self.role = role
         self.policy = policy
+        # Kept alongside command_template so a resumed call can splice in
+        # `--resume <id>` without disturbing the fresh-dispatch template (deny
+        # rules, model, mcp config, ...) that every other call site relies on.
+        self._env_prefix = env_prefix
+        self._command_parts = command_parts
         super().__init__(
             command_template=f"{env_prefix}{' '.join(command_parts)} < {{prompt_path}}",
             prompt_dir=prompt_dir,
@@ -119,17 +130,25 @@ class ClaudeCodeAdapter(CommandAgentAdapter):
         env: Environment,
         budget: EpisodeBudget,
         live_trajectory_path: str | None = None,
+        *,
+        resume_session_id: str | None = None,
     ) -> EpisodeResult:
         before = (
             snapshot_workspace(self.workspace_path, self.hidden_paths)
             if is_auditor_role(self.role)
             else None
         )
+        command_override = None
+        if resume_session_id is not None:
+            resumed_parts = [self._command_parts[0], "--resume", shlex.quote(resume_session_id)]
+            resumed_parts.extend(self._command_parts[1:])
+            command_override = f"{self._env_prefix}{' '.join(resumed_parts)} < {{prompt_path}}"
         result = await super().run_episode(
             prompt,
             env,
             budget,
             live_trajectory_path=live_trajectory_path,
+            command_override=command_override,
         )
         result.metadata.update(
             {

--- a/src/lh_harness/adapters/cli_agent.py
+++ b/src/lh_harness/adapters/cli_agent.py
@@ -29,6 +29,11 @@ def redact_secrets(text: str) -> str:
 
 
 class CommandAgentAdapter:
+    # Overridden True by adapters that can continue a prior run rather than
+    # starting over (see ClaudeCodeAdapter). v0's runner falls back to a fresh
+    # redispatch whenever this is False instead of erroring.
+    supports_session_resume = False
+
     def __init__(
         self,
         *,
@@ -50,6 +55,8 @@ class CommandAgentAdapter:
         env: Environment,
         budget: EpisodeBudget,
         live_trajectory_path: str | None = None,
+        *,
+        command_override: str | None = None,
     ) -> EpisodeResult:
         start = time.monotonic()
         # Never reuse one global prompt.md. A run owns its prompt directory and
@@ -64,7 +71,10 @@ class CommandAgentAdapter:
         # Substituted by explicit replace, not str.format: templates embed literal
         # braces (e.g. Codex passes inline-TOML `-c` overrides) that format() would
         # try to interpret as placeholders.
-        command_body = self.command_template
+        # command_override lets a subclass swap in a session-resume invocation
+        # (e.g. `claude --resume <id>`) for one call without mutating the
+        # instance's own command_template, which stays the fresh-dispatch form.
+        command_body = command_override if command_override is not None else self.command_template
         for placeholder, value in (
             ("{prompt_path}", shlex.quote(prompt_path)),
             ("{timeout}", str(budget.max_duration_seconds)),

--- a/src/lh_harness/v0/__init__.py
+++ b/src/lh_harness/v0/__init__.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from .events import EventLog
+from .run_dir import create_run_dir
+from .runner import run_node
+
+__all__ = ["EventLog", "create_run_dir", "run_node"]

--- a/src/lh_harness/v0/events.py
+++ b/src/lh_harness/v0/events.py
@@ -1,0 +1,70 @@
+"""events.jsonl: append-only, fsync'd — the resume log (PLAN.md §10).
+
+This is the load-bearing property of the whole harness. Every event carries
+``ts``, ``node_id``, ``role``, ``round``, ``type``. A caller must be able to
+kill -9 the process at any instant and, on restart, ``read_all()`` must see
+every event that was durably appended before the kill and none that wasn't.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+
+class EventLog:
+    def __init__(self, path: str | Path) -> None:
+        self.path = Path(path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+
+    def append(self, event: dict[str, Any]) -> None:
+        record = dict(event)
+        record.setdefault("ts", time.time())
+        line = json.dumps(record, sort_keys=True)
+        # Open-write-fsync-close per call rather than holding a file handle:
+        # durability has to survive the process dying *between* calls, and a
+        # cached fd buys nothing against that. flush() alone is not enough —
+        # it only moves bytes from the Python buffer to the OS page cache,
+        # which a power loss or container kill can still lose; fsync() is
+        # what forces them to the disk.
+        with open(self.path, "a", encoding="utf-8") as fh:
+            fh.write(line + "\n")
+            fh.flush()
+            os.fsync(fh.fileno())
+
+    def read_all(self) -> list[dict[str, Any]]:
+        if not self.path.exists():
+            return []
+        events: list[dict[str, Any]] = []
+        with open(self.path, "r", encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    events.append(json.loads(line))
+                except json.JSONDecodeError:
+                    # Truncation policy: silently drop unparsable lines. We
+                    # fsync after every write, so a torn line can only be the
+                    # tail end of a write that was interrupted mid-syscall by
+                    # a kill -9 — that event never reached durable state from
+                    # any reader's point of view, so resume must behave as if
+                    # it was never appended, not raise or half-parse it.
+                    continue
+        return events
+
+    def events_for(self, node_id: str) -> list[dict[str, Any]]:
+        return [event for event in self.read_all() if event.get("node_id") == node_id]
+
+    def last_event(self, node_id: str, event_type: str) -> dict[str, Any] | None:
+        match: dict[str, Any] | None = None
+        for event in self.read_all():
+            if event.get("node_id") == node_id and event.get("type") == event_type:
+                match = event
+        return match
+
+    def has_terminal(self, node_id: str) -> bool:
+        return self.last_event(node_id, "episode_completed") is not None

--- a/src/lh_harness/v0/run_dir.py
+++ b/src/lh_harness/v0/run_dir.py
@@ -1,0 +1,50 @@
+"""On-disk run directory for a single-node v0 run — a slice of PLAN.md §5's
+full layout, just the pieces a single Writer node needs:
+
+    <root>/<run-id>/
+      spec.md
+      events.jsonl
+      manifest.jsonl
+      scratch/<node_id>/trace.jsonl
+      out/<node_id>.md
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def create_run_dir(root: str | Path, run_id: str) -> Path:
+    """Idempotent: safe to call again on resume, never wipes existing state."""
+    run_dir = Path(root) / run_id
+    (run_dir / "scratch").mkdir(parents=True, exist_ok=True)
+    (run_dir / "out").mkdir(parents=True, exist_ok=True)
+    for name in ("spec.md", "events.jsonl", "manifest.jsonl"):
+        path = run_dir / name
+        if not path.exists():
+            path.touch()
+    return run_dir
+
+
+def events_path(run_dir: str | Path) -> Path:
+    return Path(run_dir) / "events.jsonl"
+
+
+def manifest_path(run_dir: str | Path) -> Path:
+    return Path(run_dir) / "manifest.jsonl"
+
+
+def node_scratch_dir(run_dir: str | Path, node_id: str) -> Path:
+    path = Path(run_dir) / "scratch" / node_id
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def node_trace_path(run_dir: str | Path, node_id: str) -> Path:
+    return node_scratch_dir(run_dir, node_id) / "trace.jsonl"
+
+
+def node_artifact_path(run_dir: str | Path, node_id: str) -> Path:
+    path = Path(run_dir) / "out"
+    path.mkdir(parents=True, exist_ok=True)
+    return path / f"{node_id}.md"

--- a/src/lh_harness/v0/runner.py
+++ b/src/lh_harness/v0/runner.py
@@ -1,0 +1,239 @@
+"""The resumable single-node runner (PLAN.md §13 v0).
+
+One idempotent entrypoint, ``run_node``, handles both first-run and resume:
+calling it again after a `kill -9` just continues correctly from whatever
+events are already durable on disk. There is no separate resume code path —
+that convergence *is* the thing this module exists to prove.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+from ..adapters.base import AgentAdapter
+from ..environment.base import Environment
+from ..types import EpisodeBudget, EpisodeResult
+from .events import EventLog
+from .run_dir import events_path, manifest_path, node_artifact_path, node_trace_path
+
+_SESSION_POLL_INTERVAL_SECONDS = 0.05
+
+
+async def run_node(
+    run_dir: str | Path,
+    node_id: str,
+    prompt: str,
+    adapter: AgentAdapter,
+    env: Environment,
+    budget: EpisodeBudget,
+) -> EpisodeResult:
+    run_dir = Path(run_dir)
+    log = EventLog(events_path(run_dir))
+
+    completed = log.last_event(node_id, "episode_completed")
+    if completed is not None:
+        # Resume-after-complete is a pure no-op: replay the recorded result
+        # instead of re-dispatching, so calling run_node twice never produces
+        # two artifacts or two terminal events for the same node.
+        return _result_from_completed_event(completed)
+
+    dispatched = log.last_event(node_id, "node_dispatched")
+    session = log.last_event(node_id, "session_captured")
+    supports_resume = bool(getattr(adapter, "supports_session_resume", False))
+
+    resume_session_id: str | None = None
+    if session is not None:
+        if supports_resume:
+            resume_session_id = session.get("session_id")
+            log.append(
+                {
+                    "node_id": node_id,
+                    "role": "writer",
+                    "round": 0,
+                    "type": "node_redispatched",
+                    "reason": "resumed_session",
+                }
+            )
+        else:
+            # A session id was captured last time but this adapter (e.g.
+            # Codex today) has no continuation mechanism. Falling back to a
+            # fresh redispatch is the documented behavior rather than an
+            # error — see ClaudeCodeAdapter.supports_session_resume.
+            log.append(
+                {
+                    "node_id": node_id,
+                    "role": "writer",
+                    "round": 0,
+                    "type": "node_redispatched",
+                    "reason": "resume_unsupported",
+                }
+            )
+    elif dispatched is not None:
+        # Crashed before any output ever hit disk: nothing to continue from,
+        # so redispatch fresh from the original prompt.
+        log.append(
+            {
+                "node_id": node_id,
+                "role": "writer",
+                "round": 0,
+                "type": "node_redispatched",
+                "reason": "no_session_captured",
+            }
+        )
+    else:
+        log.append(
+            {
+                "node_id": node_id,
+                "role": "writer",
+                "round": 0,
+                "type": "node_dispatched",
+            }
+        )
+
+    trace_path = node_trace_path(run_dir, node_id)
+    # A prior crashed attempt can leave stale content in trace_path. Clear it
+    # before dispatching so the watcher below can't race the new subprocess
+    # and mistake a leftover line from the old attempt for a fresh capture —
+    # LocalEnvironment.exec truncates and recreates this file itself once the
+    # new subprocess actually starts, but that happens a few awaits later.
+    if trace_path.exists():
+        trace_path.unlink()
+
+    # LocalEnvironment.exec tees stdout to trace_path live, line by line, as
+    # the subprocess runs — so this tail can see session_id the instant the
+    # agent CLI emits it, without waiting for run_episode() to return. A
+    # kill -9 can land any time after that line hits disk.
+    stop_watching = asyncio.Event()
+    watcher = asyncio.create_task(
+        _watch_for_session_id(trace_path, log, node_id, stop_watching)
+    )
+    try:
+        episode_kwargs: dict[str, Any] = {"live_trajectory_path": str(trace_path)}
+        if resume_session_id is not None:
+            episode_kwargs["resume_session_id"] = resume_session_id
+        result = await adapter.run_episode(prompt, env, budget, **episode_kwargs)
+    finally:
+        stop_watching.set()
+        watcher.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await watcher
+
+    artifact_path = node_artifact_path(run_dir, node_id)
+    artifact_text = result.metadata.get("assistant_visible_output") or result.actions_log or ""
+    artifact_path.write_text(artifact_text, encoding="utf-8")
+
+    _append_jsonl(
+        manifest_path(run_dir),
+        {"node": node_id, "artifact": str(artifact_path), "status": result.status},
+    )
+
+    log.append(
+        {
+            "node_id": node_id,
+            "role": "writer",
+            "round": 0,
+            "type": "episode_completed",
+            "status": result.status,
+            "artifact_path": str(artifact_path),
+            "error": result.error,
+            "duration_ms": result.duration_ms,
+        }
+    )
+    return result
+
+
+async def run(
+    run_dir: str | Path,
+    node_id: str,
+    prompt: str,
+    adapter: AgentAdapter,
+    env: Environment,
+    budget: EpisodeBudget,
+) -> EpisodeResult:
+    """First-run-facing alias. Identical to ``resume`` — see module docstring."""
+    return await run_node(run_dir, node_id, prompt, adapter, env, budget)
+
+
+async def resume(
+    run_dir: str | Path,
+    node_id: str,
+    prompt: str,
+    adapter: AgentAdapter,
+    env: Environment,
+    budget: EpisodeBudget,
+) -> EpisodeResult:
+    """Resume-facing alias. Identical to ``run`` — see module docstring."""
+    return await run_node(run_dir, node_id, prompt, adapter, env, budget)
+
+
+async def _watch_for_session_id(
+    trace_path: Path,
+    log: EventLog,
+    node_id: str,
+    stop: asyncio.Event,
+) -> None:
+    while not trace_path.exists():
+        if stop.is_set():
+            return
+        await asyncio.sleep(_SESSION_POLL_INTERVAL_SECONDS)
+
+    offset = 0
+    while True:
+        try:
+            with open(trace_path, "r", encoding="utf-8") as fh:
+                fh.seek(offset)
+                new_lines = fh.readlines()
+                offset = fh.tell()
+        except OSError:
+            new_lines = []
+        for line in new_lines:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            session_id = record.get("session_id")
+            if session_id:
+                log.append(
+                    {
+                        "node_id": node_id,
+                        "role": "writer",
+                        "round": 0,
+                        "type": "session_captured",
+                        "session_id": session_id,
+                    }
+                )
+                return
+        if stop.is_set():
+            return
+        await asyncio.sleep(_SESSION_POLL_INTERVAL_SECONDS)
+
+
+def _result_from_completed_event(event: dict[str, Any]) -> EpisodeResult:
+    status = event.get("status")
+    if status not in ("done", "timeout", "error", "cancelled"):
+        status = "done"
+    return EpisodeResult(
+        status=status,
+        actions_log="",
+        error=event.get("error"),
+        duration_ms=int(event.get("duration_ms") or 0),
+        metadata={
+            "artifact_path": event.get("artifact_path"),
+            "replayed_from_event_log": True,
+        },
+    )
+
+
+def _append_jsonl(path: Path, obj: dict[str, Any]) -> None:
+    obj = dict(obj)
+    obj.setdefault("ts", time.time())
+    with open(path, "a", encoding="utf-8") as fh:
+        fh.write(json.dumps(obj, sort_keys=True) + "\n")

--- a/tests/fixtures/fake_adapter.py
+++ b/tests/fixtures/fake_adapter.py
@@ -1,0 +1,72 @@
+"""Fake AgentAdapter plugging fake_stream_agent.py into run_node exactly the
+way ClaudeCodeAdapter plugs in the real `claude` binary — same
+resume_session_id passthrough, same supports_session_resume marker.
+"""
+
+from __future__ import annotations
+
+import shlex
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+from lh_harness.adapters.cli_agent import CommandAgentAdapter  # noqa: E402
+from lh_harness.environment.base import Environment  # noqa: E402
+from lh_harness.types import EpisodeBudget, EpisodeResult  # noqa: E402
+
+
+class FakeStreamAgentAdapter(CommandAgentAdapter):
+    supports_session_resume = True
+
+    def __init__(
+        self,
+        *,
+        script_path: str,
+        pidfile: str,
+        prompt_dir: str,
+        workspace_path: str,
+        startup_delay: float = 0.0,
+        work_delay: float = 0.0,
+        session_id: str | None = None,
+    ) -> None:
+        parts = [
+            shlex.quote(sys.executable),
+            shlex.quote(script_path),
+            "--pidfile",
+            shlex.quote(pidfile),
+            "--startup-delay",
+            str(startup_delay),
+            "--work-delay",
+            str(work_delay),
+        ]
+        if session_id:
+            parts.extend(["--session-id", shlex.quote(session_id)])
+        self._base_command = " ".join(parts)
+        super().__init__(
+            command_template=f"{self._base_command} < {{prompt_path}}",
+            prompt_dir=prompt_dir,
+            workspace_path=workspace_path,
+        )
+
+    async def run_episode(
+        self,
+        prompt: str,
+        env: Environment,
+        budget: EpisodeBudget,
+        live_trajectory_path: str | None = None,
+        *,
+        resume_session_id: str | None = None,
+    ) -> EpisodeResult:
+        command_override = None
+        if resume_session_id is not None:
+            command_override = (
+                f"{self._base_command} --resume {shlex.quote(resume_session_id)} < {{prompt_path}}"
+            )
+        return await super().run_episode(
+            prompt,
+            env,
+            budget,
+            live_trajectory_path=live_trajectory_path,
+            command_override=command_override,
+        )

--- a/tests/fixtures/fake_stream_agent.py
+++ b/tests/fixtures/fake_stream_agent.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Deterministic stand-in for `claude --print --output-format stream-json`.
+
+No network, no model — every timing is controlled by flags so tests can build
+reliable kill windows around a real OS process:
+
+- Writes its own pid to --pidfile immediately, before the startup delay, so a
+  test can find (and kill) this exact process the instant it exists, even
+  before it has emitted anything on stdout.
+- Emits one JSON line carrying `session_id` as its first output (mimicking
+  Claude Code's first stream-json line), flushed immediately.
+- Sleeps for --work-delay to simulate the episode still being in flight.
+- Emits a final JSON completion line and exits 0.
+- With --resume <id>, skips straight to a "resume acknowledged" line plus a
+  fast completion, so a test can tell continuation apart from a lucky fresh
+  redispatch.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--session-id", default=None)
+    parser.add_argument("--resume", default=None)
+    parser.add_argument("--startup-delay", type=float, default=0.0)
+    parser.add_argument("--work-delay", type=float, default=0.0)
+    parser.add_argument("--pidfile", default=None)
+    args, _unknown = parser.parse_known_args()
+
+    if args.pidfile:
+        with open(args.pidfile, "w", encoding="utf-8") as fh:
+            fh.write(str(os.getpid()))
+            fh.flush()
+            os.fsync(fh.fileno())
+
+    # Drain the prompt file connected on stdin; content is irrelevant here.
+    sys.stdin.read()
+
+    if args.startup_delay:
+        time.sleep(args.startup_delay)
+
+    session_id = args.session_id or f"fake-session-{os.getpid()}"
+
+    if args.resume:
+        print(
+            json.dumps({"type": "system", "session_id": args.resume, "pid": os.getpid()}),
+            flush=True,
+        )
+        print(
+            json.dumps(
+                {
+                    "type": "resumed",
+                    "resumed_from": args.resume,
+                    "resume_acknowledged": True,
+                }
+            ),
+            flush=True,
+        )
+        time.sleep(0.05)
+        print(
+            json.dumps(
+                {
+                    "type": "result",
+                    "status": "completed",
+                    "session_id": args.resume,
+                    "resumed": True,
+                }
+            ),
+            flush=True,
+        )
+        return 0
+
+    print(json.dumps({"type": "system", "session_id": session_id, "pid": os.getpid()}), flush=True)
+    if args.work_delay:
+        time.sleep(args.work_delay)
+    print(
+        json.dumps(
+            {
+                "type": "result",
+                "status": "completed",
+                "session_id": session_id,
+                "resumed": False,
+            }
+        ),
+        flush=True,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/fixtures/run_node_subprocess.py
+++ b/tests/fixtures/run_node_subprocess.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Runs run_node in its own OS process so a test can SIGKILL it from outside —
+an in-process kill can't exercise a real crash-and-resume path.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from fake_adapter import FakeStreamAgentAdapter  # noqa: E402
+from lh_harness.environment.local import LocalEnvironment  # noqa: E402
+from lh_harness.types import EpisodeBudget  # noqa: E402
+from lh_harness.v0.runner import run_node  # noqa: E402
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--run-dir", required=True)
+    parser.add_argument("--node-id", required=True)
+    parser.add_argument("--prompt", default="do the task")
+    parser.add_argument("--script-path", required=True)
+    parser.add_argument("--pidfile", required=True)
+    parser.add_argument("--prompt-dir", required=True)
+    parser.add_argument("--startup-delay", type=float, default=0.0)
+    parser.add_argument("--work-delay", type=float, default=0.0)
+    parser.add_argument("--session-id", default=None)
+    parser.add_argument("--timeout", type=int, default=60)
+    args = parser.parse_args()
+
+    adapter = FakeStreamAgentAdapter(
+        script_path=args.script_path,
+        pidfile=args.pidfile,
+        prompt_dir=args.prompt_dir,
+        workspace_path=args.run_dir,
+        startup_delay=args.startup_delay,
+        work_delay=args.work_delay,
+        session_id=args.session_id,
+    )
+    env = LocalEnvironment(tmp_dir=args.prompt_dir)
+    budget = EpisodeBudget(max_duration_seconds=args.timeout)
+
+    result = asyncio.run(
+        run_node(Path(args.run_dir), args.node_id, args.prompt, adapter, env, budget)
+    )
+    print(f"RUN_NODE_STATUS={result.status}", flush=True)
+    return 0 if result.status == "done" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_v0_resume.py
+++ b/tests/test_v0_resume.py
@@ -1,0 +1,355 @@
+"""v0 resumability proof (PLAN.md §10, §13).
+
+No network, no real `claude`/`codex` binary, no API key: every "agent CLI" in
+this file is tests/fixtures/fake_stream_agent.py, a deterministic stdlib
+script. Two of the four cases actually SIGKILL a live OS process to prove
+resume survives a real crash, not just an in-process exception.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest import mock
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_REPO_ROOT / "src"))
+sys.path.insert(0, str(_REPO_ROOT / "tests" / "fixtures"))
+
+from fake_adapter import FakeStreamAgentAdapter  # noqa: E402
+from lh_harness.environment.local import LocalEnvironment  # noqa: E402
+from lh_harness.types import EpisodeBudget  # noqa: E402
+from lh_harness.v0.events import EventLog  # noqa: E402
+from lh_harness.v0.run_dir import create_run_dir  # noqa: E402
+from lh_harness.v0.runner import run_node  # noqa: E402
+
+FAKE_CLI = _REPO_ROOT / "tests" / "fixtures" / "fake_stream_agent.py"
+RUN_NODE_SUBPROCESS = _REPO_ROOT / "tests" / "fixtures" / "run_node_subprocess.py"
+
+
+# ---------------------------------------------------------------------------
+# Process helpers for the kill -9 tests
+# ---------------------------------------------------------------------------
+
+
+def _wait_until(predicate, timeout: float, interval: float = 0.02):
+    deadline = time.monotonic() + timeout
+    result = predicate()
+    while not result and time.monotonic() < deadline:
+        time.sleep(interval)
+        result = predicate()
+    return result
+
+
+def _wait_for_event(events_file: Path, node_id: str, event_type: str, timeout: float = 10.0):
+    log = EventLog(events_file)
+    box: dict = {}
+
+    def _check():
+        found = log.last_event(node_id, event_type)
+        if found is not None:
+            box["event"] = found
+            return True
+        return False
+
+    _wait_until(_check, timeout=timeout)
+    return box.get("event")
+
+
+def _read_pid(pidfile: Path, timeout: float = 5.0) -> int:
+    def _has_content():
+        return pidfile.exists() and pidfile.read_text().strip() != ""
+
+    if not _wait_until(_has_content, timeout=timeout):
+        raise TimeoutError(f"pidfile never populated: {pidfile}")
+    return int(pidfile.read_text().strip())
+
+
+def _pid_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def _kill_pgid(pid: int) -> None:
+    try:
+        os.killpg(pid, signal.SIGKILL)
+    except (ProcessLookupError, PermissionError, OSError):
+        pass
+
+
+def _launch_runner_subprocess(
+    *, run_dir: Path, node_id: str, pidfile: Path, prompt_dir: Path,
+    startup_delay: float, work_delay: float, timeout: int = 60,
+) -> subprocess.Popen:
+    cmd = [
+        sys.executable,
+        str(RUN_NODE_SUBPROCESS),
+        "--run-dir", str(run_dir),
+        "--node-id", node_id,
+        "--script-path", str(FAKE_CLI),
+        "--pidfile", str(pidfile),
+        "--prompt-dir", str(prompt_dir),
+        "--startup-delay", str(startup_delay),
+        "--work-delay", str(work_delay),
+        "--timeout", str(timeout),
+    ]
+    # start_new_session=True makes this subprocess its own process-group
+    # leader (pgid == pid), so os.killpg(proc.pid, ...) reliably reaps it —
+    # the same reason LocalEnvironment.exec does this for the agent CLI.
+    return subprocess.Popen(
+        cmd, start_new_session=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
+    )
+
+
+def _crash_and_verify_dead(proc: subprocess.Popen, fake_pid: int) -> None:
+    """SIGKILL both the runner process and the actual fake-CLI process.
+
+    The fake CLI runs under LocalEnvironment, which launches it with its own
+    `start_new_session=True` — it becomes a session leader in a *different*
+    process group from the runner script the instant it's spawned. Killing
+    only the runner's group would leave it running, orphaned, exactly the
+    leak lh_harness.utils.process_group exists to prevent for SIGTERM; SIGKILL
+    can't be caught, so the test has to reap both groups itself.
+    """
+    _kill_pgid(fake_pid)
+    _kill_pgid(proc.pid)
+    try:
+        proc.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait(timeout=10)
+    finally:
+        if proc.stdout is not None:
+            proc.stdout.close()
+        if proc.stderr is not None:
+            proc.stderr.close()
+    assert _wait_until(lambda: not _pid_alive(fake_pid), timeout=5), (
+        "fake CLI child process survived the kill -9"
+    )
+
+
+class ResumeAfterSessionCrashTest(unittest.TestCase):
+    def test_crash_after_session_capture_then_resume(self) -> None:
+        with tempfile.TemporaryDirectory() as root_str:
+            root = Path(root_str)
+            run_dir = create_run_dir(root, "run1")
+            node_id = "writer_1"
+            prompt_dir = root / "prompts"
+            prompt_dir.mkdir(parents=True, exist_ok=True)
+            pidfile = root / "writer_1.pid"
+
+            proc = _launch_runner_subprocess(
+                run_dir=run_dir,
+                node_id=node_id,
+                pidfile=pidfile,
+                prompt_dir=prompt_dir,
+                startup_delay=0.0,
+                work_delay=3.0,
+            )
+            try:
+                session_event = _wait_for_event(
+                    run_dir / "events.jsonl", node_id, "session_captured", timeout=10
+                )
+                self.assertIsNotNone(session_event, "session_captured never appeared before timeout")
+                original_session_id = session_event["session_id"]
+
+                fake_pid = _read_pid(pidfile)
+                self.assertTrue(_pid_alive(fake_pid), "fake CLI process should be alive right after capture")
+
+                _crash_and_verify_dead(proc, fake_pid)
+            finally:
+                if proc.poll() is None:
+                    _kill_pgid(proc.pid)
+                    proc.wait(timeout=10)
+
+            log = EventLog(run_dir / "events.jsonl")
+            node_events = [e for e in log.read_all() if e.get("node_id") == node_id]
+            self.assertTrue(any(e["type"] == "session_captured" for e in node_events))
+            self.assertFalse(any(e["type"] == "episode_completed" for e in node_events))
+
+            # Resume in-process, pointed at the same run_dir/node_id.
+            adapter = FakeStreamAgentAdapter(
+                script_path=str(FAKE_CLI),
+                pidfile=str(root / "writer_1_resume.pid"),
+                prompt_dir=str(prompt_dir),
+                workspace_path=str(run_dir),
+            )
+            env = LocalEnvironment(tmp_dir=str(prompt_dir))
+            budget = EpisodeBudget(max_duration_seconds=30)
+            result = asyncio.run(run_node(run_dir, node_id, "do the task", adapter, env, budget))
+
+            self.assertEqual(result.status, "done")
+
+            all_events = [e for e in log.read_all() if e.get("node_id") == node_id]
+            completed = [e for e in all_events if e["type"] == "episode_completed"]
+            self.assertEqual(len(completed), 1, f"expected exactly one episode_completed, got {completed}")
+
+            redispatches = [e for e in all_events if e["type"] == "node_redispatched"]
+            self.assertTrue(
+                any(e.get("reason") == "resumed_session" for e in redispatches),
+                f"expected a resumed_session redispatch, got {redispatches}",
+            )
+
+            artifact_path = run_dir / "out" / f"{node_id}.md"
+            self.assertTrue(artifact_path.exists())
+            artifact_text = artifact_path.read_text()
+            # Proves continuation actually happened, not a lucky fresh redispatch:
+            # only the fake CLI's --resume branch prints these.
+            self.assertIn("resume_acknowledged", artifact_text)
+            self.assertIn(original_session_id, artifact_text)
+
+
+class ResumeBeforeSessionCrashTest(unittest.TestCase):
+    def test_crash_before_session_capture_then_resume(self) -> None:
+        with tempfile.TemporaryDirectory() as root_str:
+            root = Path(root_str)
+            run_dir = create_run_dir(root, "run2")
+            node_id = "writer_2"
+            prompt_dir = root / "prompts"
+            prompt_dir.mkdir(parents=True, exist_ok=True)
+            pidfile = root / "writer_2.pid"
+
+            proc = _launch_runner_subprocess(
+                run_dir=run_dir,
+                node_id=node_id,
+                pidfile=pidfile,
+                prompt_dir=prompt_dir,
+                startup_delay=3.0,
+                work_delay=0.0,
+            )
+            try:
+                # The pidfile is written before the startup-delay sleep, so it
+                # appears almost immediately — well before any stdout line
+                # could exist, giving a reliable "no output yet" kill window.
+                fake_pid = _read_pid(pidfile, timeout=5)
+                self.assertTrue(_pid_alive(fake_pid))
+
+                _crash_and_verify_dead(proc, fake_pid)
+            finally:
+                if proc.poll() is None:
+                    _kill_pgid(proc.pid)
+                    proc.wait(timeout=10)
+
+            log = EventLog(run_dir / "events.jsonl")
+            node_events = [e for e in log.read_all() if e.get("node_id") == node_id]
+            self.assertTrue(any(e["type"] == "node_dispatched" for e in node_events))
+            self.assertFalse(any(e["type"] == "session_captured" for e in node_events))
+            self.assertFalse(any(e["type"] == "episode_completed" for e in node_events))
+
+            adapter = FakeStreamAgentAdapter(
+                script_path=str(FAKE_CLI),
+                pidfile=str(root / "writer_2_resume.pid"),
+                prompt_dir=str(prompt_dir),
+                workspace_path=str(run_dir),
+            )
+            env = LocalEnvironment(tmp_dir=str(prompt_dir))
+            budget = EpisodeBudget(max_duration_seconds=30)
+            result = asyncio.run(run_node(run_dir, node_id, "do the task", adapter, env, budget))
+
+            self.assertEqual(result.status, "done")
+
+            all_events = [e for e in log.read_all() if e.get("node_id") == node_id]
+            completed = [e for e in all_events if e["type"] == "episode_completed"]
+            self.assertEqual(len(completed), 1, f"expected exactly one episode_completed, got {completed}")
+
+            redispatches = [e for e in all_events if e["type"] == "node_redispatched"]
+            self.assertTrue(
+                any(e.get("reason") == "no_session_captured" for e in redispatches),
+                f"expected a no_session_captured redispatch, got {redispatches}",
+            )
+
+            artifact_path = run_dir / "out" / f"{node_id}.md"
+            self.assertTrue(artifact_path.exists())
+            self.assertIn("session_id", artifact_path.read_text())
+
+
+class ResumeAfterCompleteIsNoopTest(unittest.TestCase):
+    def test_resume_after_complete_is_noop(self) -> None:
+        with tempfile.TemporaryDirectory() as root_str:
+            root = Path(root_str)
+            run_dir = create_run_dir(root, "run3")
+            node_id = "writer_3"
+            prompt_dir = root / "prompts"
+            prompt_dir.mkdir(parents=True, exist_ok=True)
+
+            adapter = FakeStreamAgentAdapter(
+                script_path=str(FAKE_CLI),
+                pidfile=str(root / "writer_3.pid"),
+                prompt_dir=str(prompt_dir),
+                workspace_path=str(run_dir),
+            )
+            env = LocalEnvironment(tmp_dir=str(prompt_dir))
+            budget = EpisodeBudget(max_duration_seconds=30)
+
+            first = asyncio.run(run_node(run_dir, node_id, "do the task", adapter, env, budget))
+            self.assertEqual(first.status, "done")
+
+            log = EventLog(run_dir / "events.jsonl")
+            events_after_first = log.read_all()
+            completed_first = [
+                e for e in events_after_first
+                if e.get("node_id") == node_id and e["type"] == "episode_completed"
+            ]
+            self.assertEqual(len(completed_first), 1)
+
+            artifact_path = run_dir / "out" / f"{node_id}.md"
+            artifact_mtime_before = artifact_path.stat().st_mtime_ns
+            artifact_text_before = artifact_path.read_text()
+
+            second = asyncio.run(run_node(run_dir, node_id, "do the task", adapter, env, budget))
+
+            self.assertEqual(second.status, first.status)
+            self.assertEqual(second.metadata.get("replayed_from_event_log"), True)
+
+            events_after_second = log.read_all()
+            self.assertEqual(
+                len(events_after_second),
+                len(events_after_first),
+                "resume-after-complete must not append any new events",
+            )
+            self.assertEqual(artifact_path.stat().st_mtime_ns, artifact_mtime_before)
+            self.assertEqual(artifact_path.read_text(), artifact_text_before)
+
+
+class EventLogFsyncTest(unittest.TestCase):
+    def test_append_calls_fsync(self) -> None:
+        with tempfile.TemporaryDirectory() as root_str:
+            path = Path(root_str) / "events.jsonl"
+            log = EventLog(path)
+
+            with mock.patch("lh_harness.v0.events.os.fsync") as fsync_mock:
+                log.append({"node_id": "n1", "role": "writer", "round": 0, "type": "node_dispatched"})
+
+            fsync_mock.assert_called_once()
+            self.assertTrue(path.exists())
+            lines = path.read_text().strip().splitlines()
+            self.assertEqual(len(lines), 1)
+            record = json.loads(lines[0])
+            self.assertEqual(record["type"], "node_dispatched")
+            self.assertIn("ts", record)
+
+            with mock.patch("lh_harness.v0.events.os.fsync") as fsync_mock_2:
+                log.append(
+                    {"node_id": "n1", "role": "writer", "round": 0, "type": "session_captured", "session_id": "s1"}
+                )
+            self.assertEqual(fsync_mock_2.call_count, 1)
+
+            lines = path.read_text().strip().splitlines()
+            self.assertEqual(len(lines), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Implements PLAN.md §13's v0 milestone: prove resumability before anything else in the recursive-decomposition harness is built. `src/lh_harness/v0/` adds a fsync'd append-only `EventLog` and one idempotent `run_node()` entrypoint that converges to exactly one artifact/terminal event no matter when a `kill -9` lands.
- `ClaudeCodeAdapter` gains additive `--resume <session-id>` support so a killed Writer node continues its actual conversation rather than restarting from scratch (Codex has no equivalent and falls back to a clean fresh redispatch).
- Resolves a merge conflict against `main`'s "add the plan" commit and drops an accidental gitlink (`.claude/worktrees/rdh-v0-resumability`) that commit introduced; `.claude/worktrees/` is now gitignored so that can't recur.
- No existing role files (`manager.py`, `auditor_agent.py`, `cli.py`, `role_prompts.py`) were touched — this is additive scaffolding.

## Test plan
- [x] `python3 tests/test_v0_resume.py` — 4/4 passing, stdlib `unittest`, no network/API/real-binary dependency.
- [x] Two of the four tests SIGKILL real OS subprocesses (the runner and the actual fake-CLI child, in separate process groups) and verify the PIDs are dead before resuming, so this isn't a mocked-exception test.
- [x] Re-ran independently after merge to confirm the conflict resolution didn't break anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)