### PR TITLE
fix(tests): skip web-bundle assertion when the frontend is not built

### DIFF
--- a/tests/webapi/test_webapi.py
+++ b/tests/webapi/test_webapi.py
@@ -14,7 +14,7 @@ from lh_harness.agent_logs import parse_trajectory
 from lh_harness.dashboard.state import DashboardState
 from lh_harness.supervisor.control_bus import ControlBus
 from lh_harness.webapi.events import EventTailer, normalize_event
-from lh_harness.webapi.server import create_app
+from lh_harness.webapi.server import _STATIC_DIR, create_app
 from lh_harness.webapi.snapshot import build_snapshot
 
 
@@ -250,10 +250,7 @@ def test_legacy_static_dashboard_routes_are_not_registered(tmp_path: Path) -> No
     root, state = _fixture(tmp_path)
     app = create_app(state=state, runs_root=root, run_id="run-1")
     paths = {getattr(route, "path", "") for route in app.routes}
-    page = TestClient(app).get("/")
 
-    assert page.status_code == 200
-    assert '<div id="root"></div>' in page.text
     assert "/api/state" not in paths
     assert "/api/round/{round_index}" not in paths
     assert "/api/round/{round_index}/{name}" not in paths
@@ -280,6 +277,20 @@ def test_dashboard_javascript_asset_has_valid_mime_type_on_bad_platform_mapping(
     assert response.status_code == 200
     assert response.headers["content-type"].split(";", 1)[0] == "application/javascript"
     assert response.headers["x-content-type-options"] == "nosniff"
+
+
+@pytest.mark.skipif(
+    not _STATIC_DIR.is_dir(),
+    reason="web bundle not built; run `npm run build --prefix frontend/web`",
+)
+def test_built_web_bundle_is_served_at_root(tmp_path: Path) -> None:
+    root, state = _fixture(tmp_path)
+    app = create_app(state=state, runs_root=root, run_id="run-1")
+
+    page = TestClient(app).get("/")
+
+    assert page.status_code == 200
+    assert '<div id="root"></div>' in page.text
 
 
 def test_api_snapshot_replay_and_artifact(tmp_path: Path) -> None:


### PR DESCRIPTION
## Problem

On a fresh clone, `pip install -e '.[test]' && pytest` fails with one error:

```
FAILED tests/webapi/test_webapi.py::test_legacy_static_dashboard_routes_are_not_registered
assert 404 == 200
```

## Cause

The test asserts that `GET /` serves the SPA, but the web bundle lives at `src/lh_harness/_frontend/web/dist`, which is git-ignored and only produced by `npm run build --prefix frontend/web`. `create_app` already tolerates the missing bundle (`server.py`: `if _STATIC_DIR.is_dir(): app.mount(...)`) — packaging deliberately treats it as a build artifact so a checkout without a Node toolchain still installs — but the test did not. CI never hits this because `release.yml` builds the frontend before running pytest, and no workflow runs on `pull_request`, so nothing catches it for contributors.

## Fix

- The legacy-route assertions (what the test's name is about) need no bundle, so they now always run.
- The SPA-serving assertions move to a new test, `test_built_web_bundle_is_served_at_root`, guarded by `@pytest.mark.skipif(not _STATIC_DIR.is_dir(), ...)` with an actionable skip reason. The condition mirrors `create_app`'s own guard, so the test and production behavior cannot drift.

## Verification

- Without the bundle: `169 passed, 1 skipped`, with the skip reason printed under `-rs`.
- With the bundle (CI-equivalent, after `npm ci --prefix frontend/web --no-audit --no-fund && npm run build --prefix frontend/web`): `170 passed` — the new test genuinely runs when the bundle exists.