### PR TITLE
Fix 'outout' spelling to 'output' in dag_translator.txt

### DIFF
--- a/eval/OSWorldv2-harness/OSWorld-V2/mm_agents/maestro/prompts/module/manager/dag_translator.txt
+++ b/eval/OSWorldv2-harness/OSWorld-V2/mm_agents/maestro/prompts/module/manager/dag_translator.txt
@@ -116,7 +116,7 @@ Before generating the DAG, you MUST:
     "nodes": [
       {
         "name": "Task Cannot Be Completed",
-        "info": "This task cannot Be Completed, worker can directly output Done to enable Final Check. Worker success quality check can output gate_done to enable Final Check. Final Check should outout gate_fail.",
+        "info": "This task cannot Be Completed, worker can directly output Done to enable Final Check. Worker success quality check can output gate_done to enable Final Check. Final Check should output gate_fail.",
         "assignee_role": "operator"
       }
     ],


### PR DESCRIPTION
## Summary

This PR fixes a grammar issue in `eval/OSWorldv2-harness/OSWorld-V2/mm_agents/maestro/prompts/module/manager/dag_translator.txt` (line 119).

## Problem

Spelling error: 'outout' should be 'output'.

The problematic text:

```markdown
Final Check should outout gate_fail.
```

## Fix

Replaced with:

```markdown
Final Check should output gate_fail.
```

## Type of Change

- [x] Documentation fix (grammar, spelling, logical error)
- [ ] Code change
- [ ] Breaking change

## Checklist

- [x] Documentation files only
- [x] No code changes
- [x] Fix verified against original text