### PR TITLE
Fix dashboard static asset MIME types on Windows

### DIFF
--- a/src/lh_harness/webapi/server.py
+++ b/src/lh_harness/webapi/server.py
@@ -7,6 +7,7 @@ import base64
 import binascii
 import hmac
 import ipaddress
+import mimetypes
 import os
 import re
 import threading
@@ -35,6 +36,11 @@ from .snapshot import _provenance, build_run_summary, build_snapshot
 # installed wheel resolve the same path.  It is absent until the frontend is
 # built; the API then serves JSON only.
 _STATIC_DIR = Path(__file__).resolve().parents[1] / "_frontend" / "web" / "dist"
+_DASHBOARD_MIME_TYPES = {
+    ".js": "application/javascript",
+    ".mjs": "text/javascript",
+    ".css": "text/css",
+}
 
 _MAX_ARTIFACT_BYTES = 8 * 1024 * 1024
 
@@ -1033,6 +1039,11 @@ def create_app(
         return receipt
 
     if _STATIC_DIR.is_dir():
+        # Starlette's FileResponse delegates MIME detection to Python.  A
+        # Windows registry entry can incorrectly map JavaScript to text/plain,
+        # which browsers reject for module scripts when nosniff is enabled.
+        for suffix, media_type in _DASHBOARD_MIME_TYPES.items():
+            mimetypes.add_type(media_type, suffix)
         app.mount("/", StaticFiles(directory=str(_STATIC_DIR), html=True), name="dashboard-static")
     return app
 

--- a/tests/webapi/test_webapi.py
+++ b/tests/webapi/test_webapi.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import mimetypes
 import threading
 from pathlib import Path
 
@@ -257,6 +258,28 @@ def test_legacy_static_dashboard_routes_are_not_registered(tmp_path: Path) -> No
     assert "/api/round/{round_index}" not in paths
     assert "/api/round/{round_index}/{name}" not in paths
     assert "/api/inject" not in paths
+
+
+def test_dashboard_javascript_asset_has_valid_mime_type_on_bad_platform_mapping(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    static_dir = tmp_path / "dist"
+    assets_dir = static_dir / "assets"
+    assets_dir.mkdir(parents=True)
+    (assets_dir / "index.js").write_text("document.body.dataset.loaded = 'yes';", encoding="utf-8")
+    monkeypatch.setattr("lh_harness.webapi.server._STATIC_DIR", static_dir)
+
+    # Simulate the Windows registry mapping without depending on the host OS.
+    mimetypes.guess_type("index.js")
+    monkeypatch.setitem(mimetypes.types_map, ".js", "text/plain")
+    assert mimetypes.guess_type("index.js")[0] == "text/plain"
+
+    client = TestClient(create_app(state=DashboardState(tmp_path / "logs")))
+    response = client.get("/assets/index.js")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].split(";", 1)[0] == "application/javascript"
+    assert response.headers["x-content-type-options"] == "nosniff"
 
 
 def test_api_snapshot_replay_and_artifact(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- pin `.js`, `.mjs`, and `.css` MIME types before mounting the dashboard `StaticFiles`
- prevent polluted Windows MIME mappings from serving module scripts as `text/plain`
- add a regression test that reproduces the bad `.js` mapping through the real FastAPI static-file path

Closes #34.

## Verification

- focused regression: 1 passed
- Web API suite: 44 passed
- `npm run build`
- frontend tests: 47 passed
- `git diff --check`

Full Python suite: 178 passed, with 2 unrelated environment failures:
- localhost socket binding blocked by sandbox permissions
- DeepSeek fake-process test failed in the current environment