### PR TITLE
Guard-only failures fail the round, not the run; add validated guard_exclude_paths

### DIFF
--- a/src/lh_harness/adapters/claude_code.py
+++ b/src/lh_harness/adapters/claude_code.py
@@ -14,6 +14,7 @@ from .claude_permissions import (
     workspace_snapshot_diff,
 )
 from ..environment.base import Environment
+from ..provider_errors import GUARD_REJECTION_MESSAGE
 from ..types import (
     DEFAULT_CLAUDE_MODEL,
     DEFAULT_TMP_DIR,
@@ -37,6 +38,7 @@ class ClaudeCodeAdapter(CommandAgentAdapter):
         add_dirs: list[str] | None = None,
         role: ClaudeRole = "cli_executor",
         hidden_paths: tuple[str, ...] = (),
+        guard_exclude_paths: tuple[str, ...] = (),
     ) -> None:
         policy = policy_for_role(role)
         env_parts: list[str] = []
@@ -105,6 +107,10 @@ class ClaudeCodeAdapter(CommandAgentAdapter):
 
         self.role = role
         self.policy = policy
+        # Snapshot-only exclusions: unlike hidden_paths these are not denied
+        # to the agent — the guard just refrains from walking directories that
+        # legitimately churn (build outputs) during an audit window.
+        self.guard_exclude_paths = tuple(guard_exclude_paths)
         super().__init__(
             command_template=f"{env_prefix}{' '.join(command_parts)} < {{prompt_path}}",
             prompt_dir=prompt_dir,
@@ -121,7 +127,10 @@ class ClaudeCodeAdapter(CommandAgentAdapter):
         live_trajectory_path: str | None = None,
     ) -> EpisodeResult:
         before = (
-            snapshot_workspace(self.workspace_path, self.hidden_paths)
+            snapshot_workspace(
+                self.workspace_path,
+                (*self.hidden_paths, *self.guard_exclude_paths),
+            )
             if is_auditor_role(self.role)
             else None
         )
@@ -145,15 +154,22 @@ class ClaudeCodeAdapter(CommandAgentAdapter):
             }
         )
         if before is not None:
-            after = snapshot_workspace(self.workspace_path, self.hidden_paths)
+            after = snapshot_workspace(
+                self.workspace_path,
+                (*self.hidden_paths, *self.guard_exclude_paths),
+            )
             diff = workspace_snapshot_diff(before, after)
             result.metadata.update(diff)
+            # Record the effective exclusions with every audited episode so
+            # the guard's reduced coverage is visible in the run artifacts.
+            result.metadata["verifier_guard_exclude_paths"] = list(self.guard_exclude_paths)
             snapshot_errors = diff.get("verifier_workspace_snapshot_errors")
             if snapshot_errors:
-                result.status = "error"
-                guard_error = (
-                    "Auditor workspace read-only guard could not inspect every path; "
-                    "the audit was rejected fail-closed."
-                )
+                # Escalate only a successful status: a real timeout (or
+                # cancellation) is stronger evidence and must stay visible to
+                # the runtime-failure classifier.
+                if result.status == "done":
+                    result.status = "error"
+                guard_error = GUARD_REJECTION_MESSAGE
                 result.error = f"{result.error}\n{guard_error}".strip() if result.error else guard_error
         return result

--- a/src/lh_harness/cli.py
+++ b/src/lh_harness/cli.py
@@ -14,7 +14,7 @@ import traceback
 import uuid
 import webbrowser
 from pathlib import Path
-from typing import TYPE_CHECKING, Awaitable
+from typing import TYPE_CHECKING, Awaitable, Iterable
 
 from . import HOMEPAGE, ISSUES_URL, __version__
 from .config import (
@@ -498,6 +498,17 @@ def main(argv: list[str] | None = None) -> int:
         action="append",
         default=None,
         help="Extra directory to expose to the agent. May be repeated.",
+    )
+    run_parser.add_argument(
+        "--guard-exclude-path",
+        action="append",
+        default=run_default("guard_exclude_path"),
+        help=(
+            "Volatile workspace path the auditor read-only guard skips while "
+            "snapshotting (build outputs and similar churn). Relative paths "
+            "resolve against the workspace; agents may still read them. "
+            "May be repeated."
+        ),
     )
     run_parser.add_argument(
         "--max-rounds",
@@ -1489,10 +1500,38 @@ def _run_command(args: argparse.Namespace) -> int:
         prompt_dir,
     )
 
+    # Volatile workspace paths the read-only guard skips while snapshotting.
+    # Unlike hidden_paths these stay readable to the agents: excluding them
+    # only stops the guard from racing a directory that legitimately churns
+    # (build outputs) during an audit window.
+    try:
+        guard_exclude_paths = _resolve_guard_exclude_paths(
+            args.guard_exclude_path or [],
+            workspace=Path(workspace),
+            protected=(
+                Path(p)
+                for p in (
+                    PROJECT_CONFIG_PATH.parent,
+                    args.runs_root,
+                    run_dir,
+                    log_dir,
+                    harness_dir,
+                    prompt_dir,
+                )
+            ),
+        )
+    except ValueError as exc:
+        print(f"Cannot start run: {exc}", file=sys.stderr)
+        return 2
+
     print(f"Run id:    {run_id}")
     print(f"Run dir:   {run_dir.resolve()}")
     print(f"Workspace: {workspace}")
     print(f"Log dir:   {Path(log_dir).resolve()}")
+    if guard_exclude_paths:
+        # Make the audit's reduced coverage part of the run's console record;
+        # each audited episode also carries the list in its metadata.
+        print(f"Guard excludes: {', '.join(guard_exclude_paths)}")
 
     config = HarnessConfig(
         max_total_episodes=max_rounds,
@@ -1640,6 +1679,7 @@ def _run_command(args: argparse.Namespace) -> int:
                 mcp_config=resolve_mcp_config(name),
                 mcp_add_dirs=args.mcp_add_dir,
                 hidden_paths=hidden_paths,
+                guard_exclude_paths=guard_exclude_paths,
             )
         return agent_cache[key]
 
@@ -1741,6 +1781,60 @@ def _outermost_paths(*paths: str | Path) -> tuple[str, ...]:
         if not any(path.is_relative_to(parent) for parent in kept):
             kept.append(path)
     return tuple(str(path) for path in kept)
+
+
+def _resolve_guard_exclude_paths(
+    raw: list[str],
+    *,
+    workspace: Path,
+    protected: Iterable[str | Path],
+) -> tuple[str, ...]:
+    """Resolve and validate the auditor guard's snapshot exclusions.
+
+    The guard is the only witness of workspace mutations, and the agents keep
+    Bash access to excluded paths, so every exclusion is a hole in the audit.
+    Constrain the holes: an exclusion must stay inside the workspace, must not
+    disable the guard wholesale, and must not cover a path the audit exists to
+    protect - the VCS history and the harness's own control/state directories.
+    Raises ValueError with an operator-facing message on the first violation.
+    """
+
+    workspace = workspace.expanduser().resolve()
+    protected_paths = {Path(item).expanduser().resolve() for item in protected}
+    resolved: list[str] = []
+    for item in raw:
+        candidate = Path(item).expanduser()
+        if not candidate.is_absolute():
+            candidate = workspace / candidate
+        candidate = candidate.resolve()
+        if not candidate.is_relative_to(workspace):
+            raise ValueError(
+                f"guard exclude path escapes the workspace: {item!r} resolves to {candidate}"
+            )
+        if candidate == workspace:
+            raise ValueError(
+                f"guard exclude path would disable the read-only guard entirely: {item!r}"
+            )
+        if ".git" in candidate.relative_to(workspace).parts:
+            raise ValueError(
+                f"guard exclude path may not touch version-control state: {item!r}"
+            )
+        clashing = next(
+            (
+                shielded
+                for shielded in protected_paths
+                if shielded.is_relative_to(candidate) or candidate.is_relative_to(shielded)
+            ),
+            None,
+        )
+        if clashing is not None:
+            raise ValueError(
+                f"guard exclude path may not cover harness state ({clashing}): {item!r}"
+            )
+        value = str(candidate)
+        if value not in resolved:
+            resolved.append(value)
+    return tuple(resolved)
 
 
 def _open_dashboard(url: str) -> None:
@@ -1975,6 +2069,7 @@ def _build_agent(
     mcp_config: str | None = None,
     mcp_add_dirs: list[str] | None = None,
     hidden_paths: tuple[str, ...] = (),
+    guard_exclude_paths: tuple[str, ...] = (),
 ):
     if name == "codex":
         from .adapters.codex import CodexAdapter
@@ -2003,6 +2098,9 @@ def _build_agent(
             add_dirs=mcp_add_dirs,
             role=role,
             hidden_paths=hidden_paths,
+            # The Codex adapter has no auditor snapshot guard, so the
+            # exclusions are a Claude-Code-only concern for now.
+            guard_exclude_paths=guard_exclude_paths,
         )
         if model is not None:
             kwargs["model"] = model

--- a/src/lh_harness/config.py
+++ b/src/lh_harness/config.py
@@ -38,6 +38,7 @@ _RUN_KEYS = {
     "claude_mcp_config",
     "codex_mcp_config",
     "mcp_add_dirs",
+    "guard_exclude_paths",
     "max_rounds",
     "dashboard",
     "dashboard_port",
@@ -76,6 +77,13 @@ prompt_language = "en"
 # claude_mcp_config = "/path/to/mcp.json"
 # codex_mcp_config = "/path/to/mcp.toml"
 mcp_add_dirs = []
+
+# Build/cache directories the auditor read-only guard should not snapshot,
+# e.g. ["target", "node_modules", "build", ".venv"]. Agents can still read
+# them. Exclusions must stay inside the workspace; ".git" and harness-owned
+# control/state paths are rejected at startup, and the effective list is
+# echoed at run start and recorded in each audited episode's metadata.
+guard_exclude_paths = []
 
 max_rounds = 25
 dashboard = true
@@ -191,6 +199,11 @@ def _flatten_run_table(run: dict[str, Any]) -> dict[str, Any]:
         if not isinstance(value, list) or not all(isinstance(item, str) and item for item in value):
             raise ProjectConfigError("run.mcp_add_dirs must be an array of non-empty strings")
         defaults["mcp_add_dir"] = list(value)
+    if "guard_exclude_paths" in run:
+        value = run["guard_exclude_paths"]
+        if not isinstance(value, list) or not all(isinstance(item, str) and item for item in value):
+            raise ProjectConfigError("run.guard_exclude_paths must be an array of non-empty strings")
+        defaults["guard_exclude_path"] = list(value)
 
     roles = run.get("roles", {})
     if not isinstance(roles, dict):

--- a/src/lh_harness/provider_errors.py
+++ b/src/lh_harness/provider_errors.py
@@ -11,6 +11,16 @@ from .runtime_signals import hard_signal_labels
 from .types import EpisodeResult
 
 
+# The exact sentence the Claude Code adapter appends when the read-only guard
+# rejects an audit fail-closed. The classifier strips it from failure evidence
+# so a guard-only rejection stays a round-level problem while any coexisting
+# provider failure keeps its terminal classification.
+GUARD_REJECTION_MESSAGE = (
+    "Auditor workspace read-only guard could not inspect every path; "
+    "the audit was rejected fail-closed."
+)
+
+
 @dataclass(frozen=True)
 class AgentRuntimeFailure:
     kind: str
@@ -81,6 +91,12 @@ def classify_agent_runtime_failure(result: EpisodeResult) -> AgentRuntimeFailure
     if result.status not in {"error", "timeout"} and not hard_signals:
         return None
     candidates = _failure_messages(result, metadata)
+    guard_rejected = bool(metadata.get("verifier_workspace_snapshot_errors"))
+    if guard_rejected:
+        # The guard's fail-closed rejection sentence is local bookkeeping,
+        # not provider evidence; classify only what remains so a coexisting
+        # authentication/network/quota failure keeps its terminal kind.
+        candidates = _strip_guard_rejection(candidates)
     combined = "\n".join(candidates)
     kind = "timeout" if result.status == "timeout" else "provider_error"
     label = "Agent 执行超时" if kind == "timeout" else "Agent provider 启动或运行失败"
@@ -89,12 +105,30 @@ def classify_agent_runtime_failure(result: EpisodeResult) -> AgentRuntimeFailure
     # adapter's own "Episode timed out after ..." message matches the generic
     # network classifier below. Keep the explicit status authoritative so the
     # manager can recover from the real workspace in a later round.
+    matched_provider_kind = False
     if result.status != "timeout":
         for candidate_kind, pattern, candidate_label in _CLASSIFIERS:
             if pattern.search(combined):
                 kind = candidate_kind
                 label = candidate_label
+                matched_provider_kind = True
                 break
+    # Downgrade to a round-level failure only when the failure is proven to
+    # be caused solely by the snapshot guard: the guard rejected the audit,
+    # nothing matched a provider classifier, no hard runtime signal fired,
+    # the episode did not time out, and the episode's own failure channels
+    # (actions log, error field) carry nothing beyond the guard rejection.
+    # The audit is already rejected fail-closed by the adapter, so the round
+    # fails and is retried instead of the whole run aborting over a transient
+    # filesystem race, e.g. a build directory churning underneath the walk.
+    if (
+        guard_rejected
+        and not matched_provider_kind
+        and not hard_signals
+        and result.status != "timeout"
+        and not _non_guard_failure_evidence(result)
+    ):
+        return None
     message = next((item for item in candidates if _specific_message(item)), None)
     message = message or next(iter(candidates), "agent runtime failed")
     message = _clean(message, 1200)
@@ -104,6 +138,45 @@ def classify_agent_runtime_failure(result: EpisodeResult) -> AgentRuntimeFailure
         message=message,
         user_message=f"{label}：{message}",
     )
+
+
+def _strip_guard_rejection(candidates: list[str]) -> list[str]:
+    """Remove the guard's own rejection sentence, keeping any other evidence."""
+
+    stripped: list[str] = []
+    for item in candidates:
+        text = item.replace(GUARD_REJECTION_MESSAGE, " ")
+        text = " ".join(text.split())
+        if text and text not in stripped:
+            stripped.append(text)
+    return stripped
+
+
+def _non_guard_failure_evidence(result: EpisodeResult) -> bool:
+    """True when the episode's failure channels carry more than the guard.
+
+    Looks only at channels that are silent on a successful episode (failure
+    records in the actions log and the episode error field), so stderr noise
+    from a healthy run cannot escalate a guard-only rejection back into a
+    terminal provider failure.
+    """
+
+    values: list[str] = []
+    for record in _json_records(result.actions_log):
+        record_type = str(record.get("type") or "")
+        if record_type == "turn.failed":
+            error = record.get("error")
+            _append(values, error.get("message") if isinstance(error, dict) else error)
+        elif record_type == "error":
+            _append(values, record.get("message") or record.get("error"))
+        elif record_type == "result" and record.get("is_error"):
+            _append(values, record.get("result") or record.get("error") or record.get("subtype"))
+    _append(values, result.error)
+    for value in values:
+        text = _clean(value, 2000).replace(GUARD_REJECTION_MESSAGE, " ").strip()
+        if text:
+            return True
+    return False
 
 
 def _failure_messages(result: EpisodeResult, metadata: dict[str, Any]) -> list[str]:

--- a/tests/test_guard_exclude_paths.py
+++ b/tests/test_guard_exclude_paths.py
@@ -1,0 +1,104 @@
+"""Validation boundaries for auditor guard snapshot exclusions.
+
+Excluded paths stay readable (and writable, via Bash) to the agents while the
+guard stops watching them, so every exclusion is a hole in the audit. The
+resolver must keep the holes inside the workspace and away from the paths the
+audit exists to protect.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from lh_harness.cli import _resolve_guard_exclude_paths
+from lh_harness.config import ProjectConfigError, _flatten_run_table
+
+
+def _workspace(tmp_path: Path) -> Path:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    return workspace
+
+
+def test_relative_paths_resolve_against_the_workspace(tmp_path: Path) -> None:
+    workspace = _workspace(tmp_path)
+
+    resolved = _resolve_guard_exclude_paths(
+        ["target", "node_modules"], workspace=workspace, protected=()
+    )
+
+    assert resolved == (
+        str(workspace / "target"),
+        str(workspace / "node_modules"),
+    )
+
+
+def test_duplicate_exclusions_are_collapsed(tmp_path: Path) -> None:
+    workspace = _workspace(tmp_path)
+
+    resolved = _resolve_guard_exclude_paths(
+        ["target", str(workspace / "target")], workspace=workspace, protected=()
+    )
+
+    assert resolved == (str(workspace / "target"),)
+
+
+@pytest.mark.parametrize("escape", ["..", "../sibling", "/etc", "a/../../.."])
+def test_paths_outside_the_workspace_are_rejected(tmp_path: Path, escape: str) -> None:
+    workspace = _workspace(tmp_path)
+
+    with pytest.raises(ValueError, match="escapes the workspace"):
+        _resolve_guard_exclude_paths([escape], workspace=workspace, protected=())
+
+
+def test_excluding_the_workspace_itself_is_rejected(tmp_path: Path) -> None:
+    workspace = _workspace(tmp_path)
+
+    with pytest.raises(ValueError, match="disable the read-only guard"):
+        _resolve_guard_exclude_paths(["."], workspace=workspace, protected=())
+
+
+@pytest.mark.parametrize("vcs_path", [".git", ".git/objects", "vendored/.git"])
+def test_version_control_state_is_protected(tmp_path: Path, vcs_path: str) -> None:
+    """Mutations under an excluded .git would be invisible to the guard."""
+
+    workspace = _workspace(tmp_path)
+
+    with pytest.raises(ValueError, match="version-control state"):
+        _resolve_guard_exclude_paths([vcs_path], workspace=workspace, protected=())
+
+
+def test_harness_state_paths_are_protected(tmp_path: Path) -> None:
+    workspace = _workspace(tmp_path)
+    run_dir = workspace / "runs" / "run-1"
+
+    # Excluding the harness path itself, or any parent that covers it, would
+    # hide the run's own control/state files from the guard.
+    for candidate in ("runs/run-1", "runs"):
+        with pytest.raises(ValueError, match="harness state"):
+            _resolve_guard_exclude_paths(
+                [candidate], workspace=workspace, protected=(run_dir,)
+            )
+
+
+def test_sibling_of_harness_state_is_allowed(tmp_path: Path) -> None:
+    workspace = _workspace(tmp_path)
+    run_dir = workspace / "runs" / "run-1"
+
+    resolved = _resolve_guard_exclude_paths(
+        ["target"], workspace=workspace, protected=(run_dir,)
+    )
+
+    assert resolved == (str(workspace / "target"),)
+
+
+def test_config_accepts_a_string_array() -> None:
+    defaults = _flatten_run_table({"guard_exclude_paths": ["target", "build"]})
+
+    assert defaults["guard_exclude_path"] == ["target", "build"]
+
+
+@pytest.mark.parametrize("bad", ["target", [""], [1], [None], {"a": 1}])
+def test_config_rejects_non_string_arrays(bad: object) -> None:
+    with pytest.raises(ProjectConfigError, match="guard_exclude_paths"):
+        _flatten_run_table({"guard_exclude_paths": bad})

--- a/tests/test_provider_errors.py
+++ b/tests/test_provider_errors.py
@@ -1,0 +1,141 @@
+"""Classification boundaries for terminal agent-CLI failures."""
+
+from lh_harness.provider_errors import classify_agent_runtime_failure
+from lh_harness.types import EpisodeResult
+
+
+def test_guard_snapshot_failure_is_not_a_runtime_failure():
+    """A read-only-guard snapshot failure must fail the round, not the run.
+
+    The guard rejects the audit fail-closed when it cannot inspect every
+    workspace path (e.g. a build directory changing underneath the walk).
+    That is a local audit-validity problem: the episode itself ran to
+    completion, so classifying it as a provider failure — and aborting the
+    whole run — turns a transient filesystem race into a fatal outcome.
+    """
+
+    result = EpisodeResult(
+        status="error",
+        error=(
+            "Auditor workspace read-only guard could not inspect every path; "
+            "the audit was rejected fail-closed."
+        ),
+        metadata={
+            "verifier_workspace_snapshot_errors": [
+                "target/debug/incremental/x.o: OSError: [Errno 9] Bad file descriptor"
+            ]
+        },
+    )
+
+    assert classify_agent_runtime_failure(result) is None
+
+
+def test_plain_provider_error_is_still_terminal():
+    """Genuine runtime failures keep their terminal classification."""
+
+    result = EpisodeResult(status="error", error="connection reset by peer")
+
+    failure = classify_agent_runtime_failure(result)
+    assert failure is not None
+    assert failure.abort_reason == "provider_network"
+
+
+def _guard_rejected_result(**overrides):
+    """An episode whose audit the guard rejected fail-closed."""
+
+    from lh_harness.provider_errors import GUARD_REJECTION_MESSAGE
+
+    fields = {
+        "status": "error",
+        "error": GUARD_REJECTION_MESSAGE,
+        "metadata": {
+            "verifier_workspace_snapshot_errors": [
+                "target/debug/incremental/x.o: OSError: [Errno 9] Bad file descriptor"
+            ]
+        },
+    }
+    metadata_overrides = overrides.pop("metadata", {})
+    fields.update(overrides)
+    fields["metadata"] = {**fields["metadata"], **metadata_overrides}
+    return EpisodeResult(**fields)
+
+
+def test_guard_rejection_with_stderr_noise_is_still_round_level():
+    """Harmless stderr from a healthy episode must not resurrect the abort."""
+
+    result = _guard_rejected_result(
+        metadata={"stderr_tail": "warning: unused variable `x`"}
+    )
+
+    assert classify_agent_runtime_failure(result) is None
+
+
+def test_guard_rejection_does_not_hide_authentication_failure():
+    """A terminal provider failure coexisting with snapshot errors stays terminal.
+
+    Hiding it would make the manager retry until the round budget is
+    exhausted instead of surfacing the real authentication problem.
+    """
+
+    from lh_harness.provider_errors import GUARD_REJECTION_MESSAGE
+
+    result = _guard_rejected_result(
+        error=f"401 Unauthorized: invalid api key\n{GUARD_REJECTION_MESSAGE}",
+    )
+
+    failure = classify_agent_runtime_failure(result)
+    assert failure is not None
+    assert failure.abort_reason == "provider_authentication"
+
+
+def test_guard_rejection_does_not_hide_network_failure_in_stderr():
+    result = _guard_rejected_result(
+        metadata={"stderr_tail": "connection reset by peer"}
+    )
+
+    failure = classify_agent_runtime_failure(result)
+    assert failure is not None
+    assert failure.abort_reason == "provider_network"
+
+
+def test_guard_rejection_does_not_hide_hard_runtime_signal():
+    result = _guard_rejected_result(
+        metadata={
+            "runtime_signals": [
+                {"signal": "AGENT_EXIT=1", "evidence": "AGENT_EXIT=1"}
+            ]
+        },
+    )
+
+    failure = classify_agent_runtime_failure(result)
+    assert failure is not None
+    assert failure.abort_reason == "provider_provider_error"
+
+
+def test_guard_rejection_does_not_hide_episode_timeout():
+    """A timed-out audited episode stays a timeout for manager recovery."""
+
+    result = _guard_rejected_result(
+        status="timeout",
+        error="Episode timed out after 1800s",
+    )
+
+    failure = classify_agent_runtime_failure(result)
+    assert failure is not None
+    assert failure.abort_reason == "provider_timeout"
+
+
+def test_guard_rejection_does_not_hide_agent_error_records():
+    """Failure records in the actions log count as real evidence."""
+
+    import json as _json
+
+    result = _guard_rejected_result(
+        actions_log=_json.dumps(
+            {"type": "turn.failed", "error": {"message": "AGENT_TURN_FAILED"}}
+        ),
+    )
+
+    failure = classify_agent_runtime_failure(result)
+    assert failure is not None
+    assert failure.abort_reason == "provider_provider_error"


### PR DESCRIPTION
Fixes #27.

Two related changes for auditor read-only-guard snapshot errors (e.g. `EBADF` when a build directory churns underneath the walk):

### 1. A guard-only snapshot failure fails the round, not the run

`classify_agent_runtime_failure` classifies hard/provider signals **first** and downgrades to a round-level failure only when the failure is proven to be caused solely by the snapshot guard:

- The guard's fail-closed rejection sentence (now shared as `GUARD_REJECTION_MESSAGE`) is stripped from the evidence, and what remains is classified normally — a coexisting authentication, network, quota, rate-limit, or model failure keeps its terminal classification.
- A hard runtime signal, an episode timeout, or any failure record in the actions log / episode error beyond the guard sentence also blocks the downgrade (the adapter no longer overwrites a real `timeout` status with `error` when snapshot errors coexist).
- Only the proven guard-only case returns `None`: the adapter has already rejected the audit fail-closed, so the round fails and is retried — restoring the 0.1.3 behavior — instead of the whole run aborting with `provider_provider_error`.

### 2. New `guard_exclude_paths` option, validated

A `[run] guard_exclude_paths` config key (and matching `--guard-exclude-path` CLI flag) lists volatile workspace paths the guard should not snapshot — build/cache directories such as `target`, `node_modules`, `build`, `.venv`. Unlike `hidden_paths` these stay fully readable to the agents; relative paths resolve against the workspace; the default is empty.

Because every exclusion is a hole in the audit while agents keep Bash access, exclusions are **validated at startup** and the run refuses to start on the first violation:

- must resolve to a path **inside the workspace** (symlinks/`..` resolved first);
- must not be the workspace itself (which would disable the guard wholesale);
- must not touch version-control state (`.git` anywhere in the relative path);
- must not equal, contain, or sit inside a harness-owned control/state path (runs root, run dir, log dir, harness dir, prompt dir, project config dir).

For auditability the effective exclusion list is echoed in the run's console record at startup and recorded in every audited episode's metadata as `verifier_guard_exclude_paths`.

### Testing

- `tests/test_provider_errors.py`: guard-only rejection (with and without harmless stderr noise) → `None`; coexisting authentication (`401` + guard sentence), network-in-stderr, hard runtime signal, episode timeout, and actions-log failure records all stay terminal with the right `abort_reason`.
- `tests/test_guard_exclude_paths.py` (new): relative resolution, dedup, workspace containment (`..`, absolute escapes), workspace-root rejection, `.git`/nested-`.git` rejection, harness-state rejection (exact, parent, and child), sibling paths allowed; config-level type validation.
- Full suite on current `main` with the frontend bundle built: **229 passed, 1 skipped** (the remaining skip is the macOS `/var`-alias check, N/A on Linux).
