### PR TITLE
Recover from isolated EBADF in control-bus reads; keep the watcher alive

### DIFF
--- a/src/lh_harness/cli.py
+++ b/src/lh_harness/cli.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import errno
 import json
 import os
 import platform
@@ -1355,7 +1356,19 @@ async def _run_with_attached_control(
 
     async def watch_control() -> None:
         while not manager_task.done():
-            status = bus.read_status()
+            # A stolen-descriptor EBADF must cost one poll, not the whole
+            # watcher: if this task dies, stop/abort requests go unheard for
+            # the rest of the run and the stored exception resurfaces at
+            # shutdown as the process exit status of an otherwise clean run.
+            # Only EBADF is recoverable noise; permission, I/O, or filesystem
+            # failures would silently blind the watcher to legitimate
+            # stop/abort requests, so they propagate.
+            try:
+                status = bus.read_status()
+            except OSError as exc:
+                if exc.errno != errno.EBADF:
+                    raise
+                status = {}
             action = str(status.get("requested_action") or "").strip().lower()
             if action in {"stop", "abort"}:
                 manager_task.cancel()
@@ -1371,6 +1384,12 @@ async def _run_with_attached_control(
             await watcher
         except asyncio.CancelledError:
             pass
+        except OSError as exc:
+            # A stored stolen-descriptor EBADF must not override the outcome
+            # of the finished run; any other I/O failure in the watcher is a
+            # real problem and keeps propagating.
+            if exc.errno != errno.EBADF:
+                raise
 
 
 def _run_command(args: argparse.Namespace) -> int:

--- a/src/lh_harness/supervisor/control_bus.py
+++ b/src/lh_harness/supervisor/control_bus.py
@@ -7,6 +7,7 @@ an operator action. A receipt is the only terminal authority for a command.
 
 from __future__ import annotations
 
+import errno
 import json
 import os
 import stat
@@ -404,7 +405,16 @@ def _read_jsonl(path: Path) -> list[dict[str, Any]]:
         if len(raw) > _MAX_CONTROL_LOG_BYTES:
             raise ValueError("control log grew beyond the safe read limit")
     finally:
-        os.close(fd)
+        # Tolerate EBADF only: a stray double-close elsewhere in the process
+        # can recycle this descriptor number between our open and close, and
+        # crashing the reader over that stolen close would take down an
+        # otherwise healthy run.  Any other close failure is a real I/O
+        # problem and must propagate.
+        try:
+            os.close(fd)
+        except OSError as exc:
+            if exc.errno != errno.EBADF:
+                raise
     records: list[dict[str, Any]] = []
     for line in raw.splitlines():
         if len(line) > _MAX_CONTROL_RECORD_BYTES:
@@ -435,7 +445,15 @@ def _read_json_file(path: Path, *, max_bytes: int = _MAX_CONTROL_RECORD_BYTES) -
     except OSError:
         return {}
     finally:
-        os.close(fd)
+        # Same tolerance as above: this poller runs for the whole run, so a
+        # single stolen-descriptor EBADF must degrade to one empty poll, not
+        # a crash that surfaces at shutdown as the process exit status.
+        # Everything else propagates.
+        try:
+            os.close(fd)
+        except OSError as exc:
+            if exc.errno != errno.EBADF:
+                raise
     try:
         value = json.loads(raw.decode("utf-8"))
     except (UnicodeDecodeError, json.JSONDecodeError):

--- a/tests/test_cli_isolation.py
+++ b/tests/test_cli_isolation.py
@@ -169,6 +169,70 @@ def test_embedded_control_watcher_cancels_manager_task(tmp_path: Path) -> None:
     assert asyncio.run(_run_with_attached_control(worker(), run_dir=run_dir, enabled=True)) == {"status": "cancelled"}
 
 
+def test_embedded_control_watcher_survives_isolated_ebadf(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """One stolen-descriptor EBADF costs one poll; the next poll still cancels."""
+    import errno
+
+    from lh_harness.supervisor.control_bus import ControlBus
+
+    run_dir = tmp_path / "run"
+    bus = ControlBus(run_dir)
+    bus.write_status({"run_id": "run", "status": "stopping", "requested_action": "abort"})
+
+    real_read_status = ControlBus.read_status
+    calls: list[int] = []
+
+    def flaky_read_status(self):
+        calls.append(1)
+        if len(calls) == 1:
+            raise OSError(errno.EBADF, "Bad file descriptor")
+        return real_read_status(self)
+
+    monkeypatch.setattr(ControlBus, "read_status", flaky_read_status)
+
+    async def worker() -> dict[str, object]:
+        try:
+            await asyncio.sleep(30)
+        except asyncio.CancelledError:
+            return {"status": "cancelled"}
+        return {"status": "unexpected"}
+
+    result = asyncio.run(
+        _run_with_attached_control(worker(), run_dir=run_dir, enabled=True, poll_interval=0.01)
+    )
+    assert result == {"status": "cancelled"}
+    assert len(calls) >= 2
+
+
+def test_embedded_control_watcher_propagates_non_ebadf_errors(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Permission or I/O failures must surface, not blind the watcher."""
+    import errno
+
+    from lh_harness.supervisor.control_bus import ControlBus
+
+    run_dir = tmp_path / "run"
+    ControlBus(run_dir)
+
+    def denied_read_status(self):
+        raise OSError(errno.EACCES, "Permission denied")
+
+    monkeypatch.setattr(ControlBus, "read_status", denied_read_status)
+
+    async def worker() -> dict[str, object]:
+        await asyncio.sleep(0.05)
+        return {"status": "complete"}
+
+    with pytest.raises(OSError) as excinfo:
+        asyncio.run(
+            _run_with_attached_control(worker(), run_dir=run_dir, enabled=True, poll_interval=0.01)
+        )
+    assert excinfo.value.errno == errno.EACCES
+
+
 @pytest.mark.parametrize("requested_action", ["stop", "abort"])
 def test_dashboard_control_stop_keeps_embedded_server_alive(tmp_path: Path, requested_action: str) -> None:
     from lh_harness.supervisor.control_bus import ControlBus

--- a/tests/test_control_bus_close.py
+++ b/tests/test_control_bus_close.py
@@ -1,0 +1,122 @@
+"""Descriptor-close robustness for control-bus readers.
+
+These tests cover recovery from an *isolated* stolen-descriptor ``EBADF``
+(a stray double-close elsewhere in the process recycling the reader's fd
+number between open and close).  They are defense in depth around the
+root-cause fix for the dashboard walker double-close, not a substitute for
+it: only ``EBADF`` is tolerated, every other ``OSError`` must propagate.
+"""
+
+import errno
+import json
+import os
+
+import pytest
+
+from lh_harness.supervisor import control_bus
+
+
+def _reader_close_harness(monkeypatch, close_error: OSError | None):
+    """Route the reader's own close through ``close_error``, keep others real."""
+
+    real_open = control_bus._open_nofollow
+    real_close = os.close
+    reader_fd: dict[str, int] = {}
+    failed: list[int] = []
+
+    def tracking_open(target):
+        fd = real_open(target)
+        reader_fd["fd"] = fd
+        return fd
+
+    def failing_close(fd: int) -> None:
+        real_close(fd)
+        if fd == reader_fd.get("fd") and close_error is not None:
+            failed.append(fd)
+            raise close_error
+
+    monkeypatch.setattr(control_bus, "_open_nofollow", tracking_open)
+    monkeypatch.setattr(os, "close", failing_close)
+    return failed
+
+
+def test_read_json_file_survives_ebadf_on_close(tmp_path, monkeypatch):
+    """An isolated stolen-descriptor EBADF must cost one close, not the poller.
+
+    The watcher task that calls this helper runs for the whole run, so the
+    failure has to degrade gracefully instead of storing an exception that
+    resurfaces at shutdown as the process exit status.
+    """
+
+    payload = {"requested_action": "stop"}
+    path = tmp_path / "status.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    failed = _reader_close_harness(
+        monkeypatch, OSError(errno.EBADF, "Bad file descriptor")
+    )
+    try:
+        result = control_bus._read_json_file(path)
+    finally:
+        monkeypatch.undo()
+
+    assert failed, "the reader must still attempt to close its descriptor"
+    assert result == payload
+
+
+def test_read_json_file_propagates_non_ebadf_close_errors(tmp_path, monkeypatch):
+    """Only EBADF is recoverable noise; a real I/O failure must surface.
+
+    Swallowing e.g. EIO here would silently turn permission or filesystem
+    failures into an empty control status and legitimate stop/abort requests
+    could be ignored for the rest of the run.
+    """
+
+    path = tmp_path / "status.json"
+    path.write_text(json.dumps({"requested_action": "stop"}), encoding="utf-8")
+
+    failed = _reader_close_harness(
+        monkeypatch, OSError(errno.EIO, "Input/output error")
+    )
+    try:
+        with pytest.raises(OSError) as excinfo:
+            control_bus._read_json_file(path)
+    finally:
+        monkeypatch.undo()
+
+    assert failed
+    assert excinfo.value.errno == errno.EIO
+
+
+def test_read_jsonl_propagates_non_ebadf_close_errors(tmp_path, monkeypatch):
+    path = tmp_path / "control.jsonl"
+    path.write_text(json.dumps({"event": "noop"}) + "\n", encoding="utf-8")
+
+    failed = _reader_close_harness(
+        monkeypatch, OSError(errno.EIO, "Input/output error")
+    )
+    try:
+        with pytest.raises(OSError) as excinfo:
+            control_bus._read_jsonl(path)
+    finally:
+        monkeypatch.undo()
+
+    assert failed
+    assert excinfo.value.errno == errno.EIO
+
+
+def test_read_jsonl_survives_ebadf_on_close(tmp_path, monkeypatch):
+    record = {"event": "noop"}
+    path = tmp_path / "control.jsonl"
+    path.write_text(json.dumps(record) + "\n", encoding="utf-8")
+
+    failed = _reader_close_harness(
+        monkeypatch, OSError(errno.EBADF, "Bad file descriptor")
+    )
+    try:
+        result = control_bus._read_jsonl(path)
+    finally:
+        monkeypatch.undo()
+
+    assert failed
+    assert result == [record]


### PR DESCRIPTION
Related to #32 — defense in depth around the root-cause fix in #45 (merged), **not** a resolution of #32 on its own.

A run that completed all rounds and wrote its final reply crashed at shutdown with `OSError: [Errno 9] Bad file descriptor` raised from `os.close()` in `_read_json_file`: the control-watcher task had died on that exception mid-run, and the stored error resurfaced when the CLI awaited the watcher in its `finally` block — turning a fully successful run into a traceback and a non-zero exit (full analysis in #32).

The root cause — the dashboard path walker double-closing a directory FD in `_open_nofollow()`, corrupting whichever thread reused the descriptor — is fixed by #45. This PR is the narrower resilience layer around the control-bus readers: an **isolated** stolen-descriptor `EBADF` degrades gracefully instead of taking down an otherwise healthy run.

**Only `errno.EBADF` is tolerated; every other `OSError` propagates**, so permission, I/O, or filesystem failures cannot be silently turned into an empty control status that would ignore legitimate `stop`/`abort` requests:

1. **`control_bus`**: the two remaining bare `os.close()` calls in `finally` blocks (`_read_jsonl`, `_read_json_file`) tolerate `EBADF` only and re-raise anything else.
2. **`cli` / `watch_control`**: an `EBADF` poll costs that poll, not the watcher; other `OSError`s re-raise.
3. **`cli` shutdown**: a stored watcher `EBADF` does not override the outcome of the finished run; other `OSError`s keep propagating.

### Changes since the last review

- Rebased onto current `main` (post-#45, v0.1.6).
- Narrowed all four defensive handlers from `OSError` to `errno.EBADF`-only, with re-raise otherwise.
- Removed the unrelated generated `uv.lock`.
- Repositioned the PR/commit/tests as recovery from an isolated EBADF rather than the fix for #32.

### Testing

- `tests/test_control_bus_close.py`: EBADF-on-close recovery **and** non-EBADF (`EIO`) propagation for both readers; directory closes inside the path walk stay real.
- `tests/test_cli_isolation.py`: the watcher survives an isolated `EBADF` poll and still honors a pending `abort`; an `EACCES` from `read_status` propagates instead of being swallowed.
- Full suite on current `main` with the frontend bundle built: **209 passed, 1 skipped** (the remaining skip is the macOS `/var`-alias check, N/A on Linux).

Independent of #28 (different subsystem, different failure mode); branched directly off `main` so the two can be reviewed and merged in any order.
