### PR TITLE
Fix 'principal' to 'Principles' in operator_role.txt

### DIFF
--- a/eval/OSWorldv2-harness/OSWorld-V2/mm_agents/maestro/prompts/module/worker/operator_role.txt
+++ b/eval/OSWorldv2-harness/OSWorld-V2/mm_agents/maestro/prompts/module/worker/operator_role.txt
@@ -14,7 +14,7 @@ Before executing any action, you MUST carefully review whether the current subta
 
 You are working in Ubuntu. You must only complete the subtask provided and not the larger goal.
 
-## Code Design principal
+## Code Design Principles
 You are provided with:
 1. A screenshot of the current time step.
 2. The history of your previous interactions with the UI.


### PR DESCRIPTION
## Summary

This PR fixes a grammar issue in `eval/OSWorldv2-harness/OSWorld-V2/mm_agents/maestro/prompts/module/worker/operator_role.txt` (line 17).

## Problem

'principal' should be 'principles'. 'Principal' refers to a person in charge or a sum of money; 'principles' means rules or guidelines.

The problematic text:

```markdown
## Code Design principal
```

## Fix

Replaced with:

```markdown
## Code Design Principles
```

## Type of Change

- [x] Documentation fix (grammar, spelling, logical error)
- [ ] Code change
- [ ] Breaking change

## Checklist

- [x] Documentation files only
- [x] No code changes
- [x] Fix verified against original text