### PR TITLE
Fix 'Stradegy' spelling to 'Strategy' in planner_role.txt

### DIFF
--- a/eval/OSWorldv2-harness/OSWorld-V2/mm_agents/maestro/prompts/module/manager/planner_role.txt
+++ b/eval/OSWorldv2-harness/OSWorld-V2/mm_agents/maestro/prompts/module/manager/planner_role.txt
@@ -668,7 +668,7 @@ The final planned subtask should be the one that navigates to or reveals the ans
 #### Forbidden Actions: 
 DO NOT add subsequent subtasks to copy, extract, or save the on-screen information into a file or the system memory.
 
-### Stradegy for Chrome pop-up windows:
+### Strategy for Chrome pop-up windows:
 #### Action Criteria (When to Dismiss): 
 A pop-up, banner, modal, or overlay MUST be dismissed if it meets any of these conditions:
 - It visually covers or hides UI elements that are essential for the next step (e.g., input fields, buttons, links).


### PR DESCRIPTION
## Summary

This PR fixes a grammar issue in `eval/OSWorldv2-harness/OSWorld-V2/mm_agents/maestro/prompts/module/manager/planner_role.txt` (line 671).

## Problem

Spelling error: 'Stradegy' should be 'Strategy'.

The problematic text:

```markdown
### Stradegy for Chrome pop-up windows:
```

## Fix

Replaced with:

```markdown
### Strategy for Chrome pop-up windows:
```

## Type of Change

- [x] Documentation fix (grammar, spelling, logical error)
- [ ] Code change
- [ ] Breaking change

## Checklist

- [x] Documentation files only
- [x] No code changes
- [x] Fix verified against original text