### PR TITLE
Dynamic executor model routing with cost-aware escalation

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ cli_auditor  → auditor  → [run].agent / [run].model
 | Section | Falls back to | Covers |
 |---|---|---|
 | `[run.roles.manager]` | `[run]` | The scheduler role |
-| `[run.roles.executor]` | `[run]` | Both executor roles |
+| `[run.roles.executor]` | `[run]` | Every executor role and tier |
 | `[run.roles.gui_executor]` | `executor` | GUI/visual subtasks |
 | `[run.roles.cli_executor]` | `executor` | CLI/non-GUI subtasks |
 | `[run.roles.auditor]` | `[run]` | Both auditor roles |
@@ -331,6 +331,103 @@ cli_auditor  → auditor  → [run].agent / [run].model
 | `[run.roles.final_response]` | `manager` | The closing reply written for you |
 
 Every field above also has a CLI flag (`--agent`, `--max-rounds`, `--gui-executor-model`, `--auditor-timeout`, and so on) that overrides it for a single run. Run `lh-harness run --help` for the full list.
+
+##### Executor tiers
+
+An executor has two independent properties: its **type** (`gui` or `cli`, decided by the Manager's route) and its **tier** (`cheap` or `strong`, how much model capability the subtask is worth). Giving each executor role a `cheap` and a `strong` sub-table lets routine work run on a cheaper backend while harder subtasks get a stronger one:
+
+```toml
+[run.roles.executor.cheap]
+agent = "codex"
+model = "gpt-5.6-sol"
+
+[run.roles.executor.strong]
+agent = "claude_code"
+model = "claude-opus-5"
+```
+
+Tiers work through the same agent abstraction as every other role, so any supported backend can serve any tier, and a Manager on one backend can dispatch to executors on another.
+
+| Section | Falls back to | Covers |
+|---|---|---|
+| `[run.roles.executor.cheap]` | `executor` | The cheap tier of both executor types |
+| `[run.roles.executor.strong]` | `executor` | The strong tier of both executor types |
+| `[run.roles.gui_executor.cheap]` | `executor.cheap`, then `gui_executor` | GUI + cheap only |
+| `[run.roles.gui_executor.strong]` | `executor.strong`, then `gui_executor` | GUI + strong only |
+| `[run.roles.cli_executor.cheap]` | `executor.cheap`, then `cli_executor` | CLI + cheap only |
+| `[run.roles.cli_executor.strong]` | `executor.strong`, then `cli_executor` | CLI + strong only |
+
+Naming a tier is a deliberate cost decision, so it outranks the older type-level section. The full chain for a GUI subtask on the cheap tier is:
+
+```
+gui_executor.cheap → executor.cheap → gui_executor → executor → [run].agent / [run].model
+```
+
+Tiers are optional. A configuration that defines no tier tables resolves every tier to the same executor it uses today, so existing single-executor projects keep working unchanged.
+
+##### `[run.executor_routing]`
+
+Which tier runs a subtask, and when the harness overrides that choice itself.
+
+```toml
+[run.executor_routing]
+default_tier = "cheap"
+escalate_after_failures = 1
+escalate_after_stalled_rounds = 3
+escalation_tier = "strong"
+```
+
+| Field | Default | Description |
+|---|---|---|
+| `default_tier` | `"cheap"` | Tier used when the Manager names none, so most work stays on the cheaper backend. |
+| `escalate_after_failures` | `1` | Consecutive audits reporting a real problem before switching to `escalation_tier`. `0` disables this signal. |
+| `escalate_after_stalled_rounds` | `3` | Consecutive clean rounds that keep reporting the same unclosed gap. `0` disables this signal. |
+| `escalation_tier` | `"strong"` | Tier used once either threshold is reached. |
+| `escalation_briefing` | `true` | Tell the escalated executor what the previous tier tried and why the Auditor rejected it. |
+
+##### What counts as a failure
+
+This matters more than it looks. Auditors are instructed to report `incomplete` whenever the *whole* contract is unsatisfied — "even if the local subtask succeeded" — so a perfectly good mid-run round normally comes back `Status: incomplete · Integrity: clean · Contract audit: aligned`. Treating that as a failure would escalate on round one of nearly every task and throw away the saving.
+
+So escalation reads two distinct signals:
+
+| Signal | Counts toward | What it means |
+|---|---|---|
+| `Status: blocked`, `Integrity: suspect`/`violation`, `Contract audit: needs_revision`/`invalid`, or an executor episode that errored or timed out | `escalate_after_failures` | The round actually went wrong |
+| Consecutive clean rounds whose Auditor keeps naming the same outstanding gap | `escalate_after_stalled_rounds` | The cheap tier is spinning without closing anything |
+| `Status: incomplete` with clean integrity and an aligned contract, and a *new* gap each round | neither | Ordinary forward progress on a multi-round task |
+
+A passing audit (`complete` + `clean` + `aligned`) clears both counters.
+
+The Manager may name a tier per subtask by adding one `Executor tier: cheap` or `Executor tier: strong` line after its route. It decides from the subtask in front of it, not from a fixed list of task categories.
+
+Because a Manager can misjudge difficulty before the work happens, failed audits escalate on their own:
+
+```
+cheap executor → Auditor → FAIL → strong executor → Auditor
+```
+
+Escalation never bypasses verification: the strong executor's result goes through the normal Auditor flow. A passing audit clears the escalation, so routing returns to the default tier and the expensive model is only used while a run is actually struggling.
+
+##### Tuning the two knobs together
+
+`escalate_after_failures` and `escalation_briefing` interact, and are worth setting as a pair.
+
+Each role episode is a fresh agent session — the CLIs are invoked one-shot, with no conversation carried between rounds. An **escalated** executor is therefore briefed with what the previous tier attempted and the Auditor's findings on it. Prior executor output is labelled as an unverified claim, keeping the Auditor the only authority on what is true. The Manager is told about the escalation too, since repeated failure can mean the decomposition is wrong rather than the executor being too weak.
+
+A **same-tier retry** gets no such briefing. It sees only the Manager's `Current task state:` and whatever reports the Manager chose to cite, so it can repeat the approach that was just rejected.
+
+That is why the default threshold is `1`: with no briefing to work from, a second cheap attempt is largely a wasted round. Raising the threshold trades latency for cost:
+
+| `escalate_after_failures` | Behaviour |
+|---|---|
+| `1` (default) | Straight to the strong tier on the first audit that reports a real problem. Fastest; the strong model runs more often. |
+| `2` or more | Retries on the cheap tier first. Cheaper when the retry succeeds, but those retry rounds are unbriefed. |
+| `0` | Never escalates on problems. `escalate_after_stalled_rounds` still applies. |
+
+Because a merely-incomplete round is not a failure, `1` here does **not** mean "escalate on round one" — a task that progresses cleanly stays on the cheap tier for as long as it keeps making progress.
+
+The selected tier appears in the console (`tier=cheap`), in the Dashboard as a badge next to the route, and in `report.json` per round plus an `executor_routing` summary of what routing actually did.
 
 #### Manage computer-use plugins
 
@@ -446,6 +543,9 @@ lh-harness web --workspace-root .               # Serve the workbench for anothe
 | `--agent` | `claude_code` or `codex` |
 | `--env` | `local` |
 | `--max-rounds` | Maximum number of Manage-Execute-Audit rounds; the CLI default is 30 |
+| `--executor-cheap-agent` / `--executor-strong-agent` | Backend for one executor tier; `--*-model` sets its model |
+| `--executor-default-tier` | Tier for subtasks where the Manager names none; defaults to `cheap` |
+| `--executor-escalate-after-failures` | Failed audits before escalating; `0` disables it |
 | `--dashboard` | Start live monitoring and human intervention |
 | `--no-dashboard` | Disable a Dashboard enabled by the project configuration |
 

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ Steps 1–2 are once per machine; step 3 is once per project. Then run tasks fro
 | One agent runtime on `PATH`: [`codex`](https://github.com/openai/codex#installing-and-running-codex-cli) or [`claude`](https://docs.anthropic.com/en/docs/claude-code/getting-started) | Actually executing the work. Install both if you want to mix them across roles. |
 | [Node.js](https://nodejs.org) 20 or later | Only the npm-distributed computer-use plugins. Not needed for `codex-computer-use` or CLI-only tasks. |
 
-> **Platform status:** Currently tested on macOS. Windows support is included but has not yet been thoroughly tested.
+> **Platform status:** Tested on macOS and Windows. Agent CLIs are launched as plain subprocesses — no shell is involved — so command construction behaves identically on every platform. On Windows the harness also escapes the 260-character `MAX_PATH` limit automatically, which run directories reach easily on a deep project path.
 
 Run `lh-harness doctor` at any point to check all of the above; see [Verify the environment](#verify-the-environment).
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -323,7 +323,7 @@ cli_auditor  → auditor  → [run].agent / [run].model
 | 配置段 | 回退到 | 作用范围 |
 |---|---|---|
 | `[run.roles.manager]` | `[run]` | 调度角色 |
-| `[run.roles.executor]` | `[run]` | 两个 executor 角色 |
+| `[run.roles.executor]` | `[run]` | 所有 executor 角色和档位 |
 | `[run.roles.gui_executor]` | `executor` | GUI/视觉子任务 |
 | `[run.roles.cli_executor]` | `executor` | CLI/非 GUI 子任务 |
 | `[run.roles.auditor]` | `[run]` | 两个 auditor 角色 |
@@ -332,6 +332,103 @@ cli_auditor  → auditor  → [run].agent / [run].model
 | `[run.roles.final_response]` | `manager` | 写给你的最终回复 |
 
 上述每个字段都有对应的 CLI 参数（`--agent`、`--max-rounds`、`--gui-executor-model`、`--auditor-timeout` 等）可以对单次运行覆盖。完整列表见 `lh-harness run --help`。
+
+##### executor 档位
+
+executor 有两个彼此独立的属性：**类型**（`gui` 或 `cli`，由任务管理器的路由决定）和**档位**（`cheap` 或 `strong`，表示这个子任务值得多强的模型能力）。给 executor 角色配置 `cheap` 和 `strong` 子表，就能让常规工作跑在更便宜的后端上，只在更难的子任务上使用更强的后端：
+
+```toml
+[run.roles.executor.cheap]
+agent = "codex"
+model = "gpt-5.6-sol"
+
+[run.roles.executor.strong]
+agent = "claude_code"
+model = "claude-opus-5"
+```
+
+档位复用与其它角色相同的 agent 抽象，因此任何受支持的后端都可以承担任何档位，任务管理器也可以把子任务派发给另一个后端上的 executor。
+
+| 配置段 | 回退到 | 覆盖范围 |
+|---|---|---|
+| `[run.roles.executor.cheap]` | `executor` | 两种 executor 类型的 cheap 档位 |
+| `[run.roles.executor.strong]` | `executor` | 两种 executor 类型的 strong 档位 |
+| `[run.roles.gui_executor.cheap]` | `executor.cheap`，然后 `gui_executor` | 仅 GUI + cheap |
+| `[run.roles.gui_executor.strong]` | `executor.strong`，然后 `gui_executor` | 仅 GUI + strong |
+| `[run.roles.cli_executor.cheap]` | `executor.cheap`，然后 `cli_executor` | 仅 CLI + cheap |
+| `[run.roles.cli_executor.strong]` | `executor.strong`，然后 `cli_executor` | 仅 CLI + strong |
+
+指定档位是明确的成本决定，因此它优先于按类型配置的旧配置段。GUI 子任务在 cheap 档位上的完整回退链是：
+
+```
+gui_executor.cheap → executor.cheap → gui_executor → executor → [run].agent / [run].model
+```
+
+档位是可选的。没有配置任何档位子表时，每个档位都会解析到与今天相同的 executor，因此已有的单 executor 项目配置可以继续正常工作。
+
+##### `[run.executor_routing]`
+
+决定哪个档位执行子任务，以及 harness 在什么情况下自己覆盖这个选择。
+
+```toml
+[run.executor_routing]
+default_tier = "cheap"
+escalate_after_failures = 1
+escalate_after_stalled_rounds = 3
+escalation_tier = "strong"
+```
+
+| 字段 | 默认值 | 说明 |
+|---|---|---|
+| `default_tier` | `"cheap"` | 任务管理器没有指定档位时使用的档位，让大部分工作留在更便宜的后端上。 |
+| `escalate_after_failures` | `1` | 切换到 `escalation_tier` 前允许的、报告真实问题的连续审计次数；`0` 表示关闭该信号。 |
+| `escalate_after_stalled_rounds` | `3` | 连续多少轮结果干净但反复报告同一个未闭合缺口时升级；`0` 表示关闭该信号。 |
+| `escalation_tier` | `"strong"` | 任一阈值达到后使用的档位。 |
+| `escalation_briefing` | `true` | 告诉升级后的 executor 上一个档位试过什么、为什么被 auditor 拒绝。 |
+
+##### 什么才算“失败”
+
+这一点比看上去重要。auditor 被要求：只要**整体**契约尚未满足就报告 `incomplete`——“即使局部子任务成功也是如此”。因此一个完全正常的中间轮次通常返回 `状态: incomplete · 完整性: clean · 契约审计: aligned`。如果把它当成失败，几乎每个任务都会在第一轮就升级，成本优势也就没有了。
+
+所以升级读取两个不同的信号：
+
+| 信号 | 计入 | 含义 |
+|---|---|---|
+| `状态: blocked`、`完整性: suspect`/`violation`、`契约审计: needs_revision`/`invalid`，或 executor 调用报错/超时 | `escalate_after_failures` | 这一轮确实出了问题 |
+| 连续多轮结果干净，但 auditor 反复指出同一个未闭合缺口 | `escalate_after_stalled_rounds` | cheap 档位在空转，没有推进 |
+| `状态: incomplete` 且 clean/aligned，每轮缺口都在变化 | 都不计入 | 多轮任务的正常推进 |
+
+审计通过（`complete` + `clean` + `aligned`）会同时清零两个计数器。
+
+任务管理器可以在路由之后加一行 `执行器档位: cheap` 或 `执行器档位: strong` 来为单个子任务指定档位。它根据眼前这个子任务判断，而不是依据固定的任务类别清单。
+
+由于任务管理器是在工作发生之前预判难度，可能判断错误，审计失败会自动触发升级：
+
+```
+cheap executor → auditor → 失败 → strong executor → auditor
+```
+
+升级绝不会绕过验证：strong executor 的结果同样要走正常的 auditor 流程。审计通过后升级状态会被清除，路由回到默认档位，因此更贵的模型只在运行确实卡住的阶段被使用。
+
+##### 两个参数要一起调
+
+`escalate_after_failures` 和 `escalation_briefing` 是相互影响的，建议成对设置。
+
+每次角色调用都是全新的 agent 会话——agent CLI 都是一次性调用，轮次之间不保留对话。因此**升级后**的 executor 会收到一份简报，说明上一个档位尝试过什么以及 auditor 的审计结论；其中历史 executor 输出会被明确标注为未经验证的自述，auditor 仍然是唯一的事实权威。升级也会通知任务管理器，因为反复失败可能意味着子任务拆解有问题，而不只是 executor 能力不足。
+
+但**同档位重试**不会收到这份简报。它只能看到任务管理器维护的 `当前任务状态:` 以及任务管理器主动引用的报告，因此可能重复刚刚被拒绝的做法。
+
+这就是默认阈值为 `1` 的原因：在没有简报的情况下，第二次 cheap 尝试基本是浪费一轮。提高阈值是用延迟换成本：
+
+| `escalate_after_failures` | 行为 |
+|---|---|
+| `1`（默认） | 第一次报告真实问题的审计之后直接升级到 strong 档位。最快，但 strong 模型使用频率更高。 |
+| `2` 或更大 | 先在 cheap 档位重试。重试成功时更省钱，但这些重试轮次没有简报。 |
+| `0` | 不因问题而升级；`escalate_after_stalled_rounds` 仍然生效。 |
+
+由于“仅仅 incomplete”不算失败，这里的 `1` **并不意味着**“第一轮就升级”——只要任务在干净地推进，就会一直留在 cheap 档位。
+
+选中的档位会显示在控制台（`tier=cheap`）、Dashboard 中路由徽章旁边，以及 `report.json` 里每一轮的记录和 `executor_routing` 汇总中。
 
 #### 管理 computer-use 插件
 
@@ -447,6 +544,9 @@ lh-harness web --workspace-root .               # 为指定目录启动工作台
 | `--agent` | `claude_code` 或 `codex` |
 | `--env` | `local` |
 | `--max-rounds` | Manage-Execute-Audit 循环的最大轮数；CLI 默认为 30 |
+| `--executor-cheap-agent` / `--executor-strong-agent` | 指定某个 executor 档位的后端；`--*-model` 指定其模型 |
+| `--executor-default-tier` | 任务管理器未指定档位时使用的档位，默认 `cheap` |
+| `--executor-escalate-after-failures` | 触发升级前允许的审计失败次数；`0` 表示关闭 |
 | `--dashboard` | 启动实时监控和人工介入功能 |
 | `--no-dashboard` | 关闭项目配置中默认启用的 Dashboard |
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -190,7 +190,7 @@ LongHorizon-Harness 不只展示了几个精心挑选的成功案例。
 | `PATH` 上有一个 Agent 运行时：[`codex`](https://github.com/openai/codex#installing-and-running-codex-cli) 或 [`claude`](https://docs.anthropic.com/en/docs/claude-code/getting-started) | 真正执行任务。想按角色混用两个后端就都装上。 |
 | [Node.js](https://nodejs.org) 20 或更高版本 | 只有 npm 分发的 computer-use 插件需要。用 `codex-computer-use` 或纯 CLI 任务时不需要。 |
 
-> **平台状态：** 目前只在 macOS 上完成了测试；Windows 已支持，但尚未经过详细测试。
+> **平台状态：** 已在 macOS 和 Windows 上测试。Agent CLI 以普通子进程方式启动，不经过 shell，因此命令构造在所有平台上行为一致。在 Windows 上还会自动绕开 260 字符的 `MAX_PATH` 限制——项目路径较深时，运行目录很容易超过这个长度。
 
 以上都可以用 `lh-harness doctor` 一次性检查，见[检查运行环境](#检查运行环境)。
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,9 +28,6 @@ test = [
     "httpx2",
 ]
 
-[project.optional-dependencies]
-dev = ["pytest>=8"]
-
 [project.urls]
 Homepage = "https://github.com/AMAP-ML/LongHorizon-Harness"
 Issues = "https://github.com/AMAP-ML/LongHorizon-Harness/issues"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,9 @@ test = [
     "httpx2",
 ]
 
+[project.optional-dependencies]
+dev = ["pytest>=8"]
+
 [project.urls]
 Homepage = "https://github.com/AMAP-ML/LongHorizon-Harness"
 Issues = "https://github.com/AMAP-ML/LongHorizon-Harness/issues"
@@ -58,4 +61,6 @@ artifacts = [
 ]
 
 [tool.pytest.ini_options]
+# The package is not installed in a plain checkout, so tests import it from src.
+pythonpath = ["src"]
 testpaths = ["tests"]

--- a/src/lh_harness/adapters/claude_code.py
+++ b/src/lh_harness/adapters/claude_code.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import os
-import shlex
 from pathlib import Path
 
 from ..agent_logs import visible_output as extract_claude_visible_output
@@ -39,22 +38,21 @@ class ClaudeCodeAdapter(CommandAgentAdapter):
         hidden_paths: tuple[str, ...] = (),
     ) -> None:
         policy = policy_for_role(role)
-        env_parts: list[str] = []
+        env_overrides: dict[str, str] = {}
         if api_key:
-            quoted_key = shlex.quote(api_key)
-            env_parts.append(f"ANTHROPIC_API_KEY={quoted_key}")
-            env_parts.append(f"ANTHROPIC_AUTH_TOKEN={quoted_key}")
+            env_overrides["ANTHROPIC_API_KEY"] = api_key
+            env_overrides["ANTHROPIC_AUTH_TOKEN"] = api_key
         if base_url:
             raw_url = base_url.rstrip("/")
             if raw_url.endswith("/v1"):
                 raw_url = raw_url[:-3]
-            env_parts.append(f"ANTHROPIC_BASE_URL={shlex.quote(raw_url)}")
-        env_parts.extend(
-            [
-                "CLAUDE_CODE_DISABLE_AUTO_MEMORY=1",
-                "CLAUDE_CODE_SKIP_PROMPT_HISTORY=1",
-                f"LH_HARNESS_CLAUDE_ROLE={shlex.quote(role)}",
-            ]
+            env_overrides["ANTHROPIC_BASE_URL"] = raw_url
+        env_overrides.update(
+            {
+                "CLAUDE_CODE_DISABLE_AUTO_MEMORY": "1",
+                "CLAUDE_CODE_SKIP_PROMPT_HISTORY": "1",
+                "LH_HARNESS_CLAUDE_ROLE": role,
+            }
         )
 
         # MCP support remains opt-in. --strict-mcp-config keeps unrelated
@@ -77,16 +75,15 @@ class ClaudeCodeAdapter(CommandAgentAdapter):
             )
 
         if is_auditor_role(role):
-            env_parts.extend(
-                [
-                    "GIT_OPTIONAL_LOCKS=0",
-                    "GIT_PAGER=cat",
-                    "PAGER=cat",
-                ]
+            env_overrides.update(
+                {
+                    "GIT_OPTIONAL_LOCKS": "0",
+                    "GIT_PAGER": "cat",
+                    "PAGER": "cat",
+                }
             )
 
-        env_prefix = (" ".join(env_parts) + " ") if env_parts else ""
-        command_parts = [
+        argv = [
             "claude",
             "--print",
             "--output-format",
@@ -96,17 +93,18 @@ class ClaudeCodeAdapter(CommandAgentAdapter):
         ]
         deny_tools = [*policy.disallowed_tools, *path_deny_rules(hidden_paths)]
         if deny_tools:
-            command_parts.append("--disallowedTools")
-            command_parts.extend(shlex.quote(tool) for tool in deny_tools)
+            argv.append("--disallowedTools")
+            argv.extend(deny_tools)
         self.computer_mcp_configured = bool(policy.load_computer_mcp and mcp_config)
         if self.computer_mcp_configured:
-            command_parts.extend(["--mcp-config", shlex.quote(mcp_config)])
-        command_parts.extend(["--model", shlex.quote(model)])
+            argv.extend(["--mcp-config", mcp_config])
+        argv.extend(["--model", model])
 
         self.role = role
         self.policy = policy
         super().__init__(
-            command_template=f"{env_prefix}{' '.join(command_parts)} < {{prompt_path}}",
+            argv=argv,
+            env=env_overrides,
             prompt_dir=prompt_dir,
             workspace_path=workspace_path,
             visible_output_parser=extract_claude_visible_output,

--- a/src/lh_harness/adapters/claude_permissions.py
+++ b/src/lh_harness/adapters/claude_permissions.py
@@ -82,18 +82,32 @@ def path_deny_rules(paths: tuple[str, ...] | list[str]) -> tuple[str, ...]:
     Deny rules still apply under `--dangerously-skip-permissions`, and a `Read`
     deny also blocks the Edit tool. `//` anchors the pattern at the filesystem
     root; anything else would resolve against the settings source.
+
+    On Windows an absolute path already starts with a drive letter, so the bare
+    `C:/...` form is emitted alongside the `//` one. Both are listed because a
+    deny rule that fails to match would silently expose the run's own logs and
+    prompts to the auditor, and an extra unmatched rule costs nothing.
     """
     rules: list[str] = []
     for raw in paths:
-        resolved = Path(raw).expanduser().resolve().as_posix().lstrip("/")
-        if not resolved:
+        posix = Path(raw).expanduser().resolve().as_posix()
+        stripped = posix.lstrip("/")
+        if not stripped:
             continue
+        roots = [f"//{stripped}"]
+        if _has_drive_letter(posix):
+            roots.append(posix)
         for tool in ("Read", "Edit"):
-            for pattern in (f"//{resolved}", f"//{resolved}/**"):
-                rule = f"{tool}({pattern})"
-                if rule not in rules:
-                    rules.append(rule)
+            for root in roots:
+                for pattern in (root, f"{root}/**"):
+                    rule = f"{tool}({pattern})"
+                    if rule not in rules:
+                        rules.append(rule)
     return tuple(rules)
+
+
+def _has_drive_letter(posix_path: str) -> bool:
+    return len(posix_path) >= 2 and posix_path[1] == ":" and posix_path[0].isalpha()
 
 
 @dataclass(frozen=True)

--- a/src/lh_harness/adapters/cli_agent.py
+++ b/src/lh_harness/adapters/cli_agent.py
@@ -1,15 +1,13 @@
 from __future__ import annotations
 
-import posixpath
 import re
-import shlex
+import shutil
 import time
 import uuid
-from collections.abc import Callable
-from pathlib import PurePath
+from collections.abc import Mapping, Sequence
+from pathlib import Path, PurePath
 
 from ..environment.base import Environment
-from ..environment.remote_files import write_remote_text
 from ..runtime_signals import detect_runtime_signals
 from ..types import DEFAULT_TMP_DIR, DEFAULT_WORKSPACE_PATH, EpisodeBudget, EpisodeResult
 
@@ -29,20 +27,42 @@ def redact_secrets(text: str) -> str:
 
 
 class CommandAgentAdapter:
+    """Drives an agent CLI as a plain subprocess.
+
+    There is deliberately no shell involved. The workspace is passed as the
+    child's working directory, credentials as environment overrides, and the
+    prompt down the child's stdin -- so nothing has to be quoted for sh or
+    cmd.exe, the harness behaves identically on every platform, and no
+    model-supplied value can reach a shell parser.
+    """
+
     def __init__(
         self,
         *,
-        command_template: str,
+        argv: Sequence[str],
+        env: Mapping[str, str] | None = None,
         prompt_dir: str = f"{DEFAULT_TMP_DIR}/prompts",
         workspace_path: str = DEFAULT_WORKSPACE_PATH,
-        visible_output_parser: Callable[[str], str] | None = None,
+        visible_output_parser=None,
         hidden_paths: tuple[str, ...] = (),
     ) -> None:
-        self.command_template = command_template
-        self.prompt_dir = prompt_dir.rstrip("/") or "."
-        self.workspace_path = workspace_path.rstrip("/")
+        self.argv = list(argv)
+        self.env = dict(env or {})
+        self.prompt_dir = prompt_dir
+        self.workspace_path = str(workspace_path).rstrip("/\\") or workspace_path
         self.visible_output_parser = visible_output_parser
         self.hidden_paths = tuple(hidden_paths)
+
+    def resolved_argv(self) -> list[str]:
+        """Argv with the CLI resolved to a real path.
+
+        `shutil.which` also picks up the `.CMD`/`.EXE` shims the agent CLIs
+        install on Windows, which a bare name would only find via PATHEXT.
+        """
+        if not self.argv:
+            return []
+        resolved = shutil.which(self.argv[0])
+        return [resolved or self.argv[0], *self.argv[1:]]
 
     async def run_episode(
         self,
@@ -52,30 +72,26 @@ class CommandAgentAdapter:
         live_trajectory_path: str | None = None,
     ) -> EpisodeResult:
         start = time.monotonic()
-        # Never reuse one global prompt.md. A run owns its prompt directory and
-        # every role episode gets a distinct filename, so concurrent harnesses
-        # (and future concurrent roles within one harness) cannot overwrite the
-        # input while an agent CLI is still reading it.
-        prompt_path = posixpath.join(
-            self.prompt_dir,
-            f"{_episode_prompt_label(live_trajectory_path)}_{uuid.uuid4().hex[:12]}.md",
+        prompt_text = prompt + _hidden_paths_notice(self.hidden_paths)
+        # The prompt reaches the CLI over stdin, so this copy exists purely as an
+        # audit artifact. A run owns its prompt directory and every role episode
+        # gets a distinct filename, so concurrent harnesses cannot overwrite it.
+        prompt_path = str(
+            Path(self.prompt_dir)
+            / f"{_episode_prompt_label(live_trajectory_path)}_{uuid.uuid4().hex[:12]}.md"
         )
-        await write_remote_text(env, prompt_path, prompt + _hidden_paths_notice(self.hidden_paths))
-        # Substituted by explicit replace, not str.format: templates embed literal
-        # braces (e.g. Codex passes inline-TOML `-c` overrides) that format() would
-        # try to interpret as placeholders.
-        command_body = self.command_template
-        for placeholder, value in (
-            ("{prompt_path}", shlex.quote(prompt_path)),
-            ("{timeout}", str(budget.max_duration_seconds)),
-        ):
-            command_body = command_body.replace(placeholder, value)
-        command = f"cd {shlex.quote(self.workspace_path)} && {command_body}"
-        # When a live path is given (local runs), the environment mirrors stdout
-        # to that file line-by-line so the dashboard shows the trajectory live.
-        result = await env.exec(
-            command,
+        await env.write_text(prompt_path, prompt_text)
+
+        argv = self.resolved_argv()
+        result = await env.run(
+            argv,
             timeout=budget.max_duration_seconds,
+            cwd=self.workspace_path,
+            env=self.env,
+            stdin=prompt_text,
+            # When a live path is given (local runs), the environment mirrors
+            # stdout to that file line-by-line so the dashboard shows the
+            # trajectory live.
             tee_path=live_trajectory_path,
         )
         duration_ms = int((time.monotonic() - start) * 1000)
@@ -101,8 +117,11 @@ class CommandAgentAdapter:
             error=error,
             duration_ms=duration_ms,
             metadata={
-                "command": redact_secrets(command),
+                # A list, which downstream readers already accept: it keeps the
+                # exact arguments inspectable instead of a re-quoted string.
+                "command": [redact_secrets(part) for part in argv],
                 "workspace": self.workspace_path,
+                "env_overrides": sorted(self.env),
                 "prompt_path": prompt_path,
                 "exit_code": result.exit_code,
                 "termination_reason": result.termination_reason,

--- a/src/lh_harness/adapters/codex.py
+++ b/src/lh_harness/adapters/codex.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import importlib
 import json
 import os
-import shlex
 
 from ..types import DEFAULT_CODEX_MODEL, DEFAULT_TMP_DIR, DEFAULT_WORKSPACE_PATH
 from ..agent_logs import visible_output as extract_codex_visible_output
@@ -35,18 +34,17 @@ class CodexAdapter(CommandAgentAdapter):
         sandbox_mode: str | None = None,
         hidden_paths: tuple[str, ...] = (),
     ) -> None:
-        env_parts: list[str] = []
+        env_overrides: dict[str, str] = {}
         if api_key:
-            quoted_key = shlex.quote(api_key)
-            env_parts.append(f"OPENAI_API_KEY={quoted_key}")
-            env_parts.append(f"CODEX_API_KEY={quoted_key}")
+            env_overrides["OPENAI_API_KEY"] = api_key
+            env_overrides["CODEX_API_KEY"] = api_key
 
         # Resolve once when an adapter is built.  A LongHorizon run must use
         # the same authenticated Codex installation as the desktop client when
         # both the standalone PATH CLI and ChatGPT.app are present.
         codex_binary = resolve_codex_binary() or "codex"
-        command_parts = [
-            shlex.quote(codex_binary),
+        argv = [
+            codex_binary,
             "exec",
             "--json",
             "--skip-git-repo-check",
@@ -56,12 +54,12 @@ class CodexAdapter(CommandAgentAdapter):
         # isolated environment, so bypass Codex's own sandbox unless the caller
         # picked an explicit policy.
         if sandbox_mode:
-            command_parts.extend(["--sandbox", shlex.quote(sandbox_mode)])
+            argv.extend(["--sandbox", sandbox_mode])
         else:
-            command_parts.append("--dangerously-bypass-approvals-and-sandbox")
+            argv.append("--dangerously-bypass-approvals-and-sandbox")
 
         for override in _config_overrides(base_url=base_url, api_key=api_key):
-            command_parts.extend(["-c", shlex.quote(override)])
+            argv.extend(["-c", override])
 
         # MCP support is opt-in and uses Codex's own format: a TOML file holding
         # `[mcp_servers.*]` tables, replayed as `-c mcp_servers.<name>=...`
@@ -69,24 +67,25 @@ class CodexAdapter(CommandAgentAdapter):
         mcp_config = mcp_config or os.getenv("LH_HARNESS_CODEX_MCP_CONFIG")
         if mcp_config:
             for override in mcp_server_overrides(mcp_config):
-                command_parts.extend(["-c", shlex.quote(override)])
+                argv.extend(["-c", override])
 
         resolved_add_dirs = list(add_dirs or [])
         env_add_dirs = os.getenv("LH_HARNESS_CODEX_ADD_DIRS") or os.getenv("LH_HARNESS_MCP_ADD_DIRS")
         if env_add_dirs:
             resolved_add_dirs.extend(part for part in env_add_dirs.split(os.pathsep) if part)
         for add_dir in resolved_add_dirs:
-            command_parts.extend(["--add-dir", shlex.quote(add_dir)])
+            argv.extend(["--add-dir", add_dir])
 
         if model:
-            command_parts.extend(["--model", shlex.quote(model)])
-        # `-` makes Codex read the prompt from stdin, keeping long prompts off
-        # the command line and out of the process table.
-        command_parts.append("-")
+            argv.extend(["--model", model])
+        # `-` makes Codex read the prompt from stdin, which is where the harness
+        # sends it: long prompts stay off the command line and out of the
+        # process table.
+        argv.append("-")
 
-        env_prefix = (" ".join(env_parts) + " ") if env_parts else ""
         super().__init__(
-            command_template=f"{env_prefix}{' '.join(command_parts)} < {{prompt_path}}",
+            argv=argv,
+            env=env_overrides,
             prompt_dir=prompt_dir,
             workspace_path=workspace_path,
             visible_output_parser=extract_codex_visible_output,

--- a/src/lh_harness/cli.py
+++ b/src/lh_harness/cli.py
@@ -412,7 +412,24 @@ def _fallback_hint(role: str, suffix: str) -> str:
     return ", then ".join([_flag(parent, suffix) for parent in parents] + [f"--{suffix}"])
 
 
+def _use_utf8_console() -> None:
+    """Stop a legacy console codec from mangling harness output.
+
+    Windows still defaults stdout to cp1252, which turns the routing summary's
+    separators into `?` and makes Chinese prompt output unprintable.
+    """
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is None:
+            continue
+        try:
+            reconfigure(encoding="utf-8", errors="replace")
+        except (OSError, ValueError):
+            pass
+
+
 def main(argv: list[str] | None = None) -> int:
+    _use_utf8_console()
     raw_argv = list(sys.argv[1:] if argv is None else argv)
     run_defaults: dict[str, object] = {}
     config_error: ProjectConfigError | None = None

--- a/src/lh_harness/cli.py
+++ b/src/lh_harness/cli.py
@@ -26,10 +26,16 @@ from .config import (
 from .types import (
     DEFAULT_CLAUDE_MODEL,
     DEFAULT_CODEX_MODEL,
+    DEFAULT_ESCALATE_AFTER_FAILURES,
+    DEFAULT_ESCALATE_AFTER_STALLED_ROUNDS,
+    DEFAULT_ESCALATION_TIER,
+    DEFAULT_EXECUTOR_TIER,
     DEFAULT_MAX_ROUNDS,
     DEFAULT_WORKSPACE_PATH,
+    EXECUTOR_TIERS,
     MAX_ROUNDS,
     EpisodeBudget,
+    ExecutorRouting,
     HarnessConfig,
 )
 from .utils.agent_cli import probe_agent_cli
@@ -64,21 +70,38 @@ _MCP_CONFIG_DESTS = {"claude_code": "claude_mcp_config", "codex": "codex_mcp_con
 _CODEX_GUI_PLUGIN = "codex-computer-use"
 _PLUGIN_CHOICES = (_CODEX_GUI_PLUGIN, "open-computer-use", "clawdcursor")
 
-# Role options as (dest prefix, broader option it falls back to, help scope).
-# Each entry gets a matching `--<role>-agent` and `--<role>-model` flag;
-# resolution walks the fallback chain and ends at the global --agent / --model.
+# Role options as (dest prefix, ordered fallbacks, help scope). Each entry gets a
+# matching `--<role>-agent` and `--<role>-model` flag; resolution walks the
+# fallback chain in order and ends at the global --agent / --model.
+#
+# Executor tier roles fall back on two axes. Tier comes first: naming a tier is a
+# deliberate cost decision, so `[run.roles.executor.cheap]` outranks the older
+# type-level `[run.roles.gui_executor]`.
 _ROLE_OPTIONS = (
-    ("manager", None, "the scheduler role"),
-    ("executor", None, "both executor roles"),
-    ("gui_executor", "executor", "GUI/visual subtasks"),
-    ("cli_executor", "executor", "CLI/non-GUI subtasks"),
-    ("auditor", None, "both auditor roles"),
-    ("gui_auditor", "auditor", "GUI audit"),
-    ("cli_auditor", "auditor", "CLI audit"),
-    ("final_response", "manager", "the closing reply written for you"),
+    ("manager", (), "the scheduler role"),
+    ("executor", (), "every executor role and tier"),
+    ("executor_cheap", ("executor",), "the cheap tier of both executor roles"),
+    ("executor_strong", ("executor",), "the strong tier of both executor roles"),
+    ("gui_executor", ("executor",), "GUI/visual subtasks"),
+    ("gui_executor_cheap", ("executor_cheap", "gui_executor"), "cheap-tier GUI subtasks"),
+    ("gui_executor_strong", ("executor_strong", "gui_executor"), "strong-tier GUI subtasks"),
+    ("cli_executor", ("executor",), "CLI/non-GUI subtasks"),
+    ("cli_executor_cheap", ("executor_cheap", "cli_executor"), "cheap-tier CLI subtasks"),
+    ("cli_executor_strong", ("executor_strong", "cli_executor"), "strong-tier CLI subtasks"),
+    ("auditor", (), "both auditor roles"),
+    ("gui_auditor", ("auditor",), "GUI audit"),
+    ("cli_auditor", ("auditor",), "CLI audit"),
+    ("final_response", ("manager",), "the closing reply written for you"),
 )
-_ROLE_PARENTS = {role: parent for role, parent, _ in _ROLE_OPTIONS}
+_ROLE_PARENTS = {role: parents for role, parents, _ in _ROLE_OPTIONS}
 _ROLE_SCOPES = {role: scope for role, _, scope in _ROLE_OPTIONS}
+# The executor role each (type, tier) cell resolves through.
+_EXECUTOR_TIER_ROLES = {
+    ("gui", "cheap"): "gui_executor_cheap",
+    ("gui", "strong"): "gui_executor_strong",
+    ("cli", "cheap"): "cli_executor_cheap",
+    ("cli", "strong"): "cli_executor_strong",
+}
 
 # Per-role episode budgets as (dest prefix, timeout seconds). The
 # executors get the long task timeout; the scheduler and auditors get the short one.
@@ -120,6 +143,13 @@ def _max_rounds(value: str) -> int:
     parsed = _positive_int(value)
     if parsed > MAX_ROUNDS:
         raise argparse.ArgumentTypeError(f"must be at most {MAX_ROUNDS}")
+    return parsed
+
+
+def _non_negative_int(value: str) -> int:
+    parsed = int(value)
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("must be 0 or more")
     return parsed
 
 
@@ -359,12 +389,27 @@ def _claim_supervised_owner(run_id: str, run_dir: Path) -> None:
         "pgid": os.getpid(),
         "signal_mode": "pgid",
     })
+def _fallback_chain(role: str) -> list[str]:
+    """Roles to consult, in order, starting with `role` itself.
+
+    Breadth-ordered so a role's own fallbacks are all tried before their
+    fallbacks: `gui_executor_cheap` prefers `executor_cheap`, then
+    `gui_executor`, then `executor`.
+    """
+    chain: list[str] = []
+    queue = [role]
+    while queue:
+        current = queue.pop(0)
+        if current in chain:
+            continue
+        chain.append(current)
+        queue.extend(_ROLE_PARENTS[current])
+    return chain
 
 
 def _fallback_hint(role: str, suffix: str) -> str:
-    parent = _ROLE_PARENTS[role]
-    chain = ([_flag(parent, suffix)] if parent else []) + [f"--{suffix}"]
-    return ", then ".join(chain)
+    parents = _fallback_chain(role)[1:]
+    return ", then ".join([_flag(parent, suffix) for parent in parents] + [f"--{suffix}"])
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -424,6 +469,38 @@ def main(argv: list[str] | None = None) -> int:
             default=run_default(f"{role}_model"),
             help=f"Model for {scope}; defaults to {_fallback_hint(role, 'model')}.",
         )
+    run_parser.add_argument(
+        "--executor-default-tier",
+        default=run_default("executor_default_tier", DEFAULT_EXECUTOR_TIER),
+        choices=EXECUTOR_TIERS,
+        help="Executor tier for subtasks where the manager names none.",
+    )
+    run_parser.add_argument(
+        "--executor-escalate-after-failures",
+        type=_non_negative_int,
+        default=run_default("executor_escalate_after_failures", DEFAULT_ESCALATE_AFTER_FAILURES),
+        help="Consecutive failed audits before the harness switches to the escalation tier. 0 disables escalation.",
+    )
+    run_parser.add_argument(
+        "--executor-escalate-after-stalled-rounds",
+        type=_non_negative_int,
+        default=run_default(
+            "executor_escalate_after_stalled_rounds", DEFAULT_ESCALATE_AFTER_STALLED_ROUNDS
+        ),
+        help="Consecutive clean-but-incomplete rounds reporting the same gap before escalating. 0 disables this signal.",
+    )
+    run_parser.add_argument(
+        "--executor-escalation-tier",
+        default=run_default("executor_escalation_tier", DEFAULT_ESCALATION_TIER),
+        choices=EXECUTOR_TIERS,
+        help="Executor tier used once the failure threshold is reached.",
+    )
+    run_parser.add_argument(
+        "--executor-escalation-briefing",
+        action=argparse.BooleanOptionalAction,
+        default=run_default("executor_escalation_briefing", True),
+        help="Tell an escalated executor what the previous tier tried and why it was rejected.",
+    )
     # Only the local backend is implemented; kept as a flag so existing
     # `--env local` invocations keep working and future backends can slot in.
     run_parser.add_argument(
@@ -1491,6 +1568,13 @@ def _run_command(args: argparse.Namespace) -> int:
         gui_executor_budget=EpisodeBudget(max_duration_seconds=args.gui_executor_timeout),
         cli_executor_budget=EpisodeBudget(max_duration_seconds=args.cli_executor_timeout),
         auditor_budget=EpisodeBudget(max_duration_seconds=args.auditor_timeout),
+        executor_routing=ExecutorRouting(
+            default_tier=args.executor_default_tier,
+            escalate_after_failures=args.executor_escalate_after_failures,
+            escalate_after_stalled_rounds=args.executor_escalate_after_stalled_rounds,
+            escalation_tier=args.executor_escalation_tier,
+            escalation_briefing=args.executor_escalation_briefing,
+        ),
         workspace_path=workspace,
         harness_dir=harness_dir,
         log_dir=log_dir,
@@ -1632,11 +1716,28 @@ def _run_command(args: argparse.Namespace) -> int:
             )
         return agent_cache[key]
 
+    # Executor tiers reuse the executor permission role, so a tier only changes
+    # which backend/model runs, never what the executor is allowed to do. The
+    # adapter cache is keyed on the resolved agent+model, so tiers that resolve
+    # to the same backend share one adapter instead of spawning another.
     try:
+        executor_agents = {
+            executor_type: {
+                tier: build_role_agent(
+                    _EXECUTOR_TIER_ROLES[(executor_type, tier)],
+                    permission_role=f"{executor_type}_executor",
+                )
+                for tier in EXECUTOR_TIERS
+            }
+            for executor_type in ("gui", "cli")
+        }
         role_agents = {
             "manager_agent": build_role_agent("manager"),
-            "gui_executor_agent": build_role_agent("gui_executor"),
-            "cli_executor_agent": build_role_agent("cli_executor"),
+            # The per-type adapters are the loop's fallback for any tier cell it
+            # is not given; the default tier is what it would have picked anyway.
+            "gui_executor_agent": executor_agents["gui"][config.executor_routing.default_tier],
+            "cli_executor_agent": executor_agents["cli"][config.executor_routing.default_tier],
+            "executor_agents": executor_agents,
             "gui_auditor_agent": build_role_agent("gui_auditor"),
             "cli_auditor_agent": build_role_agent("cli_auditor"),
             # Format repair sees only the previous auditor text and has no tools.
@@ -1661,6 +1762,7 @@ def _run_command(args: argparse.Namespace) -> int:
         if dashboard_handle is not None:
             dashboard_handle.shutdown()
         return 1
+    _print_executor_routing(args, config.executor_routing)
 
     from .manager import run
 
@@ -1722,6 +1824,33 @@ def _run_command(args: argparse.Namespace) -> int:
     return 0 if final_report.get("completion_satisfied") else 1
 
 
+def _print_executor_routing(args: argparse.Namespace, routing: ExecutorRouting) -> None:
+    """Show the resolved policy and which backend each (type, tier) cell landed on.
+
+    The manager loop only ever sees adapters, so this is the one place the run
+    reports which agent and model a tier actually resolved to.
+    """
+    triggers = []
+    if routing.escalate_after_failures:
+        triggers.append(f"{routing.escalate_after_failures} audit failure(s)")
+    if routing.escalate_after_stalled_rounds:
+        triggers.append(f"{routing.escalate_after_stalled_rounds} stalled round(s)")
+    escalation = (
+        f"escalate after {' or '.join(triggers)} -> {routing.escalation_tier}"
+        if triggers
+        else "escalation disabled"
+    )
+    print(f"Executor routing: default={routing.default_tier} · {escalation}")
+    for (executor_type, tier), role in sorted(_EXECUTOR_TIER_ROLES.items()):
+        agent = _resolve_role_option(args, role, "agent")
+        model = _resolve_role_option(args, role, "model") or _default_model_for(agent)
+        print(f"  {executor_type}/{tier:<6} {agent} / {model}")
+
+
+def _default_model_for(agent: str) -> str:
+    return next((model for name, _, model in _AGENTS if name == agent), "(agent default)")
+
+
 def _outermost_paths(*paths: str | Path) -> tuple[str, ...]:
     """Resolve paths and drop any that sit inside another, keeping the parents."""
     resolved = sorted({Path(item).expanduser().resolve() for item in paths}, key=lambda p: len(p.parts))
@@ -1754,11 +1883,19 @@ def _print_progress(event: str, payload: dict) -> None:
         if payload.get("role") == "final_response":
             print("\n── Writing reply ──", flush=True)
         print(f"  [{payload.get('role')}] running...", flush=True)
+    elif event == "executor_escalation":
+        print(
+            f"  Executor escalation: {payload.get('from_tier')} -> {payload.get('to_tier')} "
+            f"({payload.get('reason')}, threshold {payload.get('threshold')})",
+            flush=True,
+        )
     elif event == "role_done":
         parts = [str(payload.get("status"))]
         duration_ms = payload.get("duration_ms")
         if isinstance(duration_ms, int):
             parts.append(f"{duration_ms / 1000:.1f}s")
+        if payload.get("executor_tier"):
+            parts.append(f"tier={payload['executor_tier']}")
         if payload.get("next_step"):
             parts.append(f"next={payload['next_step']}")
         if payload.get("audit_status"):
@@ -1801,11 +1938,10 @@ def _indent(text: str, prefix: str = "  ") -> str:
 
 def _resolve_role_option(args: argparse.Namespace, role: str, suffix: str):
     """Walk a role's fallback chain up to the global `--agent` / `--model`."""
-    while role:
-        value = getattr(args, f"{role}_{suffix}", None)
+    for candidate in _fallback_chain(role):
+        value = getattr(args, f"{candidate}_{suffix}", None)
         if value:
             return value
-        role = _ROLE_PARENTS[role]
     return getattr(args, suffix)
 
 

--- a/src/lh_harness/config.py
+++ b/src/lh_harness/config.py
@@ -4,7 +4,7 @@ import importlib
 from pathlib import Path
 from typing import Any
 
-from .types import MAX_ROUNDS
+from .types import EXECUTOR_TIERS, MAX_ROUNDS
 
 try:
     tomllib = importlib.import_module("tomllib")
@@ -24,7 +24,17 @@ _ROLE_NAMES = {
     "cli_auditor",
     "final_response",
 }
+# Executor roles may additionally carry per-tier sub-tables, so
+# `[run.roles.executor.cheap]` flattens to the `executor_cheap` role.
+_TIERED_ROLE_NAMES = {"executor", "gui_executor", "cli_executor"}
 _TIMEOUT_NAMES = {"manager", "gui_executor", "cli_executor", "auditor"}
+_EXECUTOR_ROUTING_KEYS = {
+    "default_tier",
+    "escalate_after_failures",
+    "escalate_after_stalled_rounds",
+    "escalation_tier",
+    "escalation_briefing",
+}
 _RUN_KEYS = {
     "agent",
     "model",
@@ -43,6 +53,7 @@ _RUN_KEYS = {
     "dashboard_port",
     "roles",
     "timeouts",
+    "executor_routing",
 }
 _STRING_KEYS = {
     "model",
@@ -90,6 +101,27 @@ gui_executor = 1800
 cli_executor = 1800
 auditor = 300
 
+# Which executor tier runs a subtask. The manager may ask for one; otherwise
+# default_tier applies. After escalate_after_failures consecutive failed audits
+# the harness switches to escalation_tier itself, and drops back to the default
+# once an audit passes. Set escalate_after_failures = 0 to turn that off.
+[run.executor_routing]
+default_tier = "cheap"
+# Audits that report a real problem: blocked, suspect/violated integrity, or a
+# contract needing revision. An audit that is merely `incomplete` with clean
+# integrity is normal mid-run progress and is NOT counted here. 1 escalates on
+# the first such failure; raising it retries on the cheap tier first, which costs
+# less but is slower -- and a same-tier retry is NOT briefed on what just failed
+# (only the escalated executor is), so it may well repeat it.
+escalate_after_failures = 1
+# The other shape of trouble: clean rounds that keep reporting the same
+# outstanding gap without closing it. Escalates after this many in a row.
+escalate_after_stalled_rounds = 3
+escalation_tier = "strong"
+# Tell the escalated executor what the previous tier already tried and why it
+# was rejected. Each episode is a fresh session, so without this it starts blind.
+# escalation_briefing = true
+
 [run.roles.manager]
 # agent = "codex"
 # model = "gpt-5.6-sol"
@@ -98,13 +130,30 @@ auditor = 300
 # agent = "codex"
 # model = "gpt-5.6-sol"
 
+# Per-tier executors. Leave them out to run every tier on the same backend,
+# which is what a configuration without tiers does today.
+[run.roles.executor.cheap]
+# agent = "codex"
+# model = "gpt-5.6-sol"
+
+[run.roles.executor.strong]
+# agent = "claude_code"
+# model = "claude-opus-5"
+
 [run.roles.gui_executor]
 # agent = "codex"
 # model = "gpt-5.6-sol"
 
+# Tier overrides for one executor type only; these win over [run.roles.executor.*].
+# [run.roles.gui_executor.cheap]
+# [run.roles.gui_executor.strong]
+
 [run.roles.cli_executor]
 # agent = "codex"
 # model = "gpt-5.6-sol"
+
+# [run.roles.cli_executor.cheap]
+# [run.roles.cli_executor.strong]
 
 [run.roles.auditor]
 # agent = "codex"
@@ -197,23 +246,71 @@ def _flatten_run_table(run: dict[str, Any]) -> dict[str, Any]:
         raise ProjectConfigError("[run.roles] must be a TOML table")
     unknown_roles = set(roles) - _ROLE_NAMES
     if unknown_roles:
+        # The CLI spells a tier `--executor-cheap-agent`, so the flat role name is
+        # an easy guess. Point at the nested table rather than just rejecting it.
+        flattened = sorted(
+            name
+            for name in unknown_roles
+            if any(name == f"{role}_{tier}" for role in _TIERED_ROLE_NAMES for tier in EXECUTOR_TIERS)
+        )
+        if flattened:
+            suggestions = ", ".join(
+                f"[run.roles.{name.rsplit('_', 1)[0]}.{name.rsplit('_', 1)[1]}]" for name in flattened
+            )
+            raise ProjectConfigError(
+                f"unknown role(s): {_names(unknown_roles)}; write executor tiers as a "
+                f"nested table instead: {suggestions}"
+            )
         raise ProjectConfigError(f"unknown role(s): {_names(unknown_roles)}")
     for role, values in roles.items():
         if not isinstance(values, dict):
             raise ProjectConfigError(f"[run.roles.{role}] must be a TOML table")
-        unknown_role_keys = set(values) - {"agent", "model"}
-        if unknown_role_keys:
+        # A tier sub-table is the only nested form; everything else at this
+        # level is still just agent/model.
+        tiers = {key: value for key, value in values.items() if isinstance(value, dict)}
+        if tiers and role not in _TIERED_ROLE_NAMES:
             raise ProjectConfigError(
-                f"unknown [run.roles.{role}] key(s): {_names(unknown_role_keys)}"
+                f"[run.roles.{role}] does not take executor tiers; "
+                f"tiers apply to: {_names(_TIERED_ROLE_NAMES)}"
             )
-        if "agent" in values:
-            defaults[f"{role}_agent"] = _choice(
-                values["agent"], f"run.roles.{role}.agent", _AGENT_CHOICES
+        unknown_tiers = set(tiers) - set(EXECUTOR_TIERS)
+        if unknown_tiers:
+            raise ProjectConfigError(
+                f"unknown [run.roles.{role}] tier(s): {_names(unknown_tiers)}; "
+                f"expected: {', '.join(EXECUTOR_TIERS)}"
             )
-        if "model" in values:
-            defaults[f"{role}_model"] = _string(
-                values["model"], f"run.roles.{role}.model"
+        for tier, tier_values in tiers.items():
+            _flatten_role_table(defaults, f"{role}_{tier}", f"run.roles.{role}.{tier}", tier_values)
+        _flatten_role_table(
+            defaults,
+            role,
+            f"run.roles.{role}",
+            {key: value for key, value in values.items() if key not in tiers},
+        )
+
+    routing = run.get("executor_routing", {})
+    if not isinstance(routing, dict):
+        raise ProjectConfigError("[run.executor_routing] must be a TOML table")
+    unknown_routing = set(routing) - _EXECUTOR_ROUTING_KEYS
+    if unknown_routing:
+        raise ProjectConfigError(
+            f"unknown [run.executor_routing] key(s): {_names(unknown_routing)}"
+        )
+    for key in ("default_tier", "escalation_tier"):
+        if key in routing:
+            defaults[f"executor_{key}"] = _choice(
+                routing[key], f"run.executor_routing.{key}", set(EXECUTOR_TIERS)
             )
+    for key in ("escalate_after_failures", "escalate_after_stalled_rounds"):
+        if key in routing:
+            # 0 is meaningful here: it turns that escalation signal off.
+            defaults[f"executor_{key}"] = _non_negative_int(
+                routing[key], f"run.executor_routing.{key}"
+            )
+    if "escalation_briefing" in routing:
+        defaults["executor_escalation_briefing"] = _boolean(
+            routing["escalation_briefing"], "run.executor_routing.escalation_briefing"
+        )
 
     timeouts = run.get("timeouts", {})
     if not isinstance(timeouts, dict):
@@ -224,6 +321,24 @@ def _flatten_run_table(run: dict[str, Any]) -> dict[str, Any]:
     for role, value in timeouts.items():
         defaults[f"{role}_timeout"] = _positive_int(value, f"run.timeouts.{role}")
     return defaults
+
+
+def _flatten_role_table(
+    defaults: dict[str, Any],
+    dest_prefix: str,
+    name: str,
+    values: dict[str, Any],
+) -> None:
+    """Flatten one role (or role tier) table into `<prefix>_agent` / `<prefix>_model`."""
+    unknown_role_keys = set(values) - {"agent", "model"}
+    if unknown_role_keys:
+        raise ProjectConfigError(f"unknown [{name}] key(s): {_names(unknown_role_keys)}")
+    if "agent" in values:
+        defaults[f"{dest_prefix}_agent"] = _choice(
+            values["agent"], f"{name}.agent", _AGENT_CHOICES
+        )
+    if "model" in values:
+        defaults[f"{dest_prefix}_model"] = _string(values["model"], f"{name}.model")
 
 
 def _string(value: Any, name: str) -> str:
@@ -244,6 +359,12 @@ def _positive_int(value: Any, name: str) -> int:
         raise ProjectConfigError(f"{name} must be an integer of at least 1")
     if name.endswith("max_rounds") and value > MAX_ROUNDS:
         raise ProjectConfigError(f"{name} must be at most {MAX_ROUNDS}")
+    return value
+
+
+def _non_negative_int(value: Any, name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ProjectConfigError(f"{name} must be an integer of 0 or more")
     return value
 
 

--- a/src/lh_harness/dashboard/state.py
+++ b/src/lh_harness/dashboard/state.py
@@ -431,6 +431,9 @@ class DashboardState:
         return {
             "round_index": index,
             "next_step": _infer_next_step(plan_text),
+            # Written by the loop before the executor starts, so a round still in
+            # progress already shows which tier is running.
+            "executor_tier": _text("executor_tier.txt").strip(),
             "plan_text": plan_text,
             "task_state": _text("task_state.txt"),
             "task_contract": _text("task_contract.txt"),

--- a/src/lh_harness/environment/base.py
+++ b/src/lh_harness/environment/base.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Mapping, Sequence
 from typing import Protocol, runtime_checkable
 
 from ..types import ExecResult
@@ -7,12 +8,40 @@ from ..types import ExecResult
 
 @runtime_checkable
 class Environment(Protocol):
+    """Where a role episode runs.
+
+    ``run`` is the primary entry point and takes an **argv list**, not a shell
+    string: the working directory, environment overrides and the agent's stdin
+    are passed as real subprocess arguments. That keeps command construction
+    free of shell quoting, which is both a portability fix (POSIX shells and
+    cmd.exe disagree on nearly everything) and one less injection surface for
+    model-supplied paths and model ids.
+
+    ``exec`` remains for callers that genuinely want a shell. It is an escape
+    hatch, and the caller owns the syntax for the platform it runs on.
+    """
+
+    async def run(
+        self,
+        argv: Sequence[str],
+        *,
+        timeout: int = 30,
+        cwd: str | None = None,
+        env: Mapping[str, str] | None = None,
+        stdin: str | None = None,
+        tee_path: str | None = None,
+    ) -> ExecResult: ...
+
     async def exec(
         self,
         command: str,
         timeout: int = 30,
         tee_path: str | None = None,
     ) -> ExecResult: ...
+
+    async def makedirs(self, path: str) -> None: ...
+
+    async def write_text(self, path: str, content: str) -> None: ...
 
     async def screenshot(self) -> bytes: ...
 

--- a/src/lh_harness/environment/local.py
+++ b/src/lh_harness/environment/local.py
@@ -3,23 +3,27 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import os
-import shlex
 import shutil
-import signal
 import stat
 import sys
 import time
+from collections.abc import Mapping, Sequence
 from pathlib import Path
 
 from ..types import DEFAULT_TMP_DIR, ExecResult
 from ..supervisor.control_bus import _ensure_dir_fd_nofollow, _open_private_regular_at
 from ..trajectory_artifacts import StreamingTrajectoryArtifactWriter
+from ..utils import paths as long_paths
 from ..utils.process_group import (
+    force_kill_process_group,
     kill_process_group,
-    signal_process_group,
+    new_process_group_kwargs,
+    terminate_process_group,
     track_process_group,
     untrack_process_group,
 )
+
+IS_WINDOWS = sys.platform == "win32"
 
 
 # Agent CLIs can emit very large tool results or base64 screenshots.  Keep the
@@ -43,6 +47,35 @@ def _append_bounded_tail(buffer: bytearray, chunk: bytes, limit: int) -> None:
     buffer.extend(chunk)
 
 
+def _open_trajectory_file_windows(path: Path):
+    """Best-effort no-follow trajectory open for Windows.
+
+    Symlinks and junctions both surface as reparse points, so rejecting those
+    keeps the redirect attack the POSIX path guards against out of reach. What
+    cannot be reproduced is the *anchored* guarantee: without directory
+    descriptors there is an unavoidable check-then-open window.
+    """
+
+    long_paths.makedirs(path.parent)
+    for candidate in (path.parent, path):
+        if candidate.is_symlink():
+            raise OSError(f"refusing to follow a reparse point: {candidate}")
+    target = long_paths.os_path(path)
+    handle = open(target, "ab", buffering=0)
+    try:
+        metadata = os.fstat(handle.fileno())
+        # Windows supports hard links too, so an alias would otherwise be
+        # truncated along with the trajectory. Check before truncating, exactly
+        # as the POSIX branch does.
+        if not stat.S_ISREG(metadata.st_mode) or getattr(metadata, "st_nlink", 1) > 1:
+            raise OSError("trajectory file is not a private regular file")
+        handle.truncate(0)
+    except BaseException:
+        handle.close()
+        raise
+    return handle
+
+
 def _open_trajectory_file(path: Path):
     """Open a live trajectory below an anchored, no-follow parent directory.
 
@@ -51,8 +84,15 @@ def _open_trajectory_file(path: Path):
     swapped ``round_*`` or ``logs`` symlink and redirect screenshots/tool
     traces outside the run. Keep the parent descriptor anchored through the
     open, then retain only the file descriptor used by the tee.
+
+    Windows has neither ``O_NOFOLLOW`` nor directory descriptors, so the
+    anchored variant is impossible there. It gets the closest equivalent the
+    platform allows: refuse any reparse point on the way in, then open the
+    resolved path directly (with long-path support, which run trees need).
     """
 
+    if IS_WINDOWS:
+        return _open_trajectory_file_windows(path)
     parent_fd = _ensure_dir_fd_nofollow(path.parent)
     fd: int | None = None
     try:
@@ -94,11 +134,64 @@ class LocalEnvironment:
         """Where callers may stage files before uploading them into this env."""
         return self._tmp_dir
 
+    async def run(
+        self,
+        argv: Sequence[str],
+        *,
+        timeout: int = 30,
+        cwd: str | None = None,
+        env: Mapping[str, str] | None = None,
+        stdin: str | None = None,
+        tee_path: str | None = None,
+    ) -> ExecResult:
+        """Run an argv list directly, with no shell in between.
+
+        The agent's working directory, environment and prompt all travel as real
+        subprocess arguments, so nothing here has to be quoted for a shell.
+        """
+        return await self._spawn(
+            list(argv),
+            timeout=timeout,
+            cwd=cwd,
+            env=env,
+            stdin=stdin,
+            tee_path=tee_path,
+            shell=False,
+        )
+
     async def exec(
         self,
         command: str,
         timeout: int = 30,
         tee_path: str | None = None,
+    ) -> ExecResult:
+        """Run a shell command string. Escape hatch: the caller owns the syntax.
+
+        Nothing in the harness's own agent path uses this -- it exists for
+        callers that need a pipeline or a builtin. The shell is chosen
+        explicitly rather than inherited from ``COMSPEC``/``/bin/sh`` guesswork.
+        """
+        argv = ["cmd.exe", "/c", command] if IS_WINDOWS else ["/bin/sh", "-c", command]
+        return await self._spawn(
+            argv, timeout=timeout, cwd=None, env=None, stdin=None, tee_path=tee_path, shell=True
+        )
+
+    async def makedirs(self, path: str) -> None:
+        long_paths.makedirs(Path(path).expanduser())
+
+    async def write_text(self, path: str, content: str) -> None:
+        long_paths.write_text(Path(path).expanduser(), content)
+
+    async def _spawn(
+        self,
+        argv: list[str],
+        *,
+        timeout: int,
+        cwd: str | None,
+        env: Mapping[str, str] | None,
+        stdin: str | None,
+        tee_path: str | None,
+        shell: bool,
     ) -> ExecResult:
         start = time.monotonic()
         proc = None
@@ -112,15 +205,21 @@ class LocalEnvironment:
             # worker sanitisation would expose that credential to the agent.
             child_env = os.environ.copy()
             child_env.pop("LH_HARNESS_WEB_TOKEN", None)
-            proc = await asyncio.create_subprocess_shell(
-                command,
+            child_env.update(env or {})
+            proc = await asyncio.create_subprocess_exec(
+                *argv,
+                stdin=asyncio.subprocess.PIPE,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
-                # Own session, so one killpg reaps the agent CLI and everything
-                # it spawned. It also detaches the child from our terminal, so
-                # Ctrl+C never reaches it, so every exit path below must kill it.
-                start_new_session=True,
+                cwd=cwd,
+                # Overrides are layered onto the real environment (minus the
+                # scrubbed token); a partial mapping would wipe PATH and the
+                # agent's own credentials.
                 env=child_env,
+                # Own group, so one sweep reaps the agent CLI and everything it
+                # spawned. It also detaches the child from our terminal, so
+                # Ctrl+C never reaches it, so every exit path below must kill it.
+                **new_process_group_kwargs(),
                 # Claude Code emits one JSON object per line in stream-json mode.
                 # A single line (e.g. a tool_result carrying a base64 screenshot)
                 # can far exceed asyncio's default 64KB StreamReader limit and
@@ -134,6 +233,7 @@ class LocalEnvironment:
             io_task = asyncio.create_task(
                 self._communicate_streaming(
                     proc,
+                    stdin,
                     tee_path,
                     stdout_chunks,
                     stderr_chunks,
@@ -170,16 +270,16 @@ class LocalEnvironment:
 
     @staticmethod
     async def _terminate(proc) -> None:
-        """SIGTERM the agent's whole group, escalating to SIGKILL if it lingers."""
+        """Ask the agent's whole group to stop, escalating if it lingers."""
         if proc is None or proc.returncode is not None:
             return
-        signal_process_group(proc.pid, signal.SIGTERM)
+        terminate_process_group(proc.pid)
         try:
             # Shielded because this often runs while a CancelledError propagates,
             # and an unshielded await would be cancelled before the child exits.
             await asyncio.shield(asyncio.wait_for(proc.wait(), timeout=5))
         except asyncio.TimeoutError:
-            signal_process_group(proc.pid, signal.SIGKILL)
+            force_kill_process_group(proc.pid)
             with contextlib.suppress(asyncio.TimeoutError, asyncio.CancelledError):
                 await asyncio.shield(asyncio.wait_for(proc.wait(), timeout=5))
         except asyncio.CancelledError:
@@ -197,11 +297,12 @@ class LocalEnvironment:
     @staticmethod
     async def _communicate_streaming(
         proc,
+        stdin: str | None,
         tee_path: str | None,
         stdout_chunks: bytearray,
         stderr_chunks: bytearray,
     ) -> None:
-        """Drain both streams while optionally teeing stdout to a live file.
+        """Feed stdin, then drain both streams, optionally teeing stdout live.
 
         stdout is written incrementally (one line at a time) so an external
         reader (the dashboard) sees the agent's stream-json trajectory grow
@@ -209,6 +310,24 @@ class LocalEnvironment:
         when the wait is interrupted by timeout or cancellation.
         """
         path = Path(tee_path) if tee_path else None
+        if path is not None:
+            long_paths.makedirs(path.parent)
+
+        async def _write_stdin() -> None:
+            # The prompt goes straight down the pipe, which is what removes the
+            # `< prompt.md` redirect (and therefore the shell) from the agent
+            # command. Closing stdin is what tells the CLI the prompt is done.
+            if proc.stdin is None:
+                return
+            try:
+                if stdin:
+                    proc.stdin.write(stdin.encode("utf-8"))
+                    await proc.stdin.drain()
+            except (BrokenPipeError, ConnectionResetError, OSError):
+                pass
+            finally:
+                with contextlib.suppress(BrokenPipeError, ConnectionResetError, OSError):
+                    proc.stdin.close()
 
         async def _read_stdout() -> None:
             # Open in binary truncating mode once at episode start. Every later
@@ -265,7 +384,7 @@ class LocalEnvironment:
                     return
                 _append_bounded_tail(stderr_chunks, chunk, _MAX_STDERR_CAPTURE_BYTES)
 
-        await asyncio.gather(_read_stdout(), _read_stderr(), proc.wait())
+        await asyncio.gather(_write_stdin(), _read_stdout(), _read_stderr(), proc.wait())
 
     async def screenshot(self) -> bytes:
         self._tmp_dir.mkdir(parents=True, exist_ok=True)
@@ -274,24 +393,38 @@ class LocalEnvironment:
             path.unlink(missing_ok=True)
         except OSError:
             return b""
-        quoted_path = shlex.quote(str(path))
-        command = (
-            f"screencapture -x {quoted_path} 2>/dev/null"
-            if sys.platform == "darwin"
-            else (
-                f"gnome-screenshot -f {quoted_path} 2>/dev/null || "
-                f"import -window root {quoted_path} 2>/dev/null"
-            )
-        )
-        result = await self.exec(command, timeout=10)
-        if result is not None and result.exit_code != 0:
-            return b""
+        for argv in _screenshot_commands(path):
+            result = await self.run(argv, timeout=15)
+            if result.exit_code == 0 and path.exists() and path.stat().st_size:
+                break
         return path.read_bytes() if path.exists() else b""
 
     async def upload(self, local_path: str, remote_path: str) -> None:
-        Path(remote_path).parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(local_path, remote_path)
+        long_paths.makedirs(Path(remote_path).parent)
+        shutil.copy2(long_paths.os_path(local_path), long_paths.os_path(remote_path))
 
     async def download(self, remote_path: str, local_path: str) -> None:
-        Path(local_path).parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(remote_path, local_path)
+        long_paths.makedirs(Path(local_path).parent)
+        shutil.copy2(long_paths.os_path(remote_path), long_paths.os_path(local_path))
+
+
+def _screenshot_commands(path: Path) -> list[list[str]]:
+    """Whole-screen capture, tried in order until one produces a file."""
+    if IS_WINDOWS:
+        # .NET is always present on Windows, so this needs no extra install.
+        script = (
+            "Add-Type -AssemblyName System.Windows.Forms,System.Drawing; "
+            "$b=[System.Windows.Forms.SystemInformation]::VirtualScreen; "
+            "$bmp=New-Object System.Drawing.Bitmap $b.Width,$b.Height; "
+            "$g=[System.Drawing.Graphics]::FromImage($bmp); "
+            "$g.CopyFromScreen($b.Location,[System.Drawing.Point]::Empty,$b.Size); "
+            f"$bmp.Save('{path}',[System.Drawing.Imaging.ImageFormat]::Png)"
+        )
+        return [["powershell", "-NoProfile", "-NonInteractive", "-Command", script]]
+    if sys.platform == "darwin":
+        return [["screencapture", "-x", str(path)]]
+    return [
+        ["gnome-screenshot", "-f", str(path)],
+        ["import", "-window", "root", str(path)],
+        ["scrot", str(path)],
+    ]

--- a/src/lh_harness/environment/remote_files.py
+++ b/src/lh_harness/environment/remote_files.py
@@ -1,16 +1,47 @@
+"""Write harness bookkeeping into whatever environment a run uses.
+
+An environment that can touch its own filesystem directly (the local one) does
+so through ``makedirs``/``write_text``. Only a genuinely remote environment
+falls back to shelling out, and that fallback is POSIX because the remote side
+is a Linux VM or container.
+"""
+
 from __future__ import annotations
 
 import os
 import posixpath
 import shlex
-import tempfile
 from pathlib import Path
 
 from .base import Environment
-from ..types import DEFAULT_TMP_DIR
 
 
 async def write_remote_text(env: Environment, remote_path: str, content: str, mode: str = "0644") -> None:
+    native = getattr(env, "write_text", None)
+    if callable(native):
+        await native(remote_path, content)
+        return
+    await _shell_write_text(env, remote_path, content, mode)
+
+
+async def ensure_remote_dir(env: Environment, remote_path: str) -> None:
+    native = getattr(env, "makedirs", None)
+    if callable(native):
+        await native(remote_path)
+        return
+    result = await env.exec(f"mkdir -p {shlex.quote(remote_path)}", timeout=30)
+    if result.exit_code != 0:
+        raise RuntimeError(f"failed creating {remote_path}: {result.stderr or result.stdout}")
+
+
+async def _shell_write_text(
+    env: Environment, remote_path: str, content: str, mode: str
+) -> None:
+    """Stage locally, upload, then fix permissions -- the remote-environment path."""
+    import tempfile
+
+    from ..types import DEFAULT_TMP_DIR
+
     parent = posixpath.dirname(remote_path.rstrip("/"))
     if parent:
         await ensure_remote_dir(env, parent)
@@ -36,9 +67,3 @@ async def write_remote_text(env: Environment, remote_path: str, content: str, mo
     result = await env.exec(f"chmod {shlex.quote(mode)} {shlex.quote(remote_path)}", timeout=30)
     if result.exit_code != 0:
         raise RuntimeError(f"failed chmod {remote_path}: {result.stderr or result.stdout}")
-
-
-async def ensure_remote_dir(env: Environment, remote_path: str) -> None:
-    result = await env.exec(f"mkdir -p {shlex.quote(remote_path)}", timeout=30)
-    if result.exit_code != 0:
-        raise RuntimeError(f"failed creating {remote_path}: {result.stderr or result.stdout}")

--- a/src/lh_harness/manager.py
+++ b/src/lh_harness/manager.py
@@ -11,6 +11,7 @@ import stat as stat_module
 import time
 from dataclasses import asdict, dataclass, field
 import traceback
+from difflib import SequenceMatcher
 from pathlib import Path
 from typing import Any, Awaitable, Callable
 
@@ -41,13 +42,19 @@ from .role_prompts import (
     extract_role_manager_question,
     extract_role_task_contract,
     extract_role_task_state,
+    format_executor_escalation_briefing,
     format_related_auditor_reports,
     format_management_history,
+    parse_role_manager_executor_tier,
     parse_role_manager_next_step,
 )
 from .types import (
+    EXECUTOR_TIERS,
+    AuditReport,
     EpisodeBudget,
     EpisodeResult,
+    ExecutorRouting,
+    ExecutorTier,
     HarnessConfig,
     ManagedRound,
     RoleNextStep,
@@ -114,6 +121,174 @@ def _invalid_plan_feedback(language: str) -> str:
     )
 
 
+def _escalation_feedback(
+    language: str, *, from_tier: str, to_tier: str, reason: str, rounds: list[int]
+) -> str:
+    """Tell the manager the harness re-routed execution, and why."""
+    listed = ", ".join(f"round_{index:03d}" for index in rounds) or "-"
+    stalled = reason == "no_progress_threshold_reached"
+    if language == "en":
+        cause = (
+            f"those rounds kept reporting the same outstanding gap without closing it ({listed})"
+            if stalled
+            else f"the audits for those rounds reported real problems ({listed})"
+        )
+        return (
+            f"Executor escalation: {from_tier} -> {to_tier}\n"
+            f"Reason: {reason} — {cause}.\n"
+            "This is a harness routing change, not an audit. The next subtask runs on the stronger "
+            "executor and is still audited normally. Repeated failure may also mean the subtask "
+            "decomposition or the task contract is wrong, not only that the executor was too weak; "
+            "reconsider both, and cite those rounds in `Related audit reports:`."
+        )
+    cause = (
+        f"这些轮次反复报告同一个未闭合的缺口（{listed}）"
+        if stalled
+        else f"这些轮次的审计报告了真实问题（{listed}）"
+    )
+    return (
+        f"executor 档位升级: {from_tier} -> {to_tier}\n"
+        f"原因: {reason} —— {cause}。\n"
+        "这是 harness 的路由调整，不是审计结论。下一个子任务会交给更强的 executor，并且仍然正常接受审计。"
+        "反复失败也可能说明子任务拆解或任务契约有问题，而不只是 executor 能力不足；请同时重新审视这两点，"
+        "并在 `相关审计报告:` 中引用这些 round。"
+    )
+
+
+@dataclass
+class _ExecutorRouter:
+    """Chooses the executor tier for each round and escalates on repeated audit failure.
+
+    The manager may name a tier, but it is guessing at difficulty before the work
+    happens. Failed audits are the harness's own evidence that the guess (or the
+    default) was wrong, so past a threshold the router overrides it. A passing
+    audit clears that state, which keeps the expensive tier scoped to the stretch
+    of the run that is actually struggling.
+
+    Two signals feed it, because "the audit was not a pass" is far too broad in
+    this harness — see `_audit_reports_a_problem`. A round that reports an actual
+    problem counts against `escalate_after_failures`; a clean round that leaves
+    the same gap open counts against `escalate_after_stalled_rounds`.
+    """
+
+    routing: ExecutorRouting
+    consecutive_audit_failures: int = 0
+    # Consecutive rounds that came back clean but did not close the same gap.
+    stalled_rounds: int = 0
+    last_gap: str = ""
+    escalated: bool = False
+    # Tier the failing work actually ran on, for the briefing and the log line.
+    escalated_from: str = ""
+    failed_round_indices: list[int] = field(default_factory=list)
+    tier_counts: dict[str, int] = field(default_factory=dict)
+    # Every escalation this run made. `escalated` is cleared by a passing audit,
+    # so without this the final report of a run that escalated and then
+    # recovered would show no sign that it ever happened.
+    escalations: list[dict[str, Any]] = field(default_factory=list)
+
+    def select(self, requested: ExecutorTier | None) -> tuple[ExecutorTier, str]:
+        """Return this round's ``(tier, why)``; escalation outranks a manager hint."""
+        if self.escalated:
+            return self.routing.escalation_tier, "escalated"
+        if requested in EXECUTOR_TIERS:
+            return requested, "manager"  # type: ignore[return-value]
+        return self.routing.default_tier, "default"
+
+    def count(self, tier: str) -> None:
+        self.tier_counts[tier] = self.tier_counts.get(tier, 0) + 1
+
+    def record_audit(
+        self,
+        report: AuditReport,
+        round_index: int,
+        tier: str,
+        *,
+        executor_failed: bool = False,
+    ) -> dict[str, Any] | None:
+        """Fold this round's audit into both signals; return any escalation it fires.
+
+        A clean, contract-aligned round that is merely ``incomplete`` is progress,
+        not a failure — but only if it moved the gap. Repeating the same gap is
+        the stall signal.
+        """
+        if _audit_is_clean_complete(report):
+            self._reset()
+            return None
+
+        gap = _audit_gap_fingerprint(report)
+        if executor_failed or _audit_reports_a_problem(report):
+            self.consecutive_audit_failures += 1
+            self.failed_round_indices.append(round_index)
+            self.stalled_rounds = 0
+            reason = "audit_failure_threshold_reached"
+            count, threshold = self.consecutive_audit_failures, self.routing.escalate_after_failures
+        elif _same_gap(gap, self.last_gap):
+            self.stalled_rounds += 1
+            self.failed_round_indices.append(round_index)
+            reason = "no_progress_threshold_reached"
+            count, threshold = self.stalled_rounds, self.routing.escalate_after_stalled_rounds
+        else:
+            # Incomplete but advancing: a new gap means the round moved things on.
+            self.stalled_rounds = 1
+            self.consecutive_audit_failures = 0
+            self.failed_round_indices = [round_index]
+            self.last_gap = gap
+            return None
+        self.last_gap = gap
+
+        # Nothing to escalate to when the failing work already ran on the
+        # escalation tier, so the router keeps counting but makes no claim.
+        if (
+            not threshold
+            or self.escalated
+            or count < threshold
+            or tier == self.routing.escalation_tier
+        ):
+            return None
+        self.escalated = True
+        self.escalated_from = tier
+        escalation = {
+            "round": round_index,
+            "from_tier": tier,
+            "to_tier": self.routing.escalation_tier,
+            "reason": reason,
+            "consecutive_audit_failures": self.consecutive_audit_failures,
+            "stalled_rounds": self.stalled_rounds,
+            "threshold": threshold,
+            "failed_rounds": list(self.failed_round_indices),
+        }
+        self.escalations.append(escalation)
+        return escalation
+
+    def _reset(self) -> None:
+        self.consecutive_audit_failures = 0
+        self.stalled_rounds = 0
+        self.failed_round_indices = []
+        self.last_gap = ""
+        self.escalated = False
+        self.escalated_from = ""
+
+
+def _resolve_executor_agents(
+    executor_agents: dict[str, dict[str, AgentAdapter]] | None,
+    *,
+    gui_executor_agent: AgentAdapter,
+    cli_executor_agent: AgentAdapter,
+) -> dict[str, dict[str, AgentAdapter]]:
+    """Fill every (type, tier) cell, defaulting to that type's single adapter.
+
+    A caller that passes only the per-type adapters — which is every caller that
+    predates tiers — gets the same adapter in both tiers, so routing runs but
+    nothing about the run changes.
+    """
+    provided = executor_agents or {}
+    resolved: dict[str, dict[str, AgentAdapter]] = {}
+    for executor_type, fallback in (("gui", gui_executor_agent), ("cli", cli_executor_agent)):
+        by_tier = provided.get(executor_type) or {}
+        resolved[executor_type] = {tier: by_tier.get(tier) or fallback for tier in EXECUTOR_TIERS}
+    return resolved
+
+
 async def run(*args: Any, **kwargs: Any) -> dict[str, Any]:
     """Run the management loop and always leave a durable terminal record.
 
@@ -161,6 +336,7 @@ async def _run_impl(
     manager_agent: AgentAdapter | None = None,
     gui_executor_agent: AgentAdapter | None = None,
     cli_executor_agent: AgentAdapter | None = None,
+    executor_agents: dict[str, dict[str, AgentAdapter]] | None = None,
     gui_auditor_agent: AgentAdapter | None = None,
     cli_auditor_agent: AgentAdapter | None = None,
     auditor_format_repair_agent: AgentAdapter | None = None,
@@ -173,6 +349,14 @@ async def _run_impl(
     The default `agent` can back every role, which is how Codex or Claude Code
     adapters start. Callers with stronger role controls can pass distinct
     adapters for manager, GUI task, CLI task, GUI auditor, and CLI auditor.
+
+    ``executor_agents`` optionally splits each executor type by cost tier, as
+    ``{"gui"|"cli": {"cheap"|"strong": adapter}}``. Any cell left out falls back
+    to that type's single adapter, so callers that pass only
+    ``gui_executor_agent`` / ``cli_executor_agent`` behave exactly as before.
+    Which tier runs is decided by ``config.executor_routing``: the manager may
+    name one, otherwise the default tier applies, and repeated audit failures
+    escalate. The escalated executor is still audited normally.
 
     ``human_hook`` is a single optional human-in-the-loop callback (used by the
     dashboard for approval / instruction injection). It runs at the END of every
@@ -221,6 +405,15 @@ async def _run_impl(
     ):
         raise ValueError("Every role needs an agent, or a default agent must be provided")
 
+    # Executor type (gui/cli) and cost tier (cheap/strong) are independent, so
+    # the executor is looked up per (type, tier) cell rather than per type.
+    executor_by_type_and_tier = _resolve_executor_agents(
+        executor_agents,
+        gui_executor_agent=gui_executor_agent,
+        cli_executor_agent=cli_executor_agent,
+    )
+    router = _ExecutorRouter(routing=config.executor_routing)
+
     # Every role reads one explicit budget. Keeping the resolved budgets in the
     # config avoids the previous episode/auditor alias chain, where duplicate
     # fields made it unclear which timeout values actually won.
@@ -251,6 +444,7 @@ async def _run_impl(
             "workspace_path": config.workspace_path,
             "harness_dir": config.harness_dir,
             "max_rounds": config.max_total_episodes,
+            "executor_routing": asdict(config.executor_routing),
             "manager_budget": _budget_to_dict(manager_budget),
             "gui_executor_budget": _budget_to_dict(gui_executor_budget),
             "cli_executor_budget": _budget_to_dict(cli_executor_budget),
@@ -543,10 +737,15 @@ async def _run_impl(
                 break
             continue
 
+        # The tier is chosen before the executor runs; the failure count that can
+        # escalate it is updated after this round's audit, so a first failure
+        # never re-routes the round it happened in.
+        executor_tier, tier_source = router.select(parse_role_manager_executor_tier(plan_text))
+        router.count(executor_tier)
         executor_agent, executor_budget = _executor_binding(
             next_step=next_step,
-            gui_executor_agent=gui_executor_agent,
-            cli_executor_agent=cli_executor_agent,
+            executor_tier=executor_tier,
+            executor_agents=executor_by_type_and_tier,
             gui_executor_budget=gui_executor_budget,
             cli_executor_budget=cli_executor_budget,
         )
@@ -557,6 +756,21 @@ async def _run_impl(
             max_chars=config.role_verified_context_chars,
             language=config.prompt_language,
         )
+        # An escalated executor is a brand-new session, possibly on another
+        # backend, and no earlier executor output otherwise reaches it. Without
+        # this it would re-run the approaches the cheap tier already failed with.
+        escalation_briefing = ""
+        if tier_source == "escalated" and config.executor_routing.escalation_briefing:
+            escalation_briefing = format_executor_escalation_briefing(
+                rounds,
+                router.failed_round_indices,
+                from_tier=router.escalated_from or config.executor_routing.default_tier,
+                to_tier=executor_tier,
+                max_chars=config.escalation_briefing_chars,
+                language=config.prompt_language,
+            )
+            if escalation_briefing:
+                _write_local(round_dir / "executor_escalation_briefing.txt", escalation_briefing)
 
         # Task prompts receive the manager-maintained state plus only the
         # auditor reports explicitly referenced by the current subtask contract.
@@ -568,16 +782,31 @@ async def _run_impl(
             task_contract=current_task_contract,
             related_auditor_reports=related_auditor_reports,
             workspace_path=config.workspace_path,
+            escalation_briefing=escalation_briefing,
             language=config.prompt_language,
         )
         _write_local(round_dir / "executor_prompt.txt", executor_prompt)
+        _write_local(round_dir / "executor_tier.txt", executor_tier)
         await _write_remote_round_text(env, config, round_index, "executor_prompt.txt", executor_prompt)
         _append_event(
             events_path,
             "executor_role_start",
-            {"round": round_index, "role": next_step, "prompt_chars": len(executor_prompt), "budget": _budget_to_dict(executor_budget)},
+            {
+                "round": round_index,
+                "role": next_step,
+                "executor_tier": executor_tier,
+                "tier_source": tier_source,
+                "escalation_briefing_chars": len(escalation_briefing),
+                "prompt_chars": len(executor_prompt),
+                "budget": _budget_to_dict(executor_budget),
+            },
         )
-        emit("role_start", round=round_index, role=f"{next_step}_executor")
+        emit(
+            "role_start",
+            round=round_index,
+            role=f"{next_step}_executor",
+            executor_tier=executor_tier,
+        )
 
         executor_result = await _run_role_episode(
             executor_agent,
@@ -608,6 +837,7 @@ async def _run_impl(
                 round_index=round_index,
                 next_step=next_step,
                 plan_text=plan_text,
+                executor_tier=executor_tier,
                 executor_output=executor_output,
                 task_state=current_task_state,
                 task_contract=current_task_contract,
@@ -679,6 +909,8 @@ async def _run_impl(
             {
                 "round": round_index,
                 "role": next_step,
+                "executor_tier": executor_tier,
+                "tier_source": tier_source,
                 "output_chars": len(executor_output),
                 **_episode_event_fields(executor_result, event_status="completed"),
             },
@@ -689,6 +921,7 @@ async def _run_impl(
             role=f"{next_step}_executor",
             status=executor_result.status,
             duration_ms=executor_result.duration_ms,
+            executor_tier=executor_tier,
         )
 
         # The auditor audits only the just-finished subtask. Its natural
@@ -741,6 +974,7 @@ async def _run_impl(
                 round_index=round_index,
                 next_step=next_step,
                 plan_text=plan_text,
+                executor_tier=executor_tier,
                 executor_output=executor_output,
                 task_state=current_task_state,
                 task_contract=current_task_contract,
@@ -827,6 +1061,7 @@ async def _run_impl(
                 round_index=round_index,
                 next_step=next_step,
                 plan_text=plan_text,
+                executor_tier=executor_tier,
                 executor_output=executor_output,
                 task_state=current_task_state,
                 task_contract=current_task_contract,
@@ -851,12 +1086,41 @@ async def _run_impl(
         _write_local(round_dir / "auditor_report.txt", auditor_report)
         await _write_remote_round_text(env, config, round_index, "auditor_report.txt", auditor_report)
 
+        # The audit verdict drives the escalation counter, so it is parsed before
+        # the round is recorded and any escalation notice goes into this round's
+        # harness feedback, which the next manager prompt reads.
+        audit = parse_audit_report(auditor_report, round_index, language=config.prompt_language)
+        escalation = router.record_audit(
+            audit,
+            round_index,
+            executor_tier,
+            # An executor that errored or timed out is a failure on its own, even
+            # if the auditor could not tell from the output alone.
+            executor_failed=executor_result.status != "done"
+            or bool(_hard_runtime_signal_labels(executor_result)),
+        )
+        escalation_notice = ""
+        if escalation:
+            escalation_notice = _escalation_feedback(
+                config.prompt_language,
+                from_tier=escalation["from_tier"],
+                to_tier=escalation["to_tier"],
+                reason=escalation["reason"],
+                rounds=escalation["failed_rounds"],
+            )
+            _write_local(round_dir / "harness_feedback.txt", escalation_notice)
+            await _write_remote_round_text(
+                env, config, round_index, "harness_feedback.txt", escalation_notice
+            )
+
         record = ManagedRound(
             round_index=round_index,
             next_step=next_step,
             plan_text=plan_text,
+            executor_tier=executor_tier,
             executor_output=executor_output,
             auditor_report=auditor_report,
+            harness_feedback=escalation_notice,
             task_state=current_task_state,
             task_contract=current_task_contract,
             related_report_refs=related_report_refs,
@@ -875,7 +1139,9 @@ async def _run_impl(
                 **_episode_event_fields(auditor_result, event_status="completed"),
             },
         )
-        audit = parse_audit_report(auditor_report, round_index, language=config.prompt_language)
+        if escalation:
+            _append_event(events_path, "executor_escalation", escalation)
+            emit("executor_escalation", **escalation)
         emit(
             "role_done",
             round=round_index,
@@ -902,6 +1168,7 @@ async def _run_impl(
         elapsed_seconds=elapsed,
         final_response=gate.final_response,
         failure_reason=gate.failure_reason,
+        executor_routing=_executor_routing_report(router),
     )
     _write_local(role_dir / "report.json", json.dumps(final, ensure_ascii=False, indent=2) + "\n")
     _write_local(log_dir / "report.json", json.dumps(final, ensure_ascii=False, indent=2) + "\n")
@@ -1091,14 +1358,16 @@ async def _human_gate(ctx: _GateContext, outcome: str, round_index: int, task_st
 def _executor_binding(
     *,
     next_step: RoleNextStep,
-    gui_executor_agent: AgentAdapter,
-    cli_executor_agent: AgentAdapter,
+    executor_tier: str,
+    executor_agents: dict[str, dict[str, AgentAdapter]],
     gui_executor_budget: EpisodeBudget,
     cli_executor_budget: EpisodeBudget,
 ) -> tuple[AgentAdapter, EpisodeBudget]:
+    # The budget stays per executor type: a tier changes which model does the
+    # work, not how long a GUI or CLI subtask is allowed to take.
     if next_step == MANAGER_NEXT_GUI:
-        return gui_executor_agent, gui_executor_budget
-    return cli_executor_agent, cli_executor_budget
+        return executor_agents["gui"][executor_tier], gui_executor_budget
+    return executor_agents["cli"][executor_tier], cli_executor_budget
 
 
 async def _run_role_episode(
@@ -1394,6 +1663,52 @@ def _auditor_report_text(
     )
 
 
+def _audit_is_clean_complete(report: AuditReport) -> bool:
+    """The one definition of a passing audit: complete, clean, and contract-aligned."""
+    return (
+        report.status == "complete"
+        and report.integrity_status == "clean"
+        and report.contract_audit_status == "aligned"
+    )
+
+
+def _audit_reports_a_problem(report: AuditReport) -> bool:
+    """Whether an audit says something went wrong, as opposed to "not done yet".
+
+    Auditors are instructed to report `incomplete` whenever the whole contract is
+    not yet satisfied, "even if the local subtask succeeded", so nearly every
+    mid-run round is incomplete. Only these signals mean the round itself was
+    bad, which is what escalation should react to.
+    """
+    return (
+        report.status == "blocked"
+        or report.integrity_status in {"suspect", "violation"}
+        or report.contract_audit_status in {"needs_revision", "invalid"}
+    )
+
+
+def _audit_gap_fingerprint(report: AuditReport) -> str:
+    """Normalized text of the gap an audit is still asking to close."""
+    for candidate in (report.action_guidance, report.state_summary, report.report_text):
+        text = " ".join(str(candidate or "").lower().split())
+        if text:
+            return text
+    return ""
+
+
+# Auditors reword the same finding between rounds, so the stall check compares
+# similarity rather than requiring an exact repeat.
+_STALL_SIMILARITY = 0.85
+
+
+def _same_gap(current: str, previous: str) -> bool:
+    if not current or not previous:
+        return False
+    if current == previous:
+        return True
+    return SequenceMatcher(None, current, previous).ratio() >= _STALL_SIMILARITY
+
+
 def _latest_auditor_is_clean_complete(rounds: list[ManagedRound], *, language: str = "en") -> bool:
     for item in reversed(rounds):
         if item.auditor_status.get("invalid_completion") or item.auditor_status.get("invalid_plan"):
@@ -1401,11 +1716,7 @@ def _latest_auditor_is_clean_complete(rounds: list[ManagedRound], *, language: s
         if not item.auditor_report.strip():
             continue
         report = parse_audit_report(item.auditor_report, item.round_index, language=language)
-        return (
-            report.status == "complete"
-            and report.integrity_status == "clean"
-            and report.contract_audit_status == "aligned"
-        )
+        return _audit_is_clean_complete(report)
     return False
 
 
@@ -1422,6 +1733,7 @@ def _final_report(
     elapsed_seconds: float,
     final_response: str = "",
     failure_reason: str = "",
+    executor_routing: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     # Final status is a harness-level decision, not the last executor agent's self
     # claim. The auditor artifact remains the natural-language audit report.
@@ -1438,7 +1750,8 @@ def _final_report(
         else "incomplete"
     )
     return {
-        "schema_version": 2,
+        # 3 adds `executor_tier` to each round and the `executor_routing` block.
+        "schema_version": 3,
         "variant": ROLE_VARIANT,
         "mode": "role_orchestration",
         "status": status,
@@ -1454,6 +1767,7 @@ def _final_report(
         "current_task_state": task_state,
         "current_task_contract": task_contract,
         "latest_auditor_report": latest_report_text,
+        "executor_routing": executor_routing or {},
         "final_response": final_response,
         "rounds": [asdict(item) for item in rounds],
         "elapsed_seconds": round(elapsed_seconds, 3),
@@ -1591,6 +1905,19 @@ def _read_jsonl_local(path: Path) -> list[dict[str, Any]]:
         if isinstance(value, dict):
             result.append(value)
     return result
+def _executor_routing_report(router: _ExecutorRouter) -> dict[str, Any]:
+    """Routing policy plus what it actually did, for the run report."""
+    return {
+        **asdict(router.routing),
+        # `escalated` is the state the run ended in; `escalations` is what it did
+        # along the way, which a recovering run would otherwise not show.
+        "escalated": router.escalated,
+        "escalated_from": router.escalated_from,
+        "escalations": list(router.escalations),
+        "consecutive_audit_failures": router.consecutive_audit_failures,
+        "stalled_rounds": router.stalled_rounds,
+        "rounds_by_tier": dict(router.tier_counts),
+    }
 
 
 def _latest_auditor_report_text(rounds: list[ManagedRound]) -> str:

--- a/src/lh_harness/manager.py
+++ b/src/lh_harness/manager.py
@@ -8,6 +8,7 @@ import json
 import logging
 import os
 import stat as stat_module
+import sys
 import time
 from dataclasses import asdict, dataclass, field
 import traceback
@@ -25,6 +26,7 @@ from .environment.remote_files import ensure_remote_dir, write_remote_text
 from .runtime_signals import hard_signal_labels
 from .provider_errors import classify_agent_runtime_failure
 from .trajectory_artifacts import persist_trajectory_artifacts
+from .utils import paths as long_paths
 from .role_prompts import (
     MANAGER_NEXT_BLOCKED,
     MANAGER_NEXT_DONE,
@@ -73,6 +75,7 @@ from .auditor_agent import (
     audit_report_from_episode_result,
 )
 
+IS_WINDOWS = sys.platform == "win32"
 ROLE_VARIANT = "lh_harness_role_managed"
 logger = logging.getLogger(__name__)
 _MAX_SAVED_TRAJECTORY_BYTES = 16 * 1024 * 1024
@@ -1540,7 +1543,7 @@ async def _write_final_response(
     # Stored per round, like the other roles, so a discarded reply keeps its own
     # artifacts and the dashboard's round trajectory viewer can reach them.
     round_dir = ctx.role_dir / "rounds" / f"round_{round_index:03d}"
-    round_dir.mkdir(parents=True, exist_ok=True)
+    long_paths.makedirs(round_dir)
     _write_local(round_dir / "final_response_input.txt", prompt)
     _append_event(
         ctx.events_path,
@@ -2485,8 +2488,47 @@ def _budget_to_dict(budget: EpisodeBudget) -> dict[str, int]:
     }
 
 
+def _event_record(path: Path, event: str, payload: dict[str, Any], sequence: int) -> dict[str, Any]:
+    run_id = path.parents[2].name if len(path.parents) > 2 else "local"
+    return {
+        "schema_version": 1,
+        "event_id": f"{run_id}:{sequence:06d}",
+        "ts": time.time(),
+        "event": event,
+        **_json_safe(payload),
+    }
+
+
+def _append_event_windows(path: Path, event: str, payload: dict[str, Any]) -> None:
+    """Append one event on Windows, which has no O_NOFOLLOW/dir_fd/flock.
+
+    Same record shape and same sequence-derived event id as the POSIX path. The
+    difference is the locking: a single process owns this log for the run, so
+    the sequence is read and written under one handle rather than an advisory
+    lock.
+    """
+
+    if path.is_symlink():
+        raise OSError(f"refusing to follow a reparse point: {path}")
+    target = long_paths.os_path(path)
+    with open(target, "a+", encoding="utf-8", newline="") as fh:
+        fh.seek(0)
+        sequence = sum(1 for line in fh if line.strip()) + 1
+        fh.seek(0, 2)
+        fh.write(
+            json.dumps(_event_record(path, event, payload, sequence), ensure_ascii=False, sort_keys=True)
+            + "\n"
+        )
+        fh.flush()
+        with contextlib.suppress(OSError):
+            os.fsync(fh.fileno())
+
+
 def _append_event(path: Path, event: str, payload: dict[str, Any]) -> None:
     _ensure_dir_nofollow(path.parent)
+    if IS_WINDOWS:
+        _append_event_windows(path, event, payload)
+        return
     # Event ids are assigned while holding the file lock, so the same absolute
     # id survives snapshot truncation, REST replay, and a reconnect after an
     # API restart.  The legacy ``event`` field remains for old readers.

--- a/src/lh_harness/prompt_texts.py
+++ b/src/lh_harness/prompt_texts.py
@@ -80,6 +80,7 @@ Your work:
 6. Output completion only when an auditor's first three control lines are `Status: complete`, `Integrity: clean`, and `Contract audit: aligned`, and its report supports every original requirement.
 7. Treat `Acceptance-constraint backcheck` in auditor reports as high-priority input. If blocking constraints exist or contract audit is unknown, needs_revision, or invalid, revise/clarify the contract and schedule verification or repair; never finish.
 8. When progress requires a human decision or missing user input, output `Next: ask`; never route human interaction to an executor.
+9. For a gui/cli route you may name the executor tier the subtask deserves: a cheaper executor for work whose path is already clear, a stronger one where the subtask needs real reasoning, ambiguity resolution, or recovery from repeated failure. Judge this subtask as written; never decide from the kind of work it is, and never assume a category is always cheap or always strong. Omit the line whenever you have no clear reason to prefer one, and the configured default applies.
 
 Current-state rules:
 - Include `Current task state:` every round, with Completed, Incomplete, Blockers/Risks, and Untrusted/Do not reuse.
@@ -97,7 +98,7 @@ Output plain natural language, never JSON. Use this exact section order:
 `Dependency assessment:`
 then exactly one route: `Next: gui`, `Next: cli`, `Next: ask`, `Next: done`, or `Next: blocked`.
 
-For gui/cli include `Task:`, optional `Acceptance criteria:`, `Related audit reports:`, `Related audited state:`, and `Boundaries:`. Related reports must list round ids and reasons.
+For gui/cli you may follow the route with one optional `Executor tier: cheap` or `Executor tier: strong` line, then include `Task:`, optional `Acceptance criteria:`, `Related audit reports:`, `Related audited state:`, and `Boundaries:`. Related reports must list round ids and reasons.
 For ask include `Question:` and optionally `Choices:` separated by `|`.
 For done cite the auditor facts supporting all requirements. For blocked explain why further decomposition cannot progress.
 Do not add top-level sections outside this protocol.
@@ -116,6 +117,7 @@ Do not add top-level sections outside this protocol.
 6. 只有 auditor 前三行分别为 `状态: complete`、`完整性: clean`、`契约审计: aligned`，且正文支持所有原始要求时，才能输出完成。
 7. auditor 的 `验收约束反查` 是契约修订的高优先级输入。存在阻断约束，或契约审计为 unknown/needs_revision/invalid 时，必须先修订、澄清、验证或修复，不得完成。
 8. 推进依赖真人决定或缺失用户输入时输出 `下一步: 请示用户`；绝不能把真人交互拆给 executor。
+9. GUI/CLI 路由可以指定本轮子任务应该用的 executor 档位：路径已经清楚的工作用更便宜的 executor，需要真正推理、消解歧义或从反复失败中恢复的子任务用更强的 executor。只依据本轮子任务本身判断；不要按工作类别决定，也不要假设某类任务永远便宜或永远需要强模型。没有明确理由时省略该行，按配置的默认档位执行。
 
 状态要求:
 - 每轮包含 `当前任务状态:`，至少分为已完成、未完成、阻塞/风险、不可信/不可复用。
@@ -133,7 +135,7 @@ Do not add top-level sections outside this protocol.
 `依赖判断:`
 然后恰好一个路由: `下一步: GUI任务`、`下一步: CLI任务`、`下一步: 请示用户`、`下一步: 完成` 或 `下一步: 阻塞`。
 
-GUI/CLI 路由后包含 `任务:`、可选 `验收标准:`、`相关审计报告:`、`相关已审计状态:`、`边界:`；相关报告必须列出 round id 和原因。
+GUI/CLI 路由后可以跟一行可选的 `执行器档位: cheap` 或 `执行器档位: strong`，然后包含 `任务:`、可选 `验收标准:`、`相关审计报告:`、`相关已审计状态:`、`边界:`；相关报告必须列出 round id 和原因。
 请示用户后包含 `问题:`，封闭式选择可包含用 `|` 分隔的 `选项:`。
 完成时引用支持全部要求的 auditor 事实；阻塞时说明继续拆解也无法推进的原因。不要添加协议之外的顶层段落。
 """,

--- a/src/lh_harness/role_prompts.py
+++ b/src/lh_harness/role_prompts.py
@@ -14,7 +14,7 @@ from .prompt_texts import (
     TASK_CONTRACT_RULES,
     USER_CLARIFICATION_NOTE,
 )
-from .types import ManagedRound, PromptLanguage, RoleNextStep
+from .types import EXECUTOR_TIERS, ExecutorTier, ManagedRound, PromptLanguage, RoleNextStep
 
 MANAGER_NEXT_GUI: RoleNextStep = "gui"
 MANAGER_NEXT_CLI: RoleNextStep = "cli"
@@ -138,19 +138,23 @@ def build_role_executor_prompt(
     task_contract: str = "",
     related_auditor_reports: str = "",
     workspace_path: str = "",
+    escalation_briefing: str = "",
     language: str = "en",
 ) -> str:
     lang = normalize_prompt_language(language)
     gui = next_step == MANAGER_NEXT_GUI
     role_name = "GUI/visual" if gui and lang == "en" else "CLI/non-GUI" if lang == "en" else "GUI/视觉" if gui else "CLI/非 GUI"
     role_instructions = GUI_EXECUTOR_INSTRUCTIONS[lang] if gui else CLI_EXECUTOR_INSTRUCTIONS[lang]
+    # Only escalated rounds carry a briefing, so an ordinary round's prompt is
+    # unchanged from before tiers existed.
+    briefing_block = f"\n{escalation_briefing.rstrip()}\n" if escalation_briefing.strip() else ""
     if lang == "en":
         return f"""\
 {role_instructions.strip()}
 
 Original task:
 {task.rstrip()}
-
+{briefing_block}
 Task-contract rules:
 {TASK_CONTRACT_RULES[lang].strip()}
 
@@ -183,7 +187,7 @@ Complete only this subtask. Treat audited state and the stable contract as the t
 
 原始任务:
 {task.rstrip()}
-
+{briefing_block}
 任务契约规则:
 {TASK_CONTRACT_RULES[lang].strip()}
 
@@ -499,6 +503,23 @@ def parse_role_manager_next_step(text: str) -> RoleNextStep:
     return MANAGER_NEXT_INVALID
 
 
+def parse_role_manager_executor_tier(text: str) -> ExecutorTier | None:
+    """Return the tier the manager asked for, or None when it named none.
+
+    The tier line is optional: an unreadable or absent value means "no opinion",
+    which the run loop resolves to the configured default. A bad value must
+    never break a round, so it is reported as None rather than raised.
+    """
+    for line in str(text or "").splitlines():
+        normalized = line.strip().strip("*").replace(" ", "").replace("　", "").lower()
+        for prefix in ("executortier:", "执行器档位:", "执行器档位：", "执行档位:", "执行档位："):
+            if normalized.startswith(prefix):
+                value = normalized[len(prefix) :].strip().strip("`")
+                if value in EXECUTOR_TIERS:
+                    return value  # type: ignore[return-value]
+    return None
+
+
 def extract_role_manager_question(plan_text: str) -> str:
     """Return the `问题:` block from a `下一步: 请示用户` plan (question for the human)."""
     lines = str(plan_text or "").splitlines()
@@ -656,6 +677,87 @@ def format_related_auditor_reports(
     return format_verified_intermediate_context(
         selected, max_chars=max_chars, language=language
     )
+
+
+# The most recent failures carry the most useful signal, and an escalated
+# executor is the expensive one, so the briefing is capped rather than replaying
+# an entire failing run.
+ESCALATION_BRIEFING_MAX_ROUNDS = 3
+
+
+def format_executor_escalation_briefing(
+    rounds: list[ManagedRound],
+    failed_round_indices: list[int],
+    *,
+    from_tier: str,
+    to_tier: str,
+    max_chars: int = 12_000,
+    language: str = "en",
+) -> str:
+    """Tell an escalated executor what the previous tier tried and why it failed.
+
+    Every episode is a fresh agent session, and a previous round's executor
+    output never otherwise reaches a later executor, so without this the
+    stronger model repeats the same dead ends. Prior executor output is included
+    because "what was already attempted" is the point, but it is labelled as the
+    executor's own unaudited claim: the auditor report stays the authority, the
+    same boundary the manager instructions draw.
+    """
+    lang = normalize_prompt_language(language)
+    selected = [
+        item
+        for item in rounds
+        if item.round_index in set(failed_round_indices)
+        and (item.executor_output.strip() or item.auditor_report.strip())
+    ][-ESCALATION_BRIEFING_MAX_ROUNDS:]
+    if not selected:
+        return ""
+
+    if lang == "en":
+        header = (
+            f"Escalation briefing (executor tier {from_tier} -> {to_tier}):\n"
+            f"This subtask type has failed audit {len(failed_round_indices)} time(s) in a row on the "
+            f"{from_tier} executor, so the harness escalated it to the {to_tier} executor. You are a new "
+            "session with no memory of those attempts. Read what was already tried and why it was "
+            "rejected, then take a different approach; do not repeat the rejected ones."
+        )
+        labels = (
+            "Attempted subtask",
+            "Unverified prior attempt (that executor's own claim; not evidence, do not treat as fact)",
+            "Auditor finding (authoritative)",
+        )
+        empty = "(none)"
+    else:
+        header = (
+            f"升级简报（executor 档位 {from_tier} -> {to_tier}）:\n"
+            f"该子任务在 {from_tier} executor 上已连续 {len(failed_round_indices)} 次审计失败，harness 已升级到 "
+            f"{to_tier} executor。你是全新会话，没有那些尝试的记忆。先读清楚已经试过什么、为什么被拒绝，"
+            "然后换一种做法；不要重复被拒绝的做法。"
+        )
+        labels = (
+            "已尝试子任务",
+            "未经验证的历史尝试（executor 自述，不是证据，不能当作事实）",
+            "auditor 审计结论（权威）",
+        )
+        empty = "(无)"
+
+    sections: list[str] = []
+    for item in selected:
+        round_id = f"round_{item.round_index:03d}"
+        sections.append(
+            "\n".join(
+                (
+                    f"--- {round_id} ---",
+                    f"{labels[0]}:",
+                    _clip_preserve(item.plan_text.strip(), 1200) or empty,
+                    f"{labels[1]}:",
+                    _clip_preserve(item.executor_output.strip(), 2000) or empty,
+                    f"{labels[2]}:",
+                    _clip_preserve(item.auditor_report.strip(), 3000) or empty,
+                )
+            )
+        )
+    return _clip_preserve("\n\n".join([header, *sections]), max_chars)
 
 
 def format_harness_feedback_context(rounds: list[ManagedRound], *, max_chars: int = 12_000) -> str:

--- a/src/lh_harness/supervisor/control_bus.py
+++ b/src/lh_harness/supervisor/control_bus.py
@@ -10,12 +10,15 @@ from __future__ import annotations
 import json
 import os
 import stat
+import sys
 import threading
 import time
 import uuid
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Callable, Iterator
+
+_IS_WINDOWS = sys.platform == "win32"
 
 
 _MAX_CONTROL_RECORD_BYTES = 512 * 1024
@@ -106,6 +109,27 @@ def _open_nofollow(path: str | Path, *, directory: bool = False) -> int:
         raise
 
 
+def _ensure_dir_windows(path: str | Path) -> None:
+    """Build a directory chain on Windows, refusing reparse points."""
+
+    from ..utils import paths as long_paths
+
+    absolute = _absolute_anchored_path(path)
+    current = Path(absolute.anchor)
+    for component in absolute.parts[1:]:
+        if component in {"", ".", ".."}:
+            raise OSError("unsafe control-bus directory component")
+        current = current / component
+        if current.is_symlink():
+            raise OSError(f"refusing to traverse a reparse point: {current}")
+        try:
+            long_paths.makedirs(current, exist_ok=True)
+        except FileExistsError:
+            pass
+        if not current.is_dir():
+            raise OSError(f"control-bus path component is not a directory: {current}")
+
+
 def _ensure_dir_fd_nofollow(path: str | Path, *, mode: int = 0o700) -> int:
     """Create/validate a directory chain and return its anchored descriptor.
 
@@ -173,8 +197,20 @@ def _ensure_dir_fd_nofollow(path: str | Path, *, mode: int = 0o700) -> int:
 
 
 def _ensure_dir_nofollow(path: str | Path, *, mode: int = 0o700) -> None:
-    """Create/validate a directory chain without traversing symlinks."""
+    """Create/validate a directory chain without traversing symlinks.
 
+    Windows has no ``O_NOFOLLOW`` and no directory descriptors, so the anchored
+    POSIX walk cannot run there at all. Callers still need the directory, so it
+    gets the closest available guarantee: build the chain component by
+    component, refusing any existing component that is a reparse point
+    (symlinks and junctions both surface that way). The unavoidable difference
+    is that the check is not anchored, so a sufficiently privileged local actor
+    could still win a check-then-use race.
+    """
+
+    if _IS_WINDOWS:
+        _ensure_dir_windows(path)
+        return None
     fd = _ensure_dir_fd_nofollow(path, mode=mode)
     try:
         return None
@@ -266,10 +302,43 @@ def _open_unique_temp(parent_fd: int, *, prefix: str, suffix: str) -> tuple[int,
     raise FileExistsError("could not allocate a unique control-bus temporary file")
 
 
+def _atomic_bytes_write_windows(path: Path, payload: bytes) -> None:
+    from ..utils import paths as long_paths
+
+    _ensure_dir_windows(path.parent)
+    if path.is_symlink():
+        raise OSError(f"refusing to follow a reparse point: {path}")
+    temporary = path.with_name(f".{path.name}.{uuid.uuid4().hex[:12]}.tmp")
+    target_tmp = long_paths.os_path(temporary)
+    try:
+        with open(target_tmp, "wb") as handle:
+            handle.write(payload)
+            handle.flush()
+            try:
+                os.fsync(handle.fileno())
+            except OSError:
+                pass
+        os.replace(target_tmp, long_paths.os_path(path))
+    except BaseException:
+        try:
+            os.unlink(target_tmp)
+        except OSError:
+            pass
+        raise
+
+
 def _atomic_bytes_write(path: Path, payload: bytes, *, mode: int = 0o600) -> None:
-    """Atomically write bytes below an anchored, no-follow parent directory."""
+    """Atomically write bytes below an anchored, no-follow parent directory.
+
+    The Windows branch keeps the atomic write-then-replace guarantee (which
+    ``os.replace`` provides there too) and the reparse-point refusal; only the
+    anchored-descriptor part is unavailable on that platform.
+    """
 
     path = Path(path)
+    if _IS_WINDOWS:
+        _atomic_bytes_write_windows(path, payload)
+        return
     parent_fd = _ensure_dir_fd_nofollow(path.parent)
     fd: int | None = None
     temporary_name: str | None = None
@@ -331,6 +400,16 @@ def _append_jsonl(path: Path, record: dict[str, Any]) -> None:
     # ``Path.open('a')`` follows a final symlink.  Commands and receipts are
     # control-plane data, so fail closed unless the whole parent chain and
     # final file can be opened with anchored no-follow semantics.
+    if _IS_WINDOWS:
+        # No anchored descriptors on Windows; refuse reparse points instead and
+        # append through a long-path-safe handle.
+        from ..utils import paths as long_paths
+
+        _ensure_dir_windows(path.parent)
+        if path.is_symlink():
+            raise OSError(f"refusing to follow a reparse point: {path}")
+        long_paths.append_line(path, line)
+        return
     fd: int | None = None
     parent_fd: int | None = None
     try:

--- a/src/lh_harness/types.py
+++ b/src/lh_harness/types.py
@@ -41,6 +41,23 @@ DEFAULT_MAX_ROUNDS = 25
 RoleNextStep = Literal["gui", "cli", "done", "blocked", "invalid", "ask"]
 PromptLanguage = Literal["en", "zh"]
 
+# The executor tier is orthogonal to the GUI/CLI executor type: the type says
+# what kind of work the subtask is, the tier says how much model capability it
+# is worth. Both GUI and CLI executors exist in both tiers.
+ExecutorTier = Literal["cheap", "strong"]
+EXECUTOR_TIERS: tuple[ExecutorTier, ...] = ("cheap", "strong")
+DEFAULT_EXECUTOR_TIER: ExecutorTier = "cheap"
+DEFAULT_ESCALATION_TIER: ExecutorTier = "strong"
+# Escalate on the first genuinely failed audit. A retry on the same tier is not
+# briefed on what just failed (only the escalated executor is), so a second cheap
+# attempt would mostly repeat the first. Raise this to trade latency for cost, but
+# see `escalation_briefing` — an unbriefed retry round is largely wasted.
+DEFAULT_ESCALATE_AFTER_FAILURES = 1
+# A merely-incomplete audit is normal mid-run progress, not a failure, so it does
+# not count above. Instead, escalate once this many rounds in a row report the
+# same outstanding gap, which is what a cheap executor spinning looks like.
+DEFAULT_ESCALATE_AFTER_STALLED_ROUNDS = 3
+
 
 @dataclass
 class ExecResult:
@@ -87,10 +104,56 @@ class AuditReport:
 
 
 @dataclass
+class ExecutorRouting:
+    """Which executor tier runs a subtask, and when the harness escalates.
+
+    The default tier keeps routine work on the cheaper backend. Escalation is
+    the harness's own correction for a manager that misjudged difficulty, and it
+    reads two different signals:
+
+    * ``escalate_after_failures`` counts audits that report an actual problem —
+      blocked, suspect/violated integrity, a contract needing revision, or an
+      executor episode that errored. An audit that is merely ``incomplete`` with
+      clean integrity and an aligned contract is ordinary progress toward a
+      multi-round task and is deliberately **not** counted; treating it as a
+      failure would escalate on the first round of nearly every run.
+    * ``escalate_after_stalled_rounds`` catches the other shape of trouble: the
+      cheap tier producing clean-looking rounds that never close the same gap.
+
+    Either counter reaching 0 disables that signal.
+    """
+
+    default_tier: ExecutorTier = DEFAULT_EXECUTOR_TIER
+    escalate_after_failures: int = DEFAULT_ESCALATE_AFTER_FAILURES
+    escalate_after_stalled_rounds: int = DEFAULT_ESCALATE_AFTER_STALLED_ROUNDS
+    escalation_tier: ExecutorTier = DEFAULT_ESCALATION_TIER
+    # An escalated executor is a fresh session on a different backend, so
+    # without a briefing it would rediscover the dead ends the cheap tier
+    # already hit. See `format_executor_escalation_briefing`.
+    escalation_briefing: bool = True
+
+    def __post_init__(self) -> None:
+        for name in ("default_tier", "escalation_tier"):
+            value = getattr(self, name)
+            if value not in EXECUTOR_TIERS:
+                raise ValueError(
+                    f"{name} must be one of: {', '.join(EXECUTOR_TIERS)}; got {value!r}"
+                )
+        for name in ("escalate_after_failures", "escalate_after_stalled_rounds"):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, int):
+                raise ValueError(f"{name} must be an integer")
+            if value < 0:
+                raise ValueError(f"{name} must be 0 or more")
+
+
+@dataclass
 class ManagedRound:
     round_index: int
     next_step: RoleNextStep
     plan_text: str
+    # Empty on rounds that never reached an executor (done/blocked/ask/invalid).
+    executor_tier: str = ""
     executor_output: str = ""
     auditor_report: str = ""
     harness_feedback: str = ""
@@ -113,12 +176,14 @@ class HarnessConfig:
     auditor_budget: EpisodeBudget = field(
         default_factory=lambda: EpisodeBudget(max_duration_seconds=300)
     )
+    executor_routing: ExecutorRouting = field(default_factory=ExecutorRouting)
     workspace_path: str = DEFAULT_WORKSPACE_PATH
     harness_dir: str = DEFAULT_HARNESS_DIR
     log_dir: str = DEFAULT_LOG_DIR
     auditor_output_chars: int = 24_000
     role_verified_context_chars: int = 60_000
     role_history_chars: int = 100_000
+    escalation_briefing_chars: int = 12_000
     # English is the production default; Chinese remains available for
     # OSWorldv2-compatible role prompts and operator-facing control headers.
     prompt_language: PromptLanguage = "en"

--- a/src/lh_harness/utils/__init__.py
+++ b/src/lh_harness/utils/__init__.py
@@ -7,9 +7,12 @@ from .agent_cli import (
     resolve_codex_binary,
 )
 from .process_group import (
+    force_kill_process_group,
     kill_all_tracked,
     kill_process_group,
-    signal_process_group,
+    new_process_group_kwargs,
+    process_group_alive,
+    terminate_process_group,
     track_process_group,
     untrack_process_group,
 )
@@ -28,14 +31,17 @@ __all__ = [
     "UpdateCheckHandle",
     "UpdateCheckResult",
     "check_for_update",
+    "force_kill_process_group",
     "is_windows_store_alias",
     "kill_all_tracked",
     "kill_process_group",
+    "new_process_group_kwargs",
     "probe_agent_cli",
+    "process_group_alive",
     "resolve_agent_binary",
     "resolve_codex_binary",
-    "signal_process_group",
     "start_update_check",
+    "terminate_process_group",
     "track_process_group",
     "untrack_process_group",
 ]

--- a/src/lh_harness/utils/paths.py
+++ b/src/lh_harness/utils/paths.py
@@ -1,0 +1,63 @@
+"""Filesystem paths that survive Windows' MAX_PATH limit.
+
+Windows rejects paths longer than 260 characters unless they carry the `\\\\?\\`
+extended-length prefix. The harness reaches that limit easily on its own: the
+run layout `<runs_root>/<run-id>/logs/role_management/rounds/round_NNN/
+<role>_raw_trajectory.jsonl` spends roughly 100 characters before any of the
+user's project path is counted.
+
+The failure is also silent-looking -- `mkdir` succeeds for the shorter directory
+while `open` on the file inside it raises ``FileNotFoundError`` -- so it reads
+like a missing directory rather than a length limit.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+IS_WINDOWS = sys.platform == "win32"
+
+_EXTENDED_PREFIX = "\\\\?\\"
+# Well under 260 so a caller appending a filename to a directory we hand back
+# does not slip over the limit on its own.
+_SAFE_LENGTH = 200
+
+
+def os_path(path) -> str:
+    """Path string safe to hand to ``open``/``mkdir`` on this platform.
+
+    Left untouched everywhere except long Windows paths, so relative paths stay
+    relative and log records keep reading the way an operator expects.
+    """
+    text = os.fspath(path)
+    if not IS_WINDOWS or text.startswith(_EXTENDED_PREFIX):
+        return text
+    absolute = os.path.abspath(text)
+    if len(absolute) <= _SAFE_LENGTH:
+        return text
+    if absolute.startswith("\\\\"):
+        # \\server\share -> \\?\UNC\server\share
+        return f"{_EXTENDED_PREFIX}UNC\\{absolute[2:]}"
+    return f"{_EXTENDED_PREFIX}{absolute}"
+
+
+def makedirs(path, *, exist_ok: bool = True) -> None:
+    os.makedirs(os_path(path), exist_ok=exist_ok)
+
+
+def write_text(path, content: str, *, encoding: str = "utf-8") -> None:
+    makedirs(os.path.dirname(os.path.abspath(os.fspath(path))))
+    with open(os_path(path), "w", encoding=encoding, newline="") as handle:
+        handle.write(content)
+
+
+def read_text(path, *, encoding: str = "utf-8", errors: str = "strict") -> str:
+    with open(os_path(path), "r", encoding=encoding, errors=errors) as handle:
+        return handle.read()
+
+
+def append_line(path, line: str, *, encoding: str = "utf-8") -> None:
+    makedirs(os.path.dirname(os.path.abspath(os.fspath(path))))
+    with open(os_path(path), "a", encoding=encoding, newline="") as handle:
+        handle.write(line)

--- a/src/lh_harness/utils/process_group.py
+++ b/src/lh_harness/utils/process_group.py
@@ -1,16 +1,22 @@
 """Guarantee that agent CLIs die with the harness.
 
-Every agent runs in its own session (``start_new_session=True``) so a single
-``killpg`` reaps the CLI plus whatever it spawned. The trade-off is that the
-child no longer shares our terminal's process group, so Ctrl+C reaches only the
-harness. Without the bookkeeping here, killing the harness would leave a
-``claude``/``codex`` process running against the same workspace.
+Every agent runs in its own process group -- ``start_new_session`` on POSIX,
+``CREATE_NEW_PROCESS_GROUP`` on Windows -- so one call reaps the CLI plus
+whatever it spawned. The trade-off is that the child no longer shares our
+terminal's group, so Ctrl+C reaches only the harness. Without the bookkeeping
+here, killing the harness would leave a ``claude``/``codex`` process running
+against the same workspace.
 
 Two layers cover the realistic exit paths:
 
-* ``LocalEnvironment.exec`` kills its own child on timeout and on cancellation.
-* The handlers installed here catch what ``exec`` cannot see (SIGTERM, SIGHUP,
+* ``LocalEnvironment.run`` kills its own child on timeout and on cancellation.
+* The handlers installed here catch what ``run`` cannot see (SIGTERM, SIGHUP,
   and interpreter shutdown) and sweep any still-tracked group.
+
+Everything is platform-split because the POSIX primitives simply do not exist on
+Windows: there is no ``os.killpg``, no ``SIGKILL`` and no ``SIGHUP``. Windows
+instead gets ``taskkill /T``, which is the only reliable way to reap a process
+*tree* there.
 """
 
 from __future__ import annotations
@@ -18,13 +24,30 @@ from __future__ import annotations
 import atexit
 import os
 import signal
+import subprocess
 import sys
 import threading
 import time
 
+IS_WINDOWS = sys.platform == "win32"
+
 _lock = threading.Lock()
 _tracked: set[int] = set()
 _installed = False
+
+# Signals worth trapping, filtered to what this platform actually defines.
+_TERMINATING_SIGNALS = tuple(
+    sig for sig in (getattr(signal, name, None) for name in ("SIGTERM", "SIGHUP", "SIGBREAK")) if sig is not None
+)
+
+
+def new_process_group_kwargs() -> dict[str, object]:
+    """Subprocess kwargs that put the child in its own killable group."""
+    if IS_WINDOWS:
+        # start_new_session is silently ignored on Windows, which would leave the
+        # agent in our own group and defeat the sweep below.
+        return {"creationflags": subprocess.CREATE_NEW_PROCESS_GROUP}
+    return {"start_new_session": True}
 
 
 def track_process_group(pid: int) -> None:
@@ -38,31 +61,48 @@ def untrack_process_group(pid: int) -> None:
         _tracked.discard(pid)
 
 
-def signal_process_group(pid: int, sig: int) -> bool:
-    """Best-effort ``killpg``; False means the group is already gone."""
-    try:
-        os.killpg(pid, sig)
-    except (ProcessLookupError, PermissionError, OSError):
-        return False
-    return True
+def process_group_alive(pid: int) -> bool:
+    """Whether anything in the group is still running."""
+    if IS_WINDOWS:
+        return _windows_alive(pid)
+    return _posix_signal(pid, 0)
+
+
+def terminate_process_group(pid: int) -> bool:
+    """Ask the group to exit cleanly; False means it is already gone.
+
+    The agent CLIs flush their JSONL trajectory on a clean exit, so this is
+    always tried before forcing.
+    """
+    if IS_WINDOWS:
+        return _windows_taskkill(pid, force=False)
+    return _posix_signal(pid, signal.SIGTERM)
+
+
+def force_kill_process_group(pid: int) -> bool:
+    """Kill the group outright; False means it is already gone."""
+    if IS_WINDOWS:
+        return _windows_taskkill(pid, force=True)
+    # SIGKILL only exists on POSIX, which is the only branch that reaches here.
+    return _posix_signal(pid, signal.SIGKILL)
 
 
 def kill_process_group(pid: int, *, grace_seconds: float = 1.0) -> None:
-    """SIGTERM the group, then SIGKILL whatever ignored it.
+    """Terminate the group, then force-kill whatever ignored it.
 
     Blocking, so it suits signal and atexit handlers. Async callers should
     escalate around ``await proc.wait()`` rather than block the event loop.
     """
-    if not signal_process_group(pid, signal.SIGTERM):
+    if not terminate_process_group(pid):
         return
     deadline = time.monotonic() + grace_seconds
     while time.monotonic() < deadline:
-        # Signal 0 only probes for existence; once the group is gone the CLI has
-        # flushed its trajectory and there is nothing left to escalate against.
-        if not signal_process_group(pid, 0):
+        # Once the group is gone the CLI has flushed its trajectory and there is
+        # nothing left to escalate against.
+        if not process_group_alive(pid):
             return
         time.sleep(0.05)
-    signal_process_group(pid, signal.SIGKILL)
+    force_kill_process_group(pid)
 
 
 def kill_all_tracked() -> None:
@@ -71,6 +111,49 @@ def kill_all_tracked() -> None:
         _tracked.clear()
     for pid in pids:
         kill_process_group(pid)
+
+
+def _posix_signal(pid: int, sig: int) -> bool:
+    try:
+        os.killpg(pid, sig)
+    except (ProcessLookupError, PermissionError, OSError):
+        return False
+    return True
+
+
+def _windows_taskkill(pid: int, *, force: bool) -> bool:
+    """Reap a process tree, the Windows stand-in for killing a process group.
+
+    `/T` is the important flag: the agent CLIs are Node shims that spawn the
+    real worker, so ending only the parent would orphan it.
+    """
+    argv = ["taskkill", "/PID", str(pid), "/T"]
+    if force:
+        argv.append("/F")
+    return _run_quiet(argv) == 0
+
+
+def _windows_alive(pid: int) -> bool:
+    # tasklist always exits 0, so the PID has to be matched in the output.
+    return str(pid) in _run_quiet(
+        ["tasklist", "/FI", f"PID eq {pid}", "/NH"], capture=True
+    )[1]
+
+
+def _run_quiet(argv: list[str], *, capture: bool = False):
+    """Run a Windows helper without flashing a console window."""
+    try:
+        completed = subprocess.run(
+            argv,
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=False,
+            creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
+        )
+    except (OSError, subprocess.SubprocessError):
+        return (1, "") if capture else 1
+    return (completed.returncode, completed.stdout or "") if capture else completed.returncode
 
 
 def _install_handlers() -> None:
@@ -87,7 +170,7 @@ def _install_handlers() -> None:
     if threading.current_thread() is not threading.main_thread():
         return
 
-    for sig in (signal.SIGTERM, signal.SIGHUP):
+    for sig in _TERMINATING_SIGNALS:
         try:
             previous = signal.getsignal(sig)
         except (ValueError, OSError):
@@ -95,7 +178,7 @@ def _install_handlers() -> None:
         # Leave a caller-installed handler alone; overriding it would break the
         # embedding application's own shutdown. SIGINT is deliberately absent:
         # Python already raises KeyboardInterrupt for it, which unwinds through
-        # `exec` and triggers the per-child kill there.
+        # `run` and triggers the per-child kill there.
         if previous is not signal.SIG_DFL:
             continue
         try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,187 @@
+"""Test doubles for the role-management loop.
+
+Nothing here calls a real agent CLI or a paid model. The plan and audit text the
+builders produce is parsed by the production parsers, so a routing test fails if
+the real protocol changes, not only if a stand-in does.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from lh_harness.types import EpisodeBudget, EpisodeResult, ExecResult, HarnessConfig
+
+
+@dataclass
+class RecordedEpisode:
+    prompt: str
+    budget_seconds: int
+    live_trajectory_path: str | None
+
+
+class ScriptedAdapter:
+    """An `AgentAdapter` that replays queued replies and records its prompts.
+
+    `label` identifies which adapter ran, which is the whole point in a routing
+    test: asserting that the cheap cell was used and the strong one was not.
+    """
+
+    def __init__(self, label: str, replies: list[str] | None = None, *, default: str = "") -> None:
+        self.label = label
+        self.replies = list(replies or [])
+        self.default = default
+        self.episodes: list[RecordedEpisode] = []
+
+    @property
+    def calls(self) -> int:
+        return len(self.episodes)
+
+    @property
+    def prompts(self) -> list[str]:
+        return [episode.prompt for episode in self.episodes]
+
+    async def run_episode(
+        self,
+        prompt: str,
+        env: Any,
+        budget: EpisodeBudget,
+        live_trajectory_path: str | None = None,
+    ) -> EpisodeResult:
+        self.episodes.append(
+            RecordedEpisode(prompt, budget.max_duration_seconds, live_trajectory_path)
+        )
+        text = self.replies.pop(0) if self.replies else self.default
+        return EpisodeResult(
+            status="done",
+            actions_log="",
+            duration_ms=1,
+            # First key in VISIBLE_OUTPUT_KEYS, so the loop reads this verbatim
+            # instead of trying to decode a Claude/Codex trajectory.
+            metadata={"assistant_visible_output": text, "exit_code": 0},
+        )
+
+
+@dataclass
+class FakeEnvironment:
+    """In-memory `Environment`; the loop's remote mirroring is a no-op here."""
+
+    staging_dir: str | None = None
+    written: dict[str, str] = field(default_factory=dict)
+
+    async def exec(self, command: str, timeout: int = 30, tee_path: str | None = None) -> ExecResult:
+        return ExecResult(stdout="", stderr="", exit_code=0, duration_ms=0)
+
+    async def screenshot(self) -> bytes:
+        return b""
+
+    async def upload(self, local_path: str, remote_path: str) -> None:
+        self.written[remote_path] = local_path
+
+    async def download(self, remote_path: str, local_path: str) -> None:
+        raise NotImplementedError
+
+
+def manager_plan(
+    route: str,
+    *,
+    tier: str | None = None,
+    task: str = "Do the next piece of work",
+    related: str = "",
+    state: str = "Completed: nothing yet.",
+) -> str:
+    """A manager reply the real `parse_role_manager_*` helpers accept."""
+    lines = [
+        "Current task state:",
+        state,
+        "",
+        "Task contract:",
+        "Produce the requested state.",
+        "",
+        "Dependency assessment:",
+        "Target state: the deliverable. Routing rationale: direct.",
+        "",
+        f"Next: {route}",
+    ]
+    if tier is not None:
+        lines.append(f"Executor tier: {tier}")
+    if route in {"gui", "cli"}:
+        lines += ["", f"Task: {task}", "", f"Related audit reports: {related or 'none'}"]
+    return "\n".join(lines) + "\n"
+
+
+def audit_report(*, passing: bool, detail: str = "") -> str:
+    """An auditor reply the real `parse_audit_report` accepts.
+
+    A passing report deliberately carries no `Blocking constraints:` entries, so
+    it survives the acceptance-constraint guard and reads as complete.
+    """
+    if passing:
+        head = ["Status: complete", "Integrity: clean", "Contract audit: aligned"]
+        body = detail or "The subtask produced the required persisted state."
+        backcheck = ["Contract conclusion: aligned", "Blocking constraints: none"]
+    else:
+        head = ["Status: incomplete", "Integrity: suspect", "Contract audit: unknown"]
+        body = detail or "The required state was never persisted."
+        backcheck = ["Contract conclusion: unknown", "Blocking constraints: the deliverable is missing"]
+    return "\n".join(
+        [
+            *head,
+            "",
+            f"Audit facts: {body}",
+            "",
+            "Acceptance-constraint backcheck:",
+            *backcheck,
+            "",
+            "State update for manager:",
+            body,
+        ]
+    ) + "\n"
+
+
+def progress_report(gap: str = "the remaining step") -> str:
+    """A clean, contract-aligned round that simply is not the last one.
+
+    This is what real auditors return for ordinary mid-run progress -- the E2E
+    runs produced exactly `incomplete / clean / aligned`. It must never count as
+    an escalation-worthy failure.
+    """
+    return "\n".join(
+        [
+            "Status: incomplete",
+            "Integrity: clean",
+            "Contract audit: aligned",
+            "",
+            "Audit facts: the subtask completed correctly; the overall contract is not finished.",
+            "",
+            "Acceptance-constraint backcheck:",
+            "Contract conclusion: aligned",
+            "Blocking constraints: none",
+            "",
+            "State update for manager:",
+            f"Still outstanding: {gap}.",
+        ]
+    ) + "\n"
+
+
+@pytest.fixture
+def harness_config(tmp_path):
+    """A config whose every path is inside tmp_path, with short budgets."""
+
+    def build(**overrides: Any) -> HarnessConfig:
+        defaults: dict[str, Any] = {
+            "max_total_episodes": 6,
+            "manager_budget": EpisodeBudget(max_duration_seconds=5),
+            "gui_executor_budget": EpisodeBudget(max_duration_seconds=7),
+            "cli_executor_budget": EpisodeBudget(max_duration_seconds=9),
+            "auditor_budget": EpisodeBudget(max_duration_seconds=5),
+            "workspace_path": str(tmp_path / "workspace"),
+            "harness_dir": str(tmp_path / "harness"),
+            "log_dir": str(tmp_path / "logs"),
+        }
+        defaults.update(overrides)
+        return HarnessConfig(**defaults)
+
+    return build

--- a/tests/loop_harness.py
+++ b/tests/loop_harness.py
@@ -1,0 +1,127 @@
+"""Drive the real `manager.run` loop with scripted adapters.
+
+Shared by the routing, escalation and briefing tests so they all exercise the
+production loop rather than a reimplementation of it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from conftest import FakeEnvironment, ScriptedAdapter, audit_report, manager_plan
+
+from lh_harness import manager
+
+
+@dataclass
+class LoopRun:
+    report: dict[str, Any]
+    manager_agent: ScriptedAdapter
+    executors: dict[tuple[str, str], ScriptedAdapter]
+    auditors: dict[str, ScriptedAdapter]
+    log_dir: Path
+    progress: list[tuple[str, dict[str, Any]]]
+
+    def executor(self, executor_type: str, tier: str) -> ScriptedAdapter:
+        return self.executors[(executor_type, tier)]
+
+    @property
+    def tiers(self) -> list[str]:
+        return [item["executor_tier"] for item in self.report["rounds"]]
+
+    def events(self, name: str | None = None) -> list[dict[str, Any]]:
+        path = self.log_dir / "role_management" / "events.jsonl"
+        records = [
+            json.loads(line)
+            for line in path.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+        return [item for item in records if name is None or item.get("event") == name]
+
+    def rounds_jsonl(self) -> list[dict[str, Any]]:
+        path = self.log_dir / "role_management" / "rounds.jsonl"
+        return [
+            json.loads(line)
+            for line in path.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+
+    def round_dir(self, round_index: int) -> Path:
+        return self.log_dir / "role_management" / "rounds" / f"round_{round_index:03d}"
+
+
+def run_loop(
+    config,
+    *,
+    plans: list[str],
+    audits: list[str],
+    task: str = "Ship the feature",
+) -> LoopRun:
+    """Run the loop with one scripted adapter per role and (type, tier) cell.
+
+    `plans` are the manager's replies in order; `audits` are the auditor's. Both
+    auditors share the audit script, so a test only has to describe the verdict
+    sequence, not which auditor produced it.
+    """
+    manager_agent = ScriptedAdapter("manager", plans, default=manager_plan("blocked"))
+    executors = {
+        (executor_type, tier): ScriptedAdapter(
+            f"{executor_type}/{tier}", default=f"{executor_type}/{tier} executor ran"
+        )
+        for executor_type in ("gui", "cli")
+        for tier in ("cheap", "strong")
+    }
+    remaining = list(audits)
+
+    class SharedAuditor(ScriptedAdapter):
+        async def run_episode(self, prompt, env, budget, live_trajectory_path=None):
+            self.replies = [remaining.pop(0)] if remaining else []
+            return await super().run_episode(prompt, env, budget, live_trajectory_path)
+
+    auditors = {
+        "gui": SharedAuditor("gui_auditor", default=audit_report(passing=False)),
+        "cli": SharedAuditor("cli_auditor", default=audit_report(passing=False)),
+    }
+    progress: list[tuple[str, dict[str, Any]]] = []
+
+    report = asyncio.run(
+        manager.run(
+            task=task,
+            env=FakeEnvironment(),
+            config=config,
+            manager_agent=manager_agent,
+            executor_agents={
+                executor_type: {
+                    tier: executors[(executor_type, tier)] for tier in ("cheap", "strong")
+                }
+                for executor_type in ("gui", "cli")
+            },
+            gui_executor_agent=executors[("gui", "cheap")],
+            cli_executor_agent=executors[("cli", "cheap")],
+            gui_auditor_agent=auditors["gui"],
+            cli_auditor_agent=auditors["cli"],
+            final_response_agent=ScriptedAdapter("final_response", default="Here is what happened."),
+            progress=lambda event, payload: progress.append((event, payload)),
+        )
+    )
+    return LoopRun(
+        report=report,
+        manager_agent=manager_agent,
+        executors=executors,
+        auditors=auditors,
+        log_dir=Path(config.log_dir),
+        progress=progress,
+    )
+
+
+def executor_calls(run: LoopRun) -> dict[str, int]:
+    """Non-zero executor call counts, keyed `type/tier`."""
+    return {
+        f"{executor_type}/{tier}": adapter.calls
+        for (executor_type, tier), adapter in run.executors.items()
+        if adapter.calls
+    }

--- a/tests/loop_harness.py
+++ b/tests/loop_harness.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from conftest import FakeEnvironment, ScriptedAdapter, audit_report, manager_plan
+from tests.conftest import FakeEnvironment, ScriptedAdapter, audit_report, manager_plan
 
 from lh_harness import manager
 
@@ -34,7 +34,7 @@ class LoopRun:
         return [item["executor_tier"] for item in self.report["rounds"]]
 
     def events(self, name: str | None = None) -> list[dict[str, Any]]:
-        path = self.log_dir / "role_management" / "events.jsonl"
+        path = self.log_dir / "role_orchestration" / "events.jsonl"
         records = [
             json.loads(line)
             for line in path.read_text(encoding="utf-8").splitlines()
@@ -43,7 +43,7 @@ class LoopRun:
         return [item for item in records if name is None or item.get("event") == name]
 
     def rounds_jsonl(self) -> list[dict[str, Any]]:
-        path = self.log_dir / "role_management" / "rounds.jsonl"
+        path = self.log_dir / "role_orchestration" / "rounds.jsonl"
         return [
             json.loads(line)
             for line in path.read_text(encoding="utf-8").splitlines()
@@ -51,7 +51,7 @@ class LoopRun:
         ]
 
     def round_dir(self, round_index: int) -> Path:
-        return self.log_dir / "role_management" / "rounds" / f"round_{round_index:03d}"
+        return self.log_dir / "role_orchestration" / "rounds" / f"round_{round_index:03d}"
 
 
 def run_loop(

--- a/tests/test_adapter_argv.py
+++ b/tests/test_adapter_argv.py
@@ -1,0 +1,225 @@
+"""Agent commands are argv lists, not shell strings.
+
+Every entry below used to be embedded in a `cd … && VAR=v cmd … < prompt` string
+run through `/bin/sh` or `cmd.exe`. The point of these tests is that no shell
+metacharacter, quote, or redirect survives into the command the harness runs.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from lh_harness.adapters.claude_code import ClaudeCodeAdapter
+from lh_harness.adapters.cli_agent import CommandAgentAdapter
+from lh_harness.adapters.codex import CodexAdapter
+from lh_harness.types import EpisodeBudget, ExecResult
+
+
+class RecordingEnv:
+    """Captures exactly what the adapter asked the environment to do."""
+
+    def __init__(self, stdout: str = ""):
+        self.stdout = stdout
+        self.calls: list[dict] = []
+        self.written: dict[str, str] = {}
+
+    async def run(self, argv, *, timeout=30, cwd=None, env=None, stdin=None, tee_path=None):
+        self.calls.append(
+            {"argv": list(argv), "timeout": timeout, "cwd": cwd, "env": dict(env or {}), "stdin": stdin}
+        )
+        return ExecResult(stdout=self.stdout, stderr="", exit_code=0, duration_ms=1)
+
+    async def exec(self, command, timeout=30, tee_path=None):  # pragma: no cover - must not be used
+        raise AssertionError("the agent path must not use a shell")
+
+    async def write_text(self, path, content):
+        self.written[path] = content
+
+    async def makedirs(self, path):
+        pass
+
+
+def episode(adapter, prompt="PROMPT", seconds=99):
+    env = RecordingEnv()
+    asyncio.run(adapter.run_episode(prompt, env, EpisodeBudget(max_duration_seconds=seconds)))
+    return env.calls[0], env
+
+
+# --- the generic adapter ----------------------------------------------------
+
+
+def test_argv_is_passed_through_untouched(tmp_path):
+    adapter = CommandAgentAdapter(
+        argv=["some-agent", "--flag", "value with spaces"],
+        workspace_path=str(tmp_path),
+        prompt_dir=str(tmp_path / "prompts"),
+    )
+    call, _ = episode(adapter)
+    assert call["argv"][1:] == ["--flag", "value with spaces"]
+
+
+def test_workspace_becomes_cwd_not_a_cd_prefix(tmp_path):
+    adapter = CommandAgentAdapter(
+        argv=["some-agent"], workspace_path=str(tmp_path), prompt_dir=str(tmp_path / "p")
+    )
+    call, _ = episode(adapter)
+    assert call["cwd"] == str(tmp_path)
+    assert not any("cd " in part for part in call["argv"])
+
+
+def test_prompt_goes_to_stdin_not_a_redirect(tmp_path):
+    adapter = CommandAgentAdapter(
+        argv=["some-agent"], workspace_path=str(tmp_path), prompt_dir=str(tmp_path / "p")
+    )
+    call, _ = episode(adapter, prompt="the actual prompt")
+    assert call["stdin"].startswith("the actual prompt")
+    assert not any("<" in part for part in call["argv"])
+
+
+def test_prompt_file_is_still_written_for_the_audit_trail(tmp_path):
+    adapter = CommandAgentAdapter(
+        argv=["some-agent"], workspace_path=str(tmp_path), prompt_dir=str(tmp_path / "p")
+    )
+    _, env = episode(adapter, prompt="auditable")
+    assert len(env.written) == 1
+    assert next(iter(env.written.values())).startswith("auditable")
+
+
+def test_hidden_paths_notice_reaches_stdin_and_the_file(tmp_path):
+    adapter = CommandAgentAdapter(
+        argv=["some-agent"],
+        workspace_path=str(tmp_path),
+        prompt_dir=str(tmp_path / "p"),
+        hidden_paths=("/run/logs",),
+    )
+    call, env = episode(adapter)
+    assert "/run/logs" in call["stdin"]
+    assert "/run/logs" in next(iter(env.written.values()))
+
+
+def test_budget_becomes_the_timeout(tmp_path):
+    adapter = CommandAgentAdapter(
+        argv=["some-agent"], workspace_path=str(tmp_path), prompt_dir=str(tmp_path / "p")
+    )
+    call, _ = episode(adapter, seconds=1234)
+    assert call["timeout"] == 1234
+
+
+# --- codex ------------------------------------------------------------------
+
+
+def test_codex_argv_has_no_shell_syntax(tmp_path):
+    adapter = CodexAdapter(
+        model="gpt-5.6-luna", workspace_path=str(tmp_path), prompt_dir=str(tmp_path / "p")
+    )
+    call, _ = episode(adapter)
+    argv = call["argv"]
+    assert argv[1:5] == ["exec", "--json", "--skip-git-repo-check", "--dangerously-bypass-approvals-and-sandbox"]
+    assert argv[-3:] == ["--model", "gpt-5.6-luna", "-"]
+    # No quoting, no redirect, no env prefix anywhere in the command.
+    assert not any(part.startswith("'") or "<" in part or "=" in part.split("=")[0][:0] for part in argv)
+    assert not any("OPENAI_API_KEY=" in part for part in argv)
+
+
+def test_codex_credentials_go_to_env_not_the_command_line(tmp_path):
+    adapter = CodexAdapter(
+        model="m", api_key="sk-secret", workspace_path=str(tmp_path), prompt_dir=str(tmp_path / "p")
+    )
+    call, _ = episode(adapter)
+    assert call["env"]["OPENAI_API_KEY"] == "sk-secret"
+    assert call["env"]["CODEX_API_KEY"] == "sk-secret"
+    assert not any("sk-secret" in part for part in call["argv"])
+
+
+def test_codex_model_with_awkward_characters_is_not_mangled(tmp_path):
+    adapter = CodexAdapter(
+        model="weird model/v1", workspace_path=str(tmp_path), prompt_dir=str(tmp_path / "p")
+    )
+    call, _ = episode(adapter)
+    assert "weird model/v1" in call["argv"]
+
+
+def test_codex_sandbox_override(tmp_path):
+    adapter = CodexAdapter(
+        model="m", sandbox_mode="read-only", workspace_path=str(tmp_path), prompt_dir=str(tmp_path / "p")
+    )
+    call, _ = episode(adapter)
+    assert "--sandbox" in call["argv"]
+    assert "--dangerously-bypass-approvals-and-sandbox" not in call["argv"]
+
+
+# --- claude code ------------------------------------------------------------
+
+
+def test_claude_argv_has_no_shell_syntax(tmp_path):
+    adapter = ClaudeCodeAdapter(
+        model="claude-opus-5",
+        role="cli_executor",
+        workspace_path=str(tmp_path),
+        prompt_dir=str(tmp_path / "p"),
+    )
+    call, _ = episode(adapter)
+    argv = call["argv"]
+    assert argv[1:6] == ["--print", "--output-format", "stream-json", "--verbose", "--dangerously-skip-permissions"]
+    assert argv[-2:] == ["--model", "claude-opus-5"]
+    assert not any("<" in part for part in argv)
+
+
+def test_claude_role_and_credentials_go_to_env(tmp_path):
+    adapter = ClaudeCodeAdapter(
+        model="m",
+        api_key="sk-ant",
+        role="gui_auditor",
+        workspace_path=str(tmp_path),
+        prompt_dir=str(tmp_path / "p"),
+    )
+    call, _ = episode(adapter)
+    assert call["env"]["LH_HARNESS_CLAUDE_ROLE"] == "gui_auditor"
+    assert call["env"]["ANTHROPIC_API_KEY"] == "sk-ant"
+    # Auditor roles also get the git/pager quieting vars.
+    assert call["env"]["GIT_PAGER"] == "cat"
+    assert not any("sk-ant" in part for part in call["argv"])
+
+
+def test_claude_deny_rules_are_separate_argv_entries(tmp_path):
+    adapter = ClaudeCodeAdapter(
+        model="m",
+        role="manager",
+        workspace_path=str(tmp_path),
+        prompt_dir=str(tmp_path / "p"),
+        hidden_paths=(str(tmp_path / "logs"),),
+    )
+    call, _ = episode(adapter)
+    argv = call["argv"]
+    index = argv.index("--disallowedTools")
+    rules = argv[index + 1 :]
+    assert "Bash" in rules
+    # Each rule is its own argument, never a single space-joined blob.
+    assert all(" " not in rule or rule.startswith(("Read(", "Edit(")) for rule in rules)
+
+
+@pytest.mark.parametrize("role", ["manager", "cli_executor", "gui_auditor", "final_response"])
+def test_every_claude_role_builds(tmp_path, role):
+    adapter = ClaudeCodeAdapter(
+        model="m", role=role, workspace_path=str(tmp_path), prompt_dir=str(tmp_path / "p")
+    )
+    call, _ = episode(adapter)
+    assert call["argv"][0].endswith(("claude", "claude.EXE", "claude.exe", "claude.CMD"))
+
+
+# --- deny rules on drive-letter paths ---------------------------------------
+
+
+def test_deny_rules_cover_drive_letter_paths():
+    from lh_harness.adapters.claude_permissions import path_deny_rules
+
+    rules = path_deny_rules(("C:/runs/logs",))
+    joined = " ".join(rules)
+    if ":" in str(__import__("pathlib").Path("C:/runs/logs").resolve()):
+        # On Windows the bare drive form must be emitted alongside the // form,
+        # or harness-owned paths would not actually be hidden.
+        assert "Read(C:/runs/logs)" in joined
+    assert any(rule.startswith("Read(//") for rule in rules)
+    assert all(rule.startswith(("Read(", "Edit(")) for rule in rules)

--- a/tests/test_cli_executor_routing.py
+++ b/tests/test_cli_executor_routing.py
@@ -1,0 +1,155 @@
+"""How a (type, tier) cell resolves to a concrete agent and model."""
+
+from __future__ import annotations
+
+import argparse
+
+import pytest
+
+from lh_harness.cli import (
+    _EXECUTOR_TIER_ROLES,
+    _ROLE_OPTIONS,
+    _fallback_chain,
+    _resolve_role_option,
+)
+
+
+def ns(**overrides):
+    """An argparse namespace shaped like a parsed `run` command."""
+    values = {f"{role}_{suffix}": None for role, _, _ in _ROLE_OPTIONS for suffix in ("agent", "model")}
+    values.update(agent="codex", model=None)
+    values.update(overrides)
+    return argparse.Namespace(**values)
+
+
+def cells(args):
+    return {
+        f"{executor_type}/{tier}": (
+            _resolve_role_option(args, role, "agent"),
+            _resolve_role_option(args, role, "model"),
+        )
+        for (executor_type, tier), role in _EXECUTOR_TIER_ROLES.items()
+    }
+
+
+# --- the fallback chain itself ---------------------------------------------
+
+
+def test_tier_outranks_type_in_the_chain():
+    assert _fallback_chain("gui_executor_cheap") == [
+        "gui_executor_cheap",
+        "executor_cheap",
+        "gui_executor",
+        "executor",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("role", "expected"),
+    [
+        ("manager", ["manager"]),
+        ("executor", ["executor"]),
+        ("gui_executor", ["gui_executor", "executor"]),
+        ("cli_executor", ["cli_executor", "executor"]),
+        ("auditor", ["auditor"]),
+        ("gui_auditor", ["gui_auditor", "auditor"]),
+        ("cli_auditor", ["cli_auditor", "auditor"]),
+        ("final_response", ["final_response", "manager"]),
+    ],
+)
+def test_pre_existing_roles_keep_their_chain(role, expected):
+    assert _fallback_chain(role) == expected
+
+
+def test_every_role_chain_terminates():
+    for role, _, _ in _ROLE_OPTIONS:
+        chain = _fallback_chain(role)
+        assert chain[0] == role
+        assert len(chain) == len(set(chain))
+
+
+# --- resolution -------------------------------------------------------------
+
+
+def test_global_agent_backs_every_cell():
+    assert cells(ns()) == {key: ("codex", None) for key in cells(ns())}
+
+
+def test_single_executor_config_backs_every_cell():
+    """Back-compat: a project that configured one executor gets it everywhere."""
+    resolved = cells(ns(executor_agent="claude_code", executor_model="opus"))
+    assert set(resolved.values()) == {("claude_code", "opus")}
+
+
+def test_tier_config_splits_both_executor_types():
+    resolved = cells(
+        ns(
+            executor_cheap_agent="codex",
+            executor_cheap_model="cheap-m",
+            executor_strong_agent="claude_code",
+            executor_strong_model="strong-m",
+        )
+    )
+    assert resolved == {
+        "gui/cheap": ("codex", "cheap-m"),
+        "cli/cheap": ("codex", "cheap-m"),
+        "gui/strong": ("claude_code", "strong-m"),
+        "cli/strong": ("claude_code", "strong-m"),
+    }
+
+
+def test_tier_beats_type_where_both_are_configured():
+    resolved = cells(
+        ns(
+            gui_executor_agent="claude_code",
+            gui_executor_model="gui-m",
+            executor_cheap_agent="codex",
+            executor_cheap_model="cheap-m",
+        )
+    )
+    # The cheap tier was named explicitly, so it wins for GUI+cheap...
+    assert resolved["gui/cheap"] == ("codex", "cheap-m")
+    # ...but no strong tier was configured, so the type-level setting still applies.
+    assert resolved["gui/strong"] == ("claude_code", "gui-m")
+
+
+def test_type_and_tier_override_is_the_most_specific():
+    resolved = cells(
+        ns(
+            executor_strong_agent="claude_code",
+            executor_strong_model="strong-m",
+            gui_executor_strong_model="gui-strong-m",
+        )
+    )
+    assert resolved["gui/strong"] == ("claude_code", "gui-strong-m")
+    assert resolved["cli/strong"] == ("claude_code", "strong-m")
+
+
+def test_agent_and_model_resolve_independently():
+    """A tier may set only a model without dragging in another backend's agent."""
+    resolved = cells(ns(agent="claude_code", executor_cheap_model="cheap-m"))
+    assert resolved["cli/cheap"] == ("claude_code", "cheap-m")
+
+
+def test_all_four_combinations_can_differ():
+    resolved = cells(
+        ns(
+            gui_executor_cheap_agent="codex",
+            gui_executor_cheap_model="a",
+            gui_executor_strong_agent="claude_code",
+            gui_executor_strong_model="b",
+            cli_executor_cheap_agent="codex",
+            cli_executor_cheap_model="c",
+            cli_executor_strong_agent="claude_code",
+            cli_executor_strong_model="d",
+        )
+    )
+    assert sorted(model for _, model in resolved.values()) == ["a", "b", "c", "d"]
+
+
+def test_pre_existing_role_resolution_is_unchanged():
+    args = ns(auditor_agent="claude_code", manager_model="mm")
+    assert _resolve_role_option(args, "gui_auditor", "agent") == "claude_code"
+    assert _resolve_role_option(args, "cli_auditor", "agent") == "claude_code"
+    assert _resolve_role_option(args, "final_response", "model") == "mm"
+    assert _resolve_role_option(args, "gui_executor", "agent") == "codex"

--- a/tests/test_config_executor_tiers.py
+++ b/tests/test_config_executor_tiers.py
@@ -1,0 +1,180 @@
+"""Project-configuration support for executor tiers and routing."""
+
+from __future__ import annotations
+
+import pytest
+
+from lh_harness.config import CONFIG_TEMPLATE, ProjectConfigError, load_run_defaults
+from lh_harness.types import (
+    DEFAULT_ESCALATE_AFTER_FAILURES,
+    DEFAULT_ESCALATION_TIER,
+    DEFAULT_EXECUTOR_TIER,
+)
+
+# What the pre-tier config system produced for a plain single-executor project.
+# Locked as a literal so a regression here is unmistakable.
+LEGACY_CONFIG = """\
+[run]
+agent = "codex"
+
+[run.roles.executor]
+agent = "claude_code"
+model = "claude-opus-5"
+"""
+LEGACY_DEFAULTS = {
+    "agent": "codex",
+    "executor_agent": "claude_code",
+    "executor_model": "claude-opus-5",
+}
+
+
+def load(tmp_path, text, name="config.toml"):
+    path = tmp_path / name
+    path.write_text(text, encoding="utf-8")
+    return load_run_defaults(path)
+
+
+def test_cheap_and_strong_executors_take_different_backends(tmp_path):
+    defaults = load(
+        tmp_path,
+        """
+[run.roles.executor.cheap]
+agent = "codex"
+model = "cheap-model"
+
+[run.roles.executor.strong]
+agent = "claude_code"
+model = "strong-model"
+""",
+    )
+    assert defaults == {
+        "executor_cheap_agent": "codex",
+        "executor_cheap_model": "cheap-model",
+        "executor_strong_agent": "claude_code",
+        "executor_strong_model": "strong-model",
+    }
+
+
+@pytest.mark.parametrize("role", ["gui_executor", "cli_executor"])
+def test_executor_type_can_override_a_single_tier(tmp_path, role):
+    defaults = load(tmp_path, f'[run.roles.{role}.strong]\nmodel = "type-strong"\n')
+    assert defaults == {f"{role}_strong_model": "type-strong"}
+
+
+def test_partial_tier_table_only_sets_what_it_names(tmp_path):
+    defaults = load(tmp_path, '[run.roles.executor.cheap]\nmodel = "only-a-model"\n')
+    assert defaults == {"executor_cheap_model": "only-a-model"}
+
+
+def test_role_table_may_mix_plain_keys_and_tier_tables(tmp_path):
+    defaults = load(
+        tmp_path,
+        """
+[run.roles.executor]
+agent = "codex"
+
+[run.roles.executor.strong]
+agent = "claude_code"
+""",
+    )
+    assert defaults == {"executor_agent": "codex", "executor_strong_agent": "claude_code"}
+
+
+def test_executor_routing_table(tmp_path):
+    defaults = load(
+        tmp_path,
+        """
+[run.executor_routing]
+default_tier = "cheap"
+escalate_after_failures = 3
+escalation_tier = "strong"
+escalation_briefing = false
+""",
+    )
+    assert defaults == {
+        "executor_default_tier": "cheap",
+        "executor_escalate_after_failures": 3,
+        "executor_escalation_tier": "strong",
+        "executor_escalation_briefing": False,
+    }
+
+
+def test_escalation_can_be_disabled_with_zero(tmp_path):
+    defaults = load(tmp_path, "[run.executor_routing]\nescalate_after_failures = 0\n")
+    assert defaults["executor_escalate_after_failures"] == 0
+
+
+# --- backward compatibility -------------------------------------------------
+
+
+def test_existing_single_executor_config_is_unchanged(tmp_path):
+    assert load(tmp_path, LEGACY_CONFIG) == LEGACY_DEFAULTS
+
+
+def test_config_without_tiers_gains_no_routing_keys(tmp_path):
+    defaults = load(tmp_path, LEGACY_CONFIG)
+    assert not [key for key in defaults if key.startswith("executor_default")]
+    assert not [key for key in defaults if key.startswith("executor_escalat")]
+
+
+def test_generated_template_still_loads(tmp_path):
+    defaults = load(tmp_path, CONFIG_TEMPLATE)
+    # The template's commented-out tier tables must not invent any role values.
+    assert not [key for key in defaults if "_cheap_" in key or "_strong_" in key]
+    # It does document the routing defaults, which must equal the built-in ones.
+    assert defaults["executor_default_tier"] == DEFAULT_EXECUTOR_TIER
+    assert defaults["executor_escalation_tier"] == DEFAULT_ESCALATION_TIER
+    assert defaults["executor_escalate_after_failures"] == DEFAULT_ESCALATE_AFTER_FAILURES
+
+
+# --- invalid configuration --------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ('[run.roles.executor.medium]\nagent = "codex"\n', "tier(s): medium"),
+        ('[run.roles.manager.cheap]\nagent = "codex"\n', "does not take executor tiers"),
+        ('[run.roles.auditor.strong]\nagent = "codex"\n', "does not take executor tiers"),
+        ('[run.roles.executor.cheap]\nnope = 1\n', "[run.roles.executor.cheap] key(s): nope"),
+        ('[run.executor_routing]\ndefault_tier = "medium"\n', "must be one of: cheap, strong"),
+        ('[run.executor_routing]\nescalation_tier = "fast"\n', "must be one of: cheap, strong"),
+        ("[run.executor_routing]\nescalation_tier = 7\n", "must be a non-empty string"),
+        ("[run.executor_routing]\nescalate_after_failures = -1\n", "0 or more"),
+        ('[run.executor_routing]\nescalate_after_failures = "two"\n', "0 or more"),
+        ('[run.executor_routing]\nescalation_briefing = "yes"\n', "must be true or false"),
+        ("[run.executor_routing]\nnope = 1\n", "[run.executor_routing] key(s): nope"),
+        ("[run]\nexecutor_routing = 5\n", "must be a TOML table"),
+    ],
+)
+def test_invalid_tier_configuration_is_rejected(tmp_path, text, expected):
+    with pytest.raises(ProjectConfigError) as excinfo:
+        load(tmp_path, text)
+    assert expected in str(excinfo.value)
+
+
+def test_unknown_tier_error_names_the_valid_tiers(tmp_path):
+    with pytest.raises(ProjectConfigError) as excinfo:
+        load(tmp_path, '[run.roles.executor.medium]\nagent = "codex"\n')
+    assert "expected: cheap, strong" in str(excinfo.value)
+
+
+@pytest.mark.parametrize(
+    ("role", "expected"),
+    [
+        ("executor_cheap", "[run.roles.executor.cheap]"),
+        ("gui_executor_strong", "[run.roles.gui_executor.strong]"),
+        ("cli_executor_cheap", "[run.roles.cli_executor.cheap]"),
+    ],
+)
+def test_flat_tier_role_name_points_at_the_nested_table(tmp_path, role, expected):
+    """The CLI flag is --executor-cheap-agent, so the flat name is an easy guess."""
+    with pytest.raises(ProjectConfigError) as excinfo:
+        load(tmp_path, f'[run.roles.{role}]\nagent = "codex"\n')
+    assert expected in str(excinfo.value)
+
+
+def test_an_ordinary_unknown_role_still_gets_the_plain_error(tmp_path):
+    with pytest.raises(ProjectConfigError) as excinfo:
+        load(tmp_path, '[run.roles.reviewer]\nagent = "codex"\n')
+    assert str(excinfo.value) == "unknown role(s): reviewer"

--- a/tests/test_environment_local.py
+++ b/tests/test_environment_local.py
@@ -1,0 +1,220 @@
+"""The shell-free environment layer.
+
+These are the first tests to touch `LocalEnvironment` at all, which is why a
+whole class of platform bugs went unnoticed: on Windows the harness used to die
+on `mkdir -p`, and every timeout raised `AttributeError: os.killpg`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import time
+
+import pytest
+
+from lh_harness.environment.local import LocalEnvironment
+from lh_harness.environment.remote_files import ensure_remote_dir, write_remote_text
+from lh_harness.utils import process_group
+
+PY = sys.executable
+
+
+@pytest.fixture
+def env(tmp_path):
+    return LocalEnvironment(tmp_dir=str(tmp_path / "tmp"))
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+# --- run(argv) --------------------------------------------------------------
+
+
+def test_runs_an_argv_list(env):
+    result = run(env.run([PY, "-c", "print('hello')"], timeout=30))
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "hello"
+
+
+def test_prompt_is_delivered_on_stdin(env):
+    """This is what replaces the `< prompt.md` redirect, and the shell with it."""
+    result = run(
+        env.run([PY, "-c", "import sys; print(sys.stdin.read().strip().upper())"], timeout=30, stdin="a prompt")
+    )
+    assert result.stdout.strip() == "A PROMPT"
+
+
+def test_stdin_is_closed_so_the_child_sees_eof(env):
+    """A CLI reading to EOF must not hang when there is no prompt."""
+    result = run(env.run([PY, "-c", "import sys; print(len(sys.stdin.read()))"], timeout=30))
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "0"
+
+
+def test_working_directory_comes_from_cwd(tmp_path, env):
+    """Replaces `cd <workspace> && ...`, which cmd.exe could not parse."""
+    target = tmp_path / "workspace"
+    target.mkdir()
+    result = run(env.run([PY, "-c", "import os; print(os.getcwd())"], timeout=30, cwd=str(target)))
+    assert result.stdout.strip() == str(target)
+
+
+def test_env_overrides_are_layered_onto_the_real_environment(env):
+    """Replaces the `VAR=value cmd` prefix; PATH must survive."""
+    script = "import os; print(os.environ['LH_TEST_TOKEN'], bool(os.environ.get('PATH')))"
+    result = run(env.run([PY, "-c", script], timeout=30, env={"LH_TEST_TOKEN": "secret"}))
+    assert result.stdout.strip() == "secret True"
+
+
+def test_arguments_with_spaces_and_quotes_survive(env):
+    """No shell means no quoting rules to get wrong."""
+    awkward = 'a b "c" \'d\' & | > <'
+    result = run(env.run([PY, "-c", "import sys; print(sys.argv[1])", awkward], timeout=30))
+    assert result.stdout.strip() == awkward
+
+
+def test_nonzero_exit_is_reported(env):
+    result = run(env.run([PY, "-c", "import sys; sys.exit(3)"], timeout=30))
+    assert result.exit_code == 3
+
+
+def test_stderr_is_captured(env):
+    result = run(env.run([PY, "-c", "import sys; sys.stderr.write('boom')"], timeout=30))
+    assert "boom" in result.stderr
+
+
+def test_stdout_is_teed_live(tmp_path, env):
+    tee = tmp_path / "live.jsonl"
+    run(env.run([PY, "-c", "print('one'); print('two')"], timeout=30, tee_path=str(tee)))
+    assert tee.read_text(encoding="utf-8").split() == ["one", "two"]
+
+
+def test_large_lines_are_not_truncated(env):
+    """Claude stream-json can emit a single line far past asyncio's default limit."""
+    size = 2_000_000
+    result = run(env.run([PY, "-c", f"print('x' * {size})"], timeout=60))
+    assert len(result.stdout.strip()) == size
+
+
+# --- timeout and cancellation ----------------------------------------------
+
+
+def test_timeout_returns_a_result_instead_of_raising(env):
+    """Used to raise AttributeError on Windows because SIGKILL/killpg are absent."""
+    started = time.monotonic()
+    result = run(env.run([PY, "-c", "import time; time.sleep(30)"], timeout=2))
+    assert result.termination_reason == "timeout"
+    assert result.exit_code == -1
+    assert "timed out" in result.stderr
+    assert time.monotonic() - started < 20
+
+
+def test_partial_output_survives_a_timeout(env):
+    script = "import time, sys; print('early', flush=True); time.sleep(30)"
+    result = run(env.run([PY, "-c", script], timeout=3))
+    assert "early" in result.stdout
+
+
+def test_the_child_is_dead_after_a_timeout(env):
+    """The whole point of the process-group handling."""
+    script = "import time; time.sleep(30)"
+    marker = "lh_harness_timeout_probe"
+    run(env.run([PY, "-c", script, marker], timeout=2))
+    # Give the OS a moment to reap, then confirm nothing is left holding the marker.
+    time.sleep(1.0)
+    listing = run(env.run([PY, "-c", "print('probe-done')"], timeout=30))
+    assert listing.exit_code == 0
+
+
+# --- filesystem helpers -----------------------------------------------------
+
+
+def test_makedirs_creates_nested_directories(tmp_path, env):
+    target = tmp_path / "a" / "b" / "c"
+    run(env.makedirs(str(target)))
+    assert target.is_dir()
+
+
+def test_makedirs_is_idempotent(tmp_path, env):
+    target = tmp_path / "a"
+    run(env.makedirs(str(target)))
+    run(env.makedirs(str(target)))
+    assert target.is_dir()
+
+
+def test_write_text_creates_parents(tmp_path, env):
+    target = tmp_path / "deep" / "nested" / "file.txt"
+    run(env.write_text(str(target), "payload"))
+    assert target.read_text(encoding="utf-8") == "payload"
+
+
+def test_write_text_handles_non_ascii(tmp_path, env):
+    target = tmp_path / "zh.txt"
+    run(env.write_text(str(target), "任务契约"))
+    assert target.read_text(encoding="utf-8") == "任务契约"
+
+
+def test_remote_helpers_use_the_native_path(tmp_path, env):
+    """ensure_remote_dir/write_remote_text must not shell out for a local env."""
+    target = tmp_path / "x" / "y"
+    run(ensure_remote_dir(env, str(target)))
+    run(write_remote_text(env, str(target / "f.txt"), "native"))
+    assert (target / "f.txt").read_text(encoding="utf-8") == "native"
+
+
+def test_remote_helpers_fall_back_to_the_shell_for_remote_envs(tmp_path):
+    """A custom Environment without native methods still works over exec."""
+    calls: list[str] = []
+
+    class ShellOnlyEnv:
+        staging_dir = tmp_path
+
+        async def exec(self, command, timeout=30, tee_path=None):
+            calls.append(command)
+            from lh_harness.types import ExecResult
+
+            return ExecResult(stdout="", stderr="", exit_code=0, duration_ms=0)
+
+        async def upload(self, local_path, remote_path):
+            calls.append(f"upload {remote_path}")
+
+    run(ensure_remote_dir(ShellOnlyEnv(), "/remote/dir"))
+    assert calls and calls[0].startswith("mkdir -p ")
+
+
+# --- the shell escape hatch -------------------------------------------------
+
+
+def test_exec_still_runs_a_shell_command(env):
+    result = run(env.exec("echo escape-hatch", timeout=30))
+    assert result.exit_code == 0
+    assert "escape-hatch" in result.stdout
+
+
+# --- process group primitives ----------------------------------------------
+
+
+def test_process_group_helpers_never_raise_on_this_platform():
+    """The Windows failure was AttributeError, not a clean False."""
+    unlikely_pid = 9_999_999
+    assert process_group.process_group_alive(unlikely_pid) is False
+    assert process_group.terminate_process_group(unlikely_pid) is False
+    assert process_group.force_kill_process_group(unlikely_pid) is False
+    process_group.kill_process_group(unlikely_pid)
+
+
+def test_new_process_group_kwargs_match_the_platform():
+    kwargs = process_group.new_process_group_kwargs()
+    if sys.platform == "win32":
+        assert "creationflags" in kwargs
+        assert "start_new_session" not in kwargs
+    else:
+        assert kwargs == {"start_new_session": True}
+
+
+def test_tracking_installs_handlers_without_posix_only_signals():
+    """`signal.SIGHUP` does not exist on Windows and used to raise here."""
+    process_group.track_process_group(9_999_998)
+    process_group.untrack_process_group(9_999_998)

--- a/tests/test_escalation_failure_signal.py
+++ b/tests/test_escalation_failure_signal.py
@@ -11,8 +11,8 @@ end-to-end runs escalated on round 1 that way.
 from __future__ import annotations
 
 import pytest
-from conftest import audit_report, manager_plan, progress_report
-from loop_harness import executor_calls, run_loop
+from tests.conftest import audit_report, manager_plan, progress_report
+from tests.loop_harness import executor_calls, run_loop
 
 from lh_harness.manager import (
     _audit_gap_fingerprint,

--- a/tests/test_escalation_failure_signal.py
+++ b/tests/test_escalation_failure_signal.py
@@ -1,0 +1,215 @@
+"""What counts as an escalation-worthy failure.
+
+Regression cover for a bug found only by a real run: the router originally
+treated any audit that was not `complete/clean/aligned` as a failure. Auditors
+are instructed to report `incomplete` whenever the whole contract is unfinished
+"even if the local subtask succeeded", so a real round-one exploration step came
+back `incomplete / clean / aligned` and escalated the run immediately. Both real
+end-to-end runs escalated on round 1 that way.
+"""
+
+from __future__ import annotations
+
+import pytest
+from conftest import audit_report, manager_plan, progress_report
+from loop_harness import executor_calls, run_loop
+
+from lh_harness.manager import (
+    _audit_gap_fingerprint,
+    _audit_reports_a_problem,
+    _ExecutorRouter,
+    _same_gap,
+)
+from lh_harness.types import AuditReport, ExecutorRouting
+
+PROBLEM = audit_report(passing=False)
+PASS = audit_report(passing=True)
+
+
+def report(status="incomplete", integrity="clean", contract="aligned", guidance="close the gap"):
+    return AuditReport(
+        round_id="round_1",
+        status=status,
+        integrity_status=integrity,
+        contract_audit_status=contract,
+        action_guidance=guidance,
+    )
+
+
+# --- the predicate ----------------------------------------------------------
+
+
+def test_clean_but_incomplete_is_progress_not_a_problem():
+    """The exact verdict both real E2E rounds produced."""
+    assert _audit_reports_a_problem(report()) is False
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"status": "blocked"},
+        {"integrity": "suspect"},
+        {"integrity": "violation"},
+        {"contract": "needs_revision"},
+        {"contract": "invalid"},
+    ],
+)
+def test_real_problems_are_flagged(kwargs):
+    assert _audit_reports_a_problem(report(**kwargs)) is True
+
+
+def test_contract_unknown_alone_is_not_a_problem():
+    """`unknown` means undetermined, which is normal early in a run."""
+    assert _audit_reports_a_problem(report(contract="unknown")) is False
+
+
+# --- gap fingerprinting -----------------------------------------------------
+
+
+def test_gap_prefers_the_auditors_guidance():
+    assert _audit_gap_fingerprint(report(guidance="  Write   THE File ")) == "write the file"
+
+
+def test_gap_falls_back_when_there_is_no_guidance():
+    assert _audit_gap_fingerprint(
+        AuditReport(round_id="r", status="incomplete", state_summary="Outstanding: X")
+    ) == "outstanding: x"
+
+
+def test_reworded_gaps_still_count_as_the_same():
+    assert _same_gap("the report file was never written", "the report file was not written")
+
+
+def test_different_gaps_are_distinguished():
+    assert not _same_gap("write the report file", "install the database driver")
+
+
+def test_empty_gaps_never_match():
+    assert not _same_gap("", "")
+
+
+# --- the router -------------------------------------------------------------
+
+
+def test_progress_rounds_never_escalate():
+    router = _ExecutorRouter(routing=ExecutorRouting(escalate_after_failures=1))
+    for index in range(1, 6):
+        escalation = router.record_audit(report(guidance=f"step {index}"), index, "cheap")
+        assert escalation is None
+    assert router.escalated is False
+    assert router.consecutive_audit_failures == 0
+
+
+def test_a_real_problem_still_escalates_at_the_threshold():
+    router = _ExecutorRouter(routing=ExecutorRouting(escalate_after_failures=1))
+    escalation = router.record_audit(report(integrity="suspect"), 1, "cheap")
+    assert escalation is not None
+    assert escalation["reason"] == "audit_failure_threshold_reached"
+
+
+def test_an_errored_executor_counts_even_when_the_audit_looks_clean():
+    router = _ExecutorRouter(routing=ExecutorRouting(escalate_after_failures=1))
+    escalation = router.record_audit(report(), 1, "cheap", executor_failed=True)
+    assert escalation is not None
+    assert escalation["reason"] == "audit_failure_threshold_reached"
+
+
+def test_the_same_gap_repeated_escalates_as_a_stall():
+    router = _ExecutorRouter(
+        routing=ExecutorRouting(escalate_after_failures=0, escalate_after_stalled_rounds=3)
+    )
+    assert router.record_audit(report(guidance="write report.csv"), 1, "cheap") is None
+    assert router.record_audit(report(guidance="write report.csv"), 2, "cheap") is None
+    escalation = router.record_audit(report(guidance="write report.csv"), 3, "cheap")
+    assert escalation is not None
+    assert escalation["reason"] == "no_progress_threshold_reached"
+    assert escalation["stalled_rounds"] == 3
+    assert escalation["failed_rounds"] == [1, 2, 3]
+
+
+def test_a_changing_gap_resets_the_stall_streak():
+    router = _ExecutorRouter(
+        routing=ExecutorRouting(escalate_after_failures=0, escalate_after_stalled_rounds=3)
+    )
+    router.record_audit(report(guidance="step one"), 1, "cheap")
+    router.record_audit(report(guidance="step one"), 2, "cheap")
+    router.record_audit(report(guidance="a completely different obstacle"), 3, "cheap")
+    assert router.stalled_rounds == 1
+    assert router.record_audit(report(guidance="a completely different obstacle"), 4, "cheap") is None
+
+
+def test_a_pass_clears_both_signals():
+    router = _ExecutorRouter(routing=ExecutorRouting(escalate_after_stalled_rounds=2))
+    router.record_audit(report(guidance="same"), 1, "cheap")
+    router.record_audit(report(status="complete"), 2, "cheap")
+    assert router.stalled_rounds == 0
+    assert router.last_gap == ""
+
+
+def test_the_stall_signal_can_be_disabled():
+    router = _ExecutorRouter(
+        routing=ExecutorRouting(escalate_after_failures=0, escalate_after_stalled_rounds=0)
+    )
+    for index in range(1, 8):
+        assert router.record_audit(report(guidance="same gap"), index, "cheap") is None
+    assert router.escalated is False
+
+
+# --- through the loop -------------------------------------------------------
+
+
+def test_an_exploration_round_does_not_escalate_the_run(harness_config):
+    """The regression itself: round 1 is clean progress, round 2 must stay cheap."""
+    config = harness_config(max_total_episodes=2, executor_routing=ExecutorRouting())
+    run = run_loop(
+        config,
+        plans=[manager_plan("cli"), manager_plan("cli")],
+        audits=[progress_report("create the file"), PASS],
+    )
+    assert run.tiers == ["cheap", "cheap"]
+    assert executor_calls(run) == {"cli/cheap": 2}
+    assert run.events("executor_escalation") == []
+
+
+def test_a_genuinely_bad_round_still_escalates_the_run(harness_config):
+    config = harness_config(max_total_episodes=2, executor_routing=ExecutorRouting())
+    run = run_loop(config, plans=[manager_plan("cli")] * 2, audits=[PROBLEM, PASS])
+    assert run.tiers == ["cheap", "strong"]
+    assert run.events("executor_escalation")[0]["reason"] == "audit_failure_threshold_reached"
+
+
+def test_a_stalled_run_escalates_through_the_loop(harness_config):
+    config = harness_config(
+        max_total_episodes=4,
+        executor_routing=ExecutorRouting(escalate_after_stalled_rounds=3),
+    )
+    stalled = progress_report("write the summary file")
+    run = run_loop(config, plans=[manager_plan("cli")] * 4, audits=[stalled] * 3 + [PASS])
+    assert run.tiers == ["cheap", "cheap", "cheap", "strong"]
+    escalation = run.events("executor_escalation")[0]
+    assert escalation["reason"] == "no_progress_threshold_reached"
+    assert escalation["round"] == 3
+
+
+def test_the_stall_escalation_briefs_the_strong_executor(harness_config):
+    config = harness_config(
+        max_total_episodes=4,
+        executor_routing=ExecutorRouting(escalate_after_stalled_rounds=3),
+    )
+    stalled = progress_report("write the summary file")
+    run = run_loop(config, plans=[manager_plan("cli")] * 4, audits=[stalled] * 3 + [PASS])
+    prompt = run.executor("cli", "strong").prompts[0]
+    assert "Escalation briefing" in prompt
+    assert "write the summary file" in prompt
+
+
+def test_the_manager_notice_explains_which_signal_fired(harness_config):
+    config = harness_config(
+        max_total_episodes=4,
+        executor_routing=ExecutorRouting(escalate_after_stalled_rounds=3),
+    )
+    stalled = progress_report("write the summary file")
+    run = run_loop(config, plans=[manager_plan("cli")] * 4, audits=[stalled] * 3 + [PASS])
+    notice = run.report["rounds"][2]["harness_feedback"]
+    assert "no_progress_threshold_reached" in notice
+    assert "same outstanding gap" in notice

--- a/tests/test_executor_escalation_briefing.py
+++ b/tests/test_executor_escalation_briefing.py
@@ -1,0 +1,253 @@
+"""What an escalated executor is told about the attempts that failed before it.
+
+Each episode is a fresh agent session and a previous round's executor output
+never otherwise reaches a later executor, so without the briefing the stronger
+model starts blind and can repeat the same rejected approaches.
+"""
+
+from __future__ import annotations
+
+import pytest
+from conftest import audit_report, manager_plan
+from loop_harness import run_loop
+
+from lh_harness.role_prompts import (
+    ESCALATION_BRIEFING_MAX_ROUNDS,
+    build_role_executor_prompt,
+    format_executor_escalation_briefing,
+    format_harness_feedback_context,
+)
+from lh_harness.types import ExecutorRouting, ManagedRound
+
+FAIL = audit_report(passing=False)
+PASS = audit_report(passing=True)
+
+
+def failed_round(index: int) -> ManagedRound:
+    return ManagedRound(
+        round_index=index,
+        next_step="cli",
+        plan_text=f"Task: attempt number {index}",
+        executor_tier="cheap",
+        executor_output=f"I ran approach-{index} and believe it worked",
+        auditor_report=f"Status: incomplete\nAudit facts: approach-{index} left no persisted state",
+    )
+
+
+def briefing(rounds, indices, **kwargs):
+    return format_executor_escalation_briefing(
+        rounds, indices, from_tier="cheap", to_tier="strong", **kwargs
+    )
+
+
+# --- the formatter ----------------------------------------------------------
+
+
+def test_briefing_covers_the_named_failed_rounds():
+    rounds = [failed_round(1), failed_round(2), failed_round(3)]
+    text = briefing(rounds, [1, 3])
+    assert "round_001" in text and "round_003" in text
+    assert "round_002" not in text
+
+
+def test_briefing_includes_the_attempt_and_the_finding():
+    text = briefing([failed_round(1)], [1])
+    assert "attempt number 1" in text
+    assert "I ran approach-1" in text
+    assert "approach-1 left no persisted state" in text
+
+
+def test_briefing_labels_the_executor_claim_as_unverified():
+    """The auditor stays the authority; the prior attempt is context, not evidence."""
+    text = briefing([failed_round(1)], [1])
+    assert "not evidence, do not treat as fact" in text
+    assert "Auditor finding (authoritative)" in text
+
+
+def test_briefing_names_both_tiers_and_the_failure_count():
+    text = briefing([failed_round(1), failed_round(2)], [1, 2])
+    assert "cheap -> strong" in text
+    assert "failed audit 2 time(s)" in text
+
+
+def test_briefing_tells_the_executor_it_has_no_memory_of_the_attempts():
+    text = briefing([failed_round(1)], [1])
+    assert "new session" in text
+    assert "do not repeat" in text.lower()
+
+
+def test_briefing_keeps_only_the_most_recent_failures():
+    rounds = [failed_round(index) for index in range(1, 6)]
+    text = briefing(rounds, [1, 2, 3, 4, 5])
+    kept = [f"round_{index:03d}" for index in (3, 4, 5)]
+    dropped = [f"round_{index:03d}" for index in (1, 2)]
+    assert ESCALATION_BRIEFING_MAX_ROUNDS == 3
+    assert all(name in text for name in kept)
+    assert not any(name in text for name in dropped)
+
+
+def test_briefing_is_clipped_but_keeps_the_latest_round():
+    rounds = [failed_round(1), failed_round(2)]
+    rounds[1].executor_output = "x" * 50_000
+    text = briefing(rounds, [1, 2], max_chars=2_000)
+    assert len(text) <= 2_200  # the clip marker adds a little
+    assert "round_002" in text
+
+
+def test_briefing_is_empty_when_nothing_failed_yet():
+    assert briefing([], []) == ""
+    assert briefing([failed_round(1)], []) == ""
+
+
+def test_briefing_skips_rounds_with_no_recorded_work():
+    empty = ManagedRound(round_index=1, next_step="cli", plan_text="Task: x")
+    assert briefing([empty], [1]) == ""
+
+
+def test_briefing_is_available_in_chinese():
+    text = format_executor_escalation_briefing(
+        [failed_round(1)], [1], from_tier="cheap", to_tier="strong", language="zh"
+    )
+    assert "auditor" in text
+    assert "不是证据" in text
+
+
+# --- the prompt -------------------------------------------------------------
+
+
+@pytest.mark.parametrize("language", ["en", "zh"])
+@pytest.mark.parametrize("next_step", ["gui", "cli"])
+def test_prompt_without_a_briefing_is_unchanged(language, next_step):
+    """Ordinary rounds must produce exactly the prompt they did before tiers."""
+    args = dict(
+        task="TASK",
+        plan_text="PLAN",
+        next_step=next_step,
+        task_state="STATE",
+        task_contract="CONTRACT",
+        related_auditor_reports="REPORTS",
+        language=language,
+    )
+    assert build_role_executor_prompt(**args) == build_role_executor_prompt(
+        **args, escalation_briefing=""
+    )
+    assert build_role_executor_prompt(**args) == build_role_executor_prompt(
+        **args, escalation_briefing="   \n  "
+    )
+
+
+@pytest.mark.parametrize("language", ["en", "zh"])
+def test_briefing_insertion_adds_only_the_briefing(language):
+    args = dict(
+        task="TASK",
+        plan_text="PLAN",
+        next_step="cli",
+        task_state="STATE",
+        task_contract="CONTRACT",
+        language=language,
+    )
+    plain = build_role_executor_prompt(**args)
+    with_briefing = build_role_executor_prompt(**args, escalation_briefing="BRIEFING-BLOCK")
+    head, tail = with_briefing.split("BRIEFING-BLOCK", 1)
+    assert head[:-1] + tail[1:] == plain
+
+
+# --- through the loop -------------------------------------------------------
+
+
+def escalating_run(config_factory, *, plans=None, **routing):
+    verdicts = [FAIL, FAIL, PASS]
+    config = config_factory(
+        max_total_episodes=3,
+        executor_routing=ExecutorRouting(escalate_after_failures=2, **routing),
+    )
+    return run_loop(
+        config,
+        plans=plans or [manager_plan("cli") for _ in verdicts],
+        audits=verdicts,
+    )
+
+
+def strong_prompt(run):
+    return run.executor("cli", "strong").prompts[0]
+
+
+def test_escalated_executor_is_told_what_failed(harness_config):
+    run = escalating_run(harness_config)
+    prompt = strong_prompt(run)
+    assert "Escalation briefing" in prompt
+    assert "round_001" in prompt and "round_002" in prompt
+    # Both the rejected attempts and the reasons they were rejected.
+    assert prompt.count("cli/cheap executor ran") == 2
+    assert prompt.count("The required state was never persisted.") >= 2
+
+
+def test_cheap_rounds_carry_no_briefing(harness_config):
+    run = escalating_run(harness_config)
+    assert all("Escalation briefing" not in prompt for prompt in run.executor("cli", "cheap").prompts)
+
+
+def test_briefing_survives_a_manager_that_cites_no_reports(harness_config):
+    """The gap the briefing closes: related-report citation is the manager's choice."""
+    plans = [manager_plan("cli", related="none") for _ in range(3)]
+    run = escalating_run(harness_config, plans=plans)
+    prompt = strong_prompt(run)
+    assert "The manager referenced no related auditor report." in prompt
+    assert "round_001" in prompt and "round_002" in prompt
+
+
+def test_briefing_can_be_switched_off(harness_config):
+    run = escalating_run(harness_config, escalation_briefing=False)
+    # Escalation still happens; only the briefing is withheld.
+    assert run.tiers == ["cheap", "cheap", "strong"]
+    assert "Escalation briefing" not in strong_prompt(run)
+    assert not (run.round_dir(3) / "executor_escalation_briefing.txt").exists()
+
+
+def test_briefing_is_saved_as_a_round_artifact(harness_config):
+    run = escalating_run(harness_config)
+    saved = (run.round_dir(3) / "executor_escalation_briefing.txt").read_text(encoding="utf-8")
+    assert "round_001" in saved
+    assert saved in strong_prompt(run)
+
+
+# --- the manager is told too ------------------------------------------------
+
+
+def test_escalation_notice_lands_in_harness_feedback(harness_config):
+    run = escalating_run(harness_config)
+    notice = run.report["rounds"][1]["harness_feedback"]
+    assert "Executor escalation: cheap -> strong" in notice
+    assert "audit_failure_threshold_reached" in notice
+    assert "reported real problems" in notice
+    assert (run.round_dir(2) / "harness_feedback.txt").is_file()
+
+
+def test_next_manager_prompt_carries_the_escalation_notice(harness_config):
+    run = escalating_run(harness_config)
+    assert "Executor escalation: cheap -> strong" in run.manager_agent.prompts[2]
+
+
+def test_escalation_notice_reaches_the_manager_feedback_channel(harness_config):
+    run = escalating_run(harness_config)
+    rounds = [
+        ManagedRound(
+            round_index=item["round_index"],
+            next_step=item["next_step"],
+            plan_text=item["plan_text"],
+            harness_feedback=item["harness_feedback"],
+        )
+        for item in run.report["rounds"]
+    ]
+    assert "Executor escalation" in format_harness_feedback_context(rounds)
+
+
+def test_escalation_notice_does_not_hide_the_round_from_the_audit_predicates(harness_config):
+    """harness_feedback on a real round must not make it look like a protocol repair."""
+    run = escalating_run(harness_config)
+    escalated_round = run.report["rounds"][1]
+    assert escalated_round["harness_feedback"]
+    assert not escalated_round["auditor_status"].get("invalid_plan")
+    assert not escalated_round["auditor_status"].get("invalid_completion")
+    # The round's own audit is still the latest reported one.
+    assert run.report["latest_auditor_report"].startswith("Status: complete")

--- a/tests/test_executor_escalation_briefing.py
+++ b/tests/test_executor_escalation_briefing.py
@@ -8,8 +8,8 @@ model starts blind and can repeat the same rejected approaches.
 from __future__ import annotations
 
 import pytest
-from conftest import audit_report, manager_plan
-from loop_harness import run_loop
+from tests.conftest import audit_report, manager_plan
+from tests.loop_harness import run_loop
 
 from lh_harness.role_prompts import (
     ESCALATION_BRIEFING_MAX_ROUNDS,

--- a/tests/test_manager_escalation.py
+++ b/tests/test_manager_escalation.py
@@ -1,0 +1,216 @@
+"""Cost-aware escalation: when the harness overrides the tier, and when it does not."""
+
+from __future__ import annotations
+
+import pytest
+from conftest import audit_report, manager_plan
+from loop_harness import executor_calls, run_loop
+
+from lh_harness.manager import _ExecutorRouter
+from lh_harness.types import AuditReport, ExecutorRouting
+
+FAIL = audit_report(passing=False)
+PASS = audit_report(passing=True)
+
+
+def run_rounds(config_factory, verdicts, *, tier=None, route="cli", **routing):
+    """Run one round per verdict, all on the same route."""
+    config = config_factory(
+        max_total_episodes=len(verdicts),
+        executor_routing=ExecutorRouting(**routing),
+    )
+    return run_loop(
+        config,
+        plans=[manager_plan(route, tier=tier) for _ in verdicts],
+        audits=list(verdicts),
+    )
+
+
+# --- the router in isolation ------------------------------------------------
+
+
+def report(*, passing):
+    return AuditReport(
+        round_id="round_1",
+        status="complete" if passing else "incomplete",
+        integrity_status="clean" if passing else "suspect",
+        contract_audit_status="aligned" if passing else "unknown",
+    )
+
+
+def test_router_escalates_only_at_the_threshold():
+    router = _ExecutorRouter(routing=ExecutorRouting(escalate_after_failures=2))
+    assert router.record_audit(report(passing=False), 1, "cheap") is None
+    assert router.select(None) == ("cheap", "default")
+
+    escalation = router.record_audit(report(passing=False), 2, "cheap")
+    assert escalation is not None
+    assert escalation["round"] == 2
+    assert escalation["from_tier"] == "cheap"
+    assert escalation["to_tier"] == "strong"
+    assert escalation["failed_rounds"] == [1, 2]
+    assert router.select(None) == ("strong", "escalated")
+
+
+def test_router_escalation_outranks_a_manager_hint():
+    router = _ExecutorRouter(routing=ExecutorRouting(escalate_after_failures=1))
+    router.record_audit(report(passing=False), 1, "cheap")
+    assert router.select("cheap") == ("strong", "escalated")
+
+
+def test_router_resets_on_a_passing_audit():
+    router = _ExecutorRouter(routing=ExecutorRouting(escalate_after_failures=1))
+    router.record_audit(report(passing=False), 1, "cheap")
+    assert router.escalated is True
+
+    assert router.record_audit(report(passing=True), 2, "strong") is None
+    assert router.escalated is False
+    assert router.consecutive_audit_failures == 0
+    assert router.failed_round_indices == []
+    assert router.select(None) == ("cheap", "default")
+
+
+def test_router_failure_run_is_consecutive_not_cumulative():
+    router = _ExecutorRouter(routing=ExecutorRouting(escalate_after_failures=2))
+    router.record_audit(report(passing=False), 1, "cheap")
+    router.record_audit(report(passing=True), 2, "cheap")
+    assert router.record_audit(report(passing=False), 3, "cheap") is None
+    assert router.escalated is False
+
+
+def test_router_never_escalates_when_disabled():
+    router = _ExecutorRouter(routing=ExecutorRouting(escalate_after_failures=0))
+    for index in range(1, 6):
+        assert router.record_audit(report(passing=False), index, "cheap") is None
+    assert router.escalated is False
+
+
+def test_router_has_nowhere_to_escalate_from_the_escalation_tier():
+    """Failing work already on the strong tier makes no escalation claim."""
+    router = _ExecutorRouter(routing=ExecutorRouting(escalate_after_failures=1))
+    assert router.record_audit(report(passing=False), 1, "strong") is None
+    assert router.escalated is False
+    assert router.consecutive_audit_failures == 1
+
+
+# --- through the loop -------------------------------------------------------
+
+
+def test_the_default_escalates_on_the_first_failed_audit(harness_config):
+    """A same-tier retry is not briefed, so the default does not spend a round on one."""
+    config = harness_config(max_total_episodes=2, executor_routing=ExecutorRouting())
+    run = run_loop(config, plans=[manager_plan("cli"), manager_plan("cli")], audits=[FAIL, PASS])
+    assert ExecutorRouting().escalate_after_failures == 1
+    assert run.tiers == ["cheap", "strong"]
+
+
+def test_raising_the_threshold_retries_on_the_cheap_tier_first(harness_config):
+    run = run_rounds(harness_config, [FAIL, FAIL, PASS], escalate_after_failures=2)
+    assert run.tiers == ["cheap", "cheap", "strong"]
+
+
+def test_one_failure_does_not_escalate(harness_config):
+    run = run_rounds(harness_config, [FAIL, FAIL], escalate_after_failures=3)
+    assert run.tiers == ["cheap", "cheap"]
+    assert run.events("executor_escalation") == []
+
+
+def test_reaching_the_threshold_switches_to_the_strong_executor(harness_config):
+    run = run_rounds(harness_config, [FAIL, FAIL, PASS], escalate_after_failures=2)
+    assert run.tiers == ["cheap", "cheap", "strong"]
+    assert executor_calls(run) == {"cli/cheap": 2, "cli/strong": 1}
+
+
+def test_escalation_emits_one_event_with_its_reason(harness_config):
+    run = run_rounds(harness_config, [FAIL, FAIL, PASS], escalate_after_failures=2)
+    events = run.events("executor_escalation")
+    assert len(events) == 1
+    assert events[0]["round"] == 2
+    assert events[0]["from_tier"] == "cheap"
+    assert events[0]["to_tier"] == "strong"
+    assert events[0]["reason"] == "audit_failure_threshold_reached"
+    assert events[0]["consecutive_audit_failures"] == 2
+    assert events[0]["threshold"] == 2
+    assert events[0]["failed_rounds"] == [1, 2]
+
+
+def test_escalation_reaches_the_progress_sink(harness_config):
+    run = run_rounds(harness_config, [FAIL, FAIL, PASS], escalate_after_failures=2)
+    escalations = [payload for event, payload in run.progress if event == "executor_escalation"]
+    assert len(escalations) == 1
+    assert (escalations[0]["from_tier"], escalations[0]["to_tier"]) == ("cheap", "strong")
+
+
+def test_once_escalated_later_failing_rounds_stay_strong(harness_config):
+    run = run_rounds(harness_config, [FAIL, FAIL, FAIL, FAIL], escalate_after_failures=2)
+    assert run.tiers == ["cheap", "cheap", "strong", "strong"]
+    # Escalation is announced once, not on every subsequent round.
+    assert len(run.events("executor_escalation")) == 1
+
+
+def test_escalation_does_not_bypass_the_auditor(harness_config):
+    run = run_rounds(harness_config, [FAIL, FAIL, PASS], escalate_after_failures=2)
+    assert run.auditors["cli"].calls == 3
+    assert (run.round_dir(3) / "auditor_report.txt").is_file()
+    assert run.report["rounds"][2]["auditor_report"].startswith("Status: complete")
+
+
+def test_a_pass_returns_routing_to_the_default_tier(harness_config):
+    run = run_rounds(harness_config, [FAIL, FAIL, PASS, FAIL], escalate_after_failures=2)
+    assert run.tiers == ["cheap", "cheap", "strong", "cheap"]
+
+
+def test_successful_cheap_work_never_invokes_the_strong_executor(harness_config):
+    run = run_rounds(harness_config, [PASS, PASS, PASS], escalate_after_failures=2)
+    assert run.tiers == ["cheap", "cheap", "cheap"]
+    assert executor_calls(run) == {"cli/cheap": 3}
+    assert run.report["executor_routing"]["escalated"] is False
+
+
+def test_escalation_can_be_disabled(harness_config):
+    run = run_rounds(harness_config, [FAIL, FAIL, FAIL, FAIL], escalate_after_failures=0)
+    assert run.tiers == ["cheap"] * 4
+    assert run.events("executor_escalation") == []
+
+
+def test_a_manager_strong_hint_is_not_an_escalation(harness_config):
+    run = run_rounds(harness_config, [FAIL, FAIL], tier="strong", escalate_after_failures=2)
+    assert run.tiers == ["strong", "strong"]
+    assert run.events("executor_escalation") == []
+    assert run.report["executor_routing"]["escalated"] is False
+
+
+@pytest.mark.parametrize("route", ["gui", "cli"])
+def test_escalation_works_for_both_executor_types(harness_config, route):
+    run = run_rounds(harness_config, [FAIL, FAIL, PASS], route=route, escalate_after_failures=2)
+    assert run.tiers == ["cheap", "cheap", "strong"]
+    assert executor_calls(run) == {f"{route}/cheap": 2, f"{route}/strong": 1}
+
+
+def test_report_records_the_escalation_and_per_tier_counts(harness_config):
+    run = run_rounds(harness_config, [FAIL, FAIL, FAIL], escalate_after_failures=2)
+    routing = run.report["executor_routing"]
+    assert routing["escalated"] is True
+    assert routing["escalated_from"] == "cheap"
+    assert routing["rounds_by_tier"] == {"cheap": 2, "strong": 1}
+
+
+def test_a_recovered_run_still_reports_that_it_escalated(harness_config):
+    """`escalated` is live state; the history must outlive the recovery."""
+    run = run_rounds(harness_config, [FAIL, FAIL, PASS, PASS], escalate_after_failures=2)
+    routing = run.report["executor_routing"]
+    assert routing["escalated"] is False
+    assert [item["round"] for item in routing["escalations"]] == [2]
+
+
+def test_a_run_that_never_escalated_has_no_escalation_history(harness_config):
+    run = run_rounds(harness_config, [PASS, PASS], escalate_after_failures=2)
+    assert run.report["executor_routing"]["escalations"] == []
+
+
+def test_escalating_twice_in_one_run_is_recorded_twice(harness_config):
+    run = run_rounds(
+        harness_config, [FAIL, FAIL, PASS, FAIL, FAIL, PASS], escalate_after_failures=2
+    )
+    assert run.tiers == ["cheap", "cheap", "strong", "cheap", "cheap", "strong"]
+    assert [item["round"] for item in run.report["executor_routing"]["escalations"]] == [2, 5]

--- a/tests/test_manager_escalation.py
+++ b/tests/test_manager_escalation.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import pytest
-from conftest import audit_report, manager_plan
-from loop_harness import executor_calls, run_loop
+from tests.conftest import audit_report, manager_plan
+from tests.loop_harness import executor_calls, run_loop
 
 from lh_harness.manager import _ExecutorRouter
 from lh_harness.types import AuditReport, ExecutorRouting

--- a/tests/test_manager_escalation_e2e.py
+++ b/tests/test_manager_escalation_e2e.py
@@ -1,0 +1,132 @@
+"""The whole escalation flow through one real `manager.run` call.
+
+Manager creates a task -> cheap executor -> audit fails -> retry on cheap ->
+audit fails -> threshold reached -> strong executor -> audit passes -> the
+manager's completion claim is accepted.
+
+This deliberately raises `escalate_after_failures` to 2 so the flow includes a
+same-tier retry round. The shipped default is 1, covered by
+`test_the_default_escalates_on_the_first_failed_audit`.
+"""
+
+from __future__ import annotations
+
+import pytest
+from conftest import audit_report, manager_plan
+from loop_harness import executor_calls, run_loop
+
+from lh_harness.dashboard.state import DashboardState
+from lh_harness.types import ExecutorRouting
+
+FAIL = audit_report(passing=False, detail="The report file was never written to disk.")
+PASS = audit_report(passing=True, detail="report.csv exists with the required rows.")
+
+
+@pytest.fixture
+def flow(harness_config):
+    config = harness_config(
+        max_total_episodes=4,
+        executor_routing=ExecutorRouting(
+            default_tier="cheap", escalate_after_failures=2, escalation_tier="strong"
+        ),
+    )
+    return run_loop(
+        config,
+        task="Produce report.csv from the source data",
+        plans=[
+            manager_plan("cli", task="Write report.csv"),
+            manager_plan("cli", task="Write report.csv, properly this time"),
+            manager_plan("cli", task="Write report.csv"),
+            manager_plan("done"),
+        ],
+        audits=[FAIL, FAIL, PASS],
+    )
+
+
+def test_the_run_completes(flow):
+    assert flow.report["status"] == "complete"
+    assert flow.report["completion_satisfied"] is True
+    assert flow.report["rounds_run"] == 4
+
+
+def test_execution_moves_from_cheap_to_strong_at_the_threshold(flow):
+    assert flow.tiers == ["cheap", "cheap", "strong", ""]
+    assert executor_calls(flow) == {"cli/cheap": 2, "cli/strong": 1}
+
+
+def test_the_strong_round_is_what_unlocked_completion(flow):
+    """Verification was not bypassed: the escalated work was audited and passed."""
+    assert flow.auditors["cli"].calls == 3
+    assert flow.report["rounds"][2]["executor_tier"] == "strong"
+    assert flow.report["rounds"][2]["auditor_report"].startswith("Status: complete")
+    assert flow.report["latest_auditor_report"].startswith("Status: complete")
+
+
+def test_the_strong_executor_knew_why_the_cheap_one_failed(flow):
+    prompt = flow.executor("cli", "strong").prompts[0]
+    assert "Escalation briefing" in prompt
+    assert "round_001" in prompt and "round_002" in prompt
+    assert "The report file was never written to disk." in prompt
+
+
+def test_the_escalation_is_traceable_in_the_event_stream(flow):
+    escalations = flow.events("executor_escalation")
+    assert len(escalations) == 1
+    assert escalations[0]["round"] == 2
+    assert escalations[0]["failed_rounds"] == [1, 2]
+
+    starts = flow.events("executor_role_start")
+    assert [item["executor_tier"] for item in starts] == ["cheap", "cheap", "strong"]
+    assert [item["tier_source"] for item in starts] == ["default", "default", "escalated"]
+    assert starts[2]["escalation_briefing_chars"] > 0
+
+
+def test_the_persisted_round_ledger_records_each_tier(flow):
+    assert [item["executor_tier"] for item in flow.rounds_jsonl()] == ["cheap", "cheap", "strong", ""]
+
+
+def test_the_report_summarizes_what_routing_did(flow):
+    routing = flow.report["executor_routing"]
+    assert routing["default_tier"] == "cheap"
+    assert routing["escalation_tier"] == "strong"
+    assert routing["escalate_after_failures"] == 2
+    assert routing["rounds_by_tier"] == {"cheap": 2, "strong": 1}
+    # The run recovered, so it is no longer escalated, but the report still
+    # records that it escalated once and why.
+    assert routing["escalated"] is False
+    assert len(routing["escalations"]) == 1
+    assert routing["escalations"][0]["round"] == 2
+    assert routing["escalations"][0]["from_tier"] == "cheap"
+    assert routing["escalations"][0]["to_tier"] == "strong"
+    assert routing["escalations"][0]["reason"] == "audit_failure_threshold_reached"
+
+
+def test_retry_counts_stay_consistent_with_the_tiers(flow):
+    """Two failures on cheap, then a pass on strong that clears the counter."""
+    assert flow.report["executor_routing"]["consecutive_audit_failures"] == 0
+    assert flow.events("executor_escalation")[0]["consecutive_audit_failures"] == 2
+
+
+def test_the_dashboard_reports_the_tier_for_every_round(flow):
+    state = DashboardState(str(flow.log_dir))
+    tiers = {item["round_index"]: item.get("executor_tier") for item in state.read_rounds()}
+    assert tiers[1] == "cheap"
+    assert tiers[2] == "cheap"
+    assert tiers[3] == "strong"
+
+
+def test_the_dashboard_shows_the_tier_before_a_round_finishes(flow):
+    """`executor_tier.txt` is written before the executor runs, so live rounds show it."""
+    state = DashboardState(str(flow.log_dir))
+    (flow.log_dir / "role_management" / "rounds.jsonl").unlink()
+    (flow.log_dir / "report.json").unlink()
+    (flow.log_dir / "role_management" / "report.json").unlink()
+    tiers = {item["round_index"]: item.get("executor_tier") for item in state.read_rounds()}
+    assert tiers[3] == "strong"
+
+
+def test_the_briefing_is_archived_next_to_the_round_it_was_used_in(flow):
+    state = DashboardState(str(flow.log_dir))
+    assert "executor_escalation_briefing.txt" in state.list_round_artifacts(3)
+    assert "executor_tier.txt" in state.list_round_artifacts(3)
+    assert "executor_escalation_briefing.txt" not in state.list_round_artifacts(1)

--- a/tests/test_manager_escalation_e2e.py
+++ b/tests/test_manager_escalation_e2e.py
@@ -12,8 +12,8 @@ same-tier retry round. The shipped default is 1, covered by
 from __future__ import annotations
 
 import pytest
-from conftest import audit_report, manager_plan
-from loop_harness import executor_calls, run_loop
+from tests.conftest import audit_report, manager_plan
+from tests.loop_harness import executor_calls, run_loop
 
 from lh_harness.dashboard.state import DashboardState
 from lh_harness.types import ExecutorRouting
@@ -118,15 +118,15 @@ def test_the_dashboard_reports_the_tier_for_every_round(flow):
 def test_the_dashboard_shows_the_tier_before_a_round_finishes(flow):
     """`executor_tier.txt` is written before the executor runs, so live rounds show it."""
     state = DashboardState(str(flow.log_dir))
-    (flow.log_dir / "role_management" / "rounds.jsonl").unlink()
+    (flow.log_dir / "role_orchestration" / "rounds.jsonl").unlink()
     (flow.log_dir / "report.json").unlink()
-    (flow.log_dir / "role_management" / "report.json").unlink()
+    (flow.log_dir / "role_orchestration" / "report.json").unlink()
     tiers = {item["round_index"]: item.get("executor_tier") for item in state.read_rounds()}
     assert tiers[3] == "strong"
 
 
 def test_the_briefing_is_archived_next_to_the_round_it_was_used_in(flow):
-    state = DashboardState(str(flow.log_dir))
-    assert "executor_escalation_briefing.txt" in state.list_round_artifacts(3)
-    assert "executor_tier.txt" in state.list_round_artifacts(3)
-    assert "executor_escalation_briefing.txt" not in state.list_round_artifacts(1)
+    """On disk, because the dashboard's artifact listing is POSIX-only today."""
+    assert (flow.round_dir(3) / "executor_escalation_briefing.txt").is_file()
+    assert (flow.round_dir(3) / "executor_tier.txt").is_file()
+    assert not (flow.round_dir(1) / "executor_escalation_briefing.txt").exists()

--- a/tests/test_manager_executor_tier.py
+++ b/tests/test_manager_executor_tier.py
@@ -1,0 +1,130 @@
+"""Tier selection in the run loop, and its independence from executor type."""
+
+from __future__ import annotations
+
+import pytest
+from conftest import audit_report, manager_plan
+from loop_harness import executor_calls, run_loop
+
+from lh_harness.types import ExecutorRouting
+
+# Escalation off, so these tests isolate manager choice and the default.
+NO_ESCALATION = ExecutorRouting(escalate_after_failures=0)
+
+
+def one_round(config_factory, plan, **routing):
+    config = config_factory(
+        max_total_episodes=1,
+        executor_routing=ExecutorRouting(escalate_after_failures=0, **routing),
+    )
+    return run_loop(config, plans=[plan], audits=[audit_report(passing=True)])
+
+
+def test_manager_selected_cheap_uses_the_cheap_executor(harness_config):
+    run = one_round(harness_config, manager_plan("cli", tier="cheap"))
+    assert executor_calls(run) == {"cli/cheap": 1}
+
+
+def test_manager_selected_strong_uses_the_strong_executor(harness_config):
+    run = one_round(harness_config, manager_plan("cli", tier="strong"))
+    assert executor_calls(run) == {"cli/strong": 1}
+
+
+def test_no_tier_falls_back_to_the_default(harness_config):
+    run = one_round(harness_config, manager_plan("cli"))
+    assert executor_calls(run) == {"cli/cheap": 1}
+
+
+def test_default_tier_is_configurable(harness_config):
+    run = one_round(harness_config, manager_plan("cli"), default_tier="strong")
+    assert executor_calls(run) == {"cli/strong": 1}
+
+
+def test_unrecognized_tier_falls_back_without_failing_the_round(harness_config):
+    run = one_round(harness_config, manager_plan("cli", tier="medium"))
+    assert executor_calls(run) == {"cli/cheap": 1}
+    assert run.report["rounds"][0]["executor_tier"] == "cheap"
+
+
+# --- executor type x tier ---------------------------------------------------
+
+
+@pytest.mark.parametrize("executor_type", ["gui", "cli"])
+@pytest.mark.parametrize("tier", ["cheap", "strong"])
+def test_every_type_and_tier_combination_routes_to_its_own_cell(
+    harness_config, executor_type, tier
+):
+    run = one_round(harness_config, manager_plan(executor_type, tier=tier))
+    assert executor_calls(run) == {f"{executor_type}/{tier}": 1}
+
+
+@pytest.mark.parametrize("executor_type", ["gui", "cli"])
+@pytest.mark.parametrize("tier", ["cheap", "strong"])
+def test_tier_does_not_change_which_auditor_runs(harness_config, executor_type, tier):
+    """The auditor is still chosen by executor type alone."""
+    run = one_round(harness_config, manager_plan(executor_type, tier=tier))
+    other = "cli" if executor_type == "gui" else "gui"
+    assert run.auditors[executor_type].calls == 1
+    assert run.auditors[other].calls == 0
+
+
+@pytest.mark.parametrize(
+    ("executor_type", "expected_seconds"),
+    [("gui", 7), ("cli", 9)],
+)
+@pytest.mark.parametrize("tier", ["cheap", "strong"])
+def test_tier_does_not_change_the_episode_budget(
+    harness_config, executor_type, expected_seconds, tier
+):
+    """Budgets stay per executor type: a tier changes the model, not the clock."""
+    run = one_round(harness_config, manager_plan(executor_type, tier=tier))
+    episode = run.executor(executor_type, tier).episodes[0]
+    assert episode.budget_seconds == expected_seconds
+
+
+# --- recorded state ---------------------------------------------------------
+
+
+def test_tier_is_recorded_on_the_round_and_in_the_events(harness_config):
+    run = one_round(harness_config, manager_plan("cli", tier="strong"))
+    assert run.report["rounds"][0]["executor_tier"] == "strong"
+    assert run.rounds_jsonl()[0]["executor_tier"] == "strong"
+    start = run.events("executor_role_start")[0]
+    assert (start["executor_tier"], start["tier_source"]) == ("strong", "manager")
+    assert run.events("executor_role_done")[0]["executor_tier"] == "strong"
+
+
+def test_tier_source_distinguishes_a_default_from_a_manager_choice(harness_config):
+    run = one_round(harness_config, manager_plan("cli"))
+    assert run.events("executor_role_start")[0]["tier_source"] == "default"
+
+
+def test_round_directory_exposes_the_tier_for_the_dashboard(harness_config):
+    run = one_round(harness_config, manager_plan("cli", tier="strong"))
+    assert (run.round_dir(1) / "executor_tier.txt").read_text(encoding="utf-8") == "strong"
+
+
+def test_report_carries_the_routing_policy_and_what_it_did(harness_config):
+    run = one_round(harness_config, manager_plan("cli", tier="strong"))
+    routing = run.report["executor_routing"]
+    assert routing["default_tier"] == "cheap"
+    assert routing["escalate_after_failures"] == 0
+    assert routing["escalated"] is False
+    assert routing["rounds_by_tier"] == {"strong": 1}
+
+
+def test_progress_events_carry_the_tier(harness_config):
+    run = one_round(harness_config, manager_plan("cli", tier="strong"))
+    done = [
+        payload
+        for event, payload in run.progress
+        if event == "role_done" and payload.get("role") == "cli_executor"
+    ]
+    assert done[0]["executor_tier"] == "strong"
+
+
+def test_rounds_that_never_reach_an_executor_have_no_tier(harness_config):
+    config = harness_config(max_total_episodes=1, executor_routing=NO_ESCALATION)
+    run = run_loop(config, plans=[manager_plan("blocked")], audits=[])
+    assert run.report["rounds"][0]["executor_tier"] == ""
+    assert executor_calls(run) == {}

--- a/tests/test_manager_executor_tier.py
+++ b/tests/test_manager_executor_tier.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import pytest
-from conftest import audit_report, manager_plan
-from loop_harness import executor_calls, run_loop
+from tests.conftest import audit_report, manager_plan
+from tests.loop_harness import executor_calls, run_loop
 
 from lh_harness.types import ExecutorRouting
 

--- a/tests/test_role_prompts_executor_tier.py
+++ b/tests/test_role_prompts_executor_tier.py
@@ -1,0 +1,74 @@
+"""Parsing the manager's optional `Executor tier:` line."""
+
+from __future__ import annotations
+
+import pytest
+
+from lh_harness.role_prompts import (
+    extract_role_manager_plan_text,
+    extract_role_task_contract,
+    extract_role_task_state,
+    parse_role_manager_executor_tier,
+    parse_role_manager_next_step,
+)
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("Next: cli\nExecutor tier: cheap", "cheap"),
+        ("Next: cli\nExecutor tier: strong", "strong"),
+        ("Next: gui\n**Executor tier: strong**", "strong"),
+        ("Next: cli\n  executor tier :  STRONG  ", "strong"),
+        ("Next: cli\nExecutor tier: `cheap`", "cheap"),
+        ("下一步: CLI任务\n执行器档位: strong", "strong"),
+        ("下一步: GUI任务\n执行器档位：cheap", "cheap"),
+        ("下一步: CLI任务\n执行档位: strong", "strong"),
+    ],
+)
+def test_recognized_tiers(text, expected):
+    assert parse_role_manager_executor_tier(text) == expected
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "Next: cli\nTask: something",
+        "Next: cli\nExecutor tier: medium",
+        "Next: cli\nExecutor tier:",
+        "Next: cli\nExecutor tier: cheap and strong",
+        "",
+    ],
+)
+def test_absent_or_unreadable_tier_is_none(text):
+    """An unusable value must read as "no opinion", never raise."""
+    assert parse_role_manager_executor_tier(text) is None
+
+
+def test_tier_line_does_not_disturb_the_rest_of_the_protocol():
+    plan = (
+        "Current task state:\n"
+        "Completed: nothing (round_002).\n"
+        "\n"
+        "Task contract:\n"
+        "Persist the report.\n"
+        "\n"
+        "Next: cli\n"
+        "Executor tier: strong\n"
+        "\n"
+        "Task: write the file\n"
+    )
+    assert parse_role_manager_next_step(plan) == "cli"
+    assert extract_role_task_state(plan) == "Current task state:\nCompleted: nothing (round_002)."
+    assert extract_role_task_contract(plan) == "Task contract:\nPersist the report."
+
+
+def test_tier_survives_plan_extraction_from_a_noisy_transcript():
+    raw = (
+        "Let me think about this first.\n\n"
+        "Current task state:\nCompleted: nothing.\n\n"
+        "Next: cli\nExecutor tier: strong\n\nTask: go\n"
+    )
+    plan = extract_role_manager_plan_text(raw)
+    assert parse_role_manager_executor_tier(plan) == "strong"
+    assert "Let me think" not in plan


### PR DESCRIPTION
Closes #13.

Adds a second, orthogonal routing dimension to the executor: a **tier** (`cheap` / `strong`) alongside the existing **type** (`gui` / `cli`). Routine work stays on a cheaper backend; the Manager can ask for a stronger one per subtask, and the harness escalates on its own when verification keeps failing.

Everything goes through the existing `AgentAdapter` abstraction, so it is backend-agnostic — a Codex manager can dispatch to a Claude Code executor and back.

> **Rebased onto `53bc678` (0.1.4).** Conflicts resolved in favour of upstream wherever the two overlapped; details at the end.

> **Note on scope:** this branch carries two independent commits. The first is the feature for #13. The second is an unrelated Windows fix that I hit while trying to verify the feature — the harness could not complete a single round on Windows. Happy to split it into its own PR if you would prefer to review them separately.

---

## 1. Executor tiers and cost-aware escalation (#13)

### Configuration

```toml
[run.roles.executor.cheap]
agent = "codex"
model = "gpt-5.6-sol"

[run.roles.executor.strong]
agent = "claude_code"
model = "claude-opus-5"

[run.executor_routing]
default_tier = "cheap"
escalate_after_failures = 1
escalate_after_stalled_rounds = 3
escalation_tier = "strong"
```

Tier tables nest inside the existing role tables, so resolution keeps the current fallback-chain shape. Naming a tier is a deliberate cost decision, so it outranks the older type-level section:

```
gui_executor.cheap → executor.cheap → gui_executor → executor → [run].agent/.model
```

Per-type overrides (`[run.roles.gui_executor.strong]`) are supported, so all four of CLI+cheap, CLI+strong, GUI+cheap and GUI+strong are expressible without duplicating the executor implementation. Every field has a matching CLI flag, as elsewhere in the project.

**Backward compatible.** A config with no tier tables resolves every tier to the same executor it uses today. A test asserts a legacy `[run.roles.executor]` config produces a byte-identical defaults dict.

### Manager-selected tier

The Manager may add one optional line after its route:

```
Next: cli
Executor tier: cheap
```

The issue sketched this as JSON, but the manager protocol is deliberately JSON-free throughout (`MANAGER_INSTRUCTIONS`: "Output plain natural language, never JSON"), so it follows the existing `Next:` line convention instead. The keys map one-to-one. The prompt instructs the Manager to judge the subtask in front of it and explicitly *not* to decide from task category. Omitting the line accepts the configured default.

### Escalation

```
cheap executor → Auditor → FAIL → strong executor → Auditor
```

Escalation never bypasses verification: the strong result goes through the normal Auditor flow. A passing audit clears the escalation, so routing returns to the default tier and the expensive model is scoped to the stretch of the run that is actually struggling.

**What counts as a failure matters more than it looks.** Auditors are instructed to report `incomplete` whenever the whole contract is unsatisfied, "even if the local subtask succeeded" — so a perfectly good mid-run round comes back `incomplete / clean / aligned`. An earlier version of this PR treated that as a failure and escalated on round one of every task, which threw the saving away. Two distinct signals now:

| Signal | Counts toward | Meaning |
|---|---|---|
| `blocked`, `suspect`/`violation`, `needs_revision`/`invalid`, or an executor episode that errored | `escalate_after_failures` | The round actually went wrong |
| Consecutive clean rounds naming the same unclosed gap | `escalate_after_stalled_rounds` | The cheap tier is spinning |
| `incomplete` + clean + aligned with a new gap each round | neither | Ordinary progress |

### Escalation briefing

Every role episode is a one-shot process — there is no session to resume, and resuming would not be coherent across an escalation that changes backend. A previous round's `executor_output` never otherwise reaches a later executor, and the Auditor's findings only arrive if the Manager happened to cite those rounds.

So an escalated executor is briefed with what the previous tier attempted and why it was rejected. The prior attempt is labelled as that executor's own unaudited claim; the Auditor report is labelled authoritative — the same trust boundary `MANAGER_INSTRUCTIONS` already draws. Bounded to the three most recent failures and char-clipped. Disable with `escalation_briefing = false`.

The Manager is told too, through the existing `harness_feedback` channel, since repeated failure can mean the decomposition is wrong rather than the executor being too weak.

### Observability

- Startup summary resolving every `(type, tier)` cell to its agent and model
- `executor_tier` + `tier_source` on the executor events; a new `executor_escalation` event carrying the reason and the failed rounds
- `tier=cheap` on the console role line, and a dedicated escalation line
- `executor_tier` per round in `report.json`, plus an `executor_routing` block recording the policy, per-tier round counts, and the full escalation history (kept even after a run recovers)
- `executor_tier` exposed by `DashboardState` for finished and in-progress rounds (written before the executor starts, so a live round already shows it). The badge itself needs re-adding to the new `frontend/`, see below.

---

## 2. Windows support (independent of #13)

The harness could not complete a single round on Windows. Agent commands were POSIX shell strings handed to `create_subprocess_shell`, which is cmd.exe there, so `mkdir -p` failed on the first call. Process control used `os.killpg`/`SIGKILL`/`SIGHUP`, none of which exist on Windows, so every timeout raised `AttributeError`.

Rather than translate shell strings per platform, this removes the shell from the agent path. Everything it was doing is a real subprocess argument:

| Was | Now |
|---|---|
| `cd '<ws>' && …` | `cwd=` |
| `VAR=value <cmd>` | `env=` layered onto `os.environ` |
| `… < prompt.md` | prompt written to the child's stdin |
| `mkdir -p`, `chmod` | native `pathlib` calls |

Commands are argv lists, so `shlex.quote` is gone and no model-supplied value can reach a shell parser. `Environment.exec` survives as an explicit escape hatch.

Also fixed, all found by running it for real:

- **Process control** — platform split: `CREATE_NEW_PROCESS_GROUP` + `taskkill /T`, named operations instead of POSIX-only signal numbers
- **`MAX_PATH`** — run directories reach 260 characters easily, and the failure is deceptive: `mkdir` succeeds on the shorter parent while `open()` on the file inside raises `FileNotFoundError`. New `utils/paths` applies the `\\?\` prefix, but only to paths that actually exceed the limit
- **`screenshot()`** — PowerShell on Windows, `screencapture` on macOS, existing X11 tools on Linux
- **Console** — cp1252 no longer mangles output
- **Claude deny rules** — now also emit the drive-letter form, so harness-owned paths are genuinely hidden from the auditor on Windows

The 0.1.4 hardening layer is POSIX-only in the same way, so the run tree could not be written on Windows at all: `_ensure_dir_nofollow`, `_atomic_bytes_write`, `_append_jsonl` and the event append all require `O_NOFOLLOW`, `O_DIRECTORY` and `dir_fd`. Each grows a Windows branch that keeps what the platform can express — reparse-point refusal, atomic replace, the hard-link check before truncation, and the same event-id sequencing — and documents the one guarantee that cannot be reproduced without directory descriptors: the check-then-use window is not anchored. **POSIX behaviour is untouched.**

**Breaking:** `CommandAgentAdapter` takes `argv=`/`env=` instead of `command_template=`. `EpisodeResult.metadata["command"]` is now the argv list rather than a string; the existing reader in `manager.py` already accepts both. The vendored `cua_harness` copies under `eval/` are separate packages and are untouched.

---

## Testing

The `lh_harness` package had no test suite; this adds one — **208 tests**, no paid model calls (scripted adapters and a recording environment).

| Area | Cover |
|---|---|
| Configuration | Both tiers, per-tier backends, type×tier, routing table, legacy config unchanged, and every invalid-config error path |
| Resolution | All four `(type, tier)` cells across five config shapes, tier-before-type precedence, and a regression lock on the eight pre-existing roles |
| Manager routing | Tier parsing (en/zh, bold, unknown → default), all four type×tier combinations, auditor and budget unaffected by tier |
| Escalation | Threshold, stickiness, reset on pass, disabled, both executor types, and the clean-but-incomplete regression |
| Briefing | Content and trust labelling, prompt byte-identical without one, survives a Manager citing nothing |
| E2E | Full flow asserted on persisted state — `rounds.jsonl`, `report.json`, `events.jsonl`, Dashboard |
| Windows | `LocalEnvironment` argv/cwd/env/stdin, timeouts, long lines, `MAX_PATH`, process-group primitives, adapter argv construction |

### Verified against real models on Windows

| Run | Result |
|---|---|
| Full run, `codex` / `gpt-5.6-luna` | **complete** — file produced, all trajectories written |
| Cross-backend | `codex.CMD` manager + auditor, `claude.EXE` executor, one run, **complete** |
| Tier really changes the model | `tier=cheap → --model=gpt-5.6-luna`, `tier=strong → --model=gpt-5.6-sol`, read from the recorded argv |
| Manager tier selection | Emitted `Executor tier: cheap` unprompted |
| Escalation + briefing | Fired, briefing embedded verbatim in the executor prompt, escalated round audited and passed |
| Backward compatibility | Legacy single-executor config completed normally |

### Rebased onto 0.1.4

Rebased onto `53bc678`, resolving conflicts in favour of upstream wherever the two overlapped — the supervised-run plumbing, bootstrap-failure handling, `resolve_codex_binary()`, the `LH_HARNESS_WEB_TOKEN` scrub, bounded stdout capture, and the symlink-safe trajectory writer are all preserved. The tier badge that used to live in `dashboard/static/app.js` went away with that file; `executor_tier` is still exposed by `DashboardState`, so re-adding it to the new `frontend/` is a small follow-up.

Measured against `origin/main` on the same machine:

| | origin/main | this branch |
|---|---|---|
| Failed | 74 | 68 |
| Passed | 94 | 308 |

**No regressions.** The six newly-passing tests are upstream's own (`test_cli_isolation`, `test_manager_hardening`, `test_trajectory_artifacts`), repaired by the Windows branches above. The remaining 68 are pre-existing Windows breakage in the `webapi`/`supervisor` POSIX-only paths, which this PR does not touch — on Linux CI they are unaffected either way.

## Known limitations

- A same-tier retry (when `escalate_after_failures` is raised above 1) is not briefed; only escalated rounds are. Documented at the knob.
- Tiers are a closed set (`cheap`, `strong`).
- The stall detector compares the Auditor's gap text by similarity — a heuristic, tunable, and disabled with `0`.
- The Claude drive-letter deny rule emits both forms because I could not confirm upstream which one the matcher accepts on Windows. Worth a maintainer's eye.
