### PR TITLE
Fix documented default round limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ Task text, run IDs, and API keys are deliberately **not** configurable here; the
 | `claude_mcp_config` | commented out | Path to a `.mcp.json` for Claude Code. Overrides the installed plugin. |
 | `codex_mcp_config` | commented out | Path to a `[mcp_servers.*]` TOML for Codex. Overrides the installed plugin. |
 | `mcp_add_dirs` | `[]` | Extra directories the MCP server may read. Claude Code rejects these, because its role isolation requires task files to live inside the workspace. |
-| `max_rounds` | `30` | Upper bound on Manage-Execute-Audit rounds before the run stops. |
+| `max_rounds` | `25` | Upper bound on Manage-Execute-Audit rounds before the run stops. |
 | `dashboard` | `true` | Start the web dashboard with each run. |
 | `dashboard_port` | `0` | Dashboard port; `0` lets the OS pick a free one. |
 
@@ -488,7 +488,7 @@ lh-harness web --workspace-root .               # Serve the workbench for anothe
 | `--task` | Task text or `@task.md` |
 | `--agent` | `claude_code`, `codex`, or `deepseek_harness` (CLI-only in phase 1) |
 | `--env` | `local` |
-| `--max-rounds` | Maximum number of Manage-Execute-Audit rounds; the CLI default is 30 |
+| `--max-rounds` | Maximum number of Manage-Execute-Audit rounds; the CLI default is 25 |
 | `--dashboard` | Start live monitoring and human intervention |
 | `--no-dashboard` | Disable a Dashboard enabled by the project configuration |
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -337,7 +337,7 @@ lh-harness check-update
 | `claude_mcp_config` | 默认注释 | Claude Code 用的 `.mcp.json` 路径，会覆盖已安装的插件。 |
 | `codex_mcp_config` | 默认注释 | Codex 用的 `[mcp_servers.*]` TOML 路径，会覆盖已安装的插件。 |
 | `mcp_add_dirs` | `[]` | 额外允许 MCP server 读取的目录。Claude Code 会拒绝该项，因为其角色隔离要求任务文件必须放在工作目录内。 |
-| `max_rounds` | `30` | Manage-Execute-Audit 循环的最大轮数，达到即停止。 |
+| `max_rounds` | `25` | Manage-Execute-Audit 循环的最大轮数，达到即停止。 |
 | `dashboard` | `true` | 每次运行时启动 Web Dashboard。 |
 | `dashboard_port` | `0` | Dashboard 端口，`0` 表示由系统分配空闲端口。 |
 
@@ -489,7 +489,7 @@ lh-harness web --workspace-root .               # 为指定目录启动工作台
 | `--task` | 任务文本或 `@task.md` |
 | `--agent` | `claude_code`、`codex` 或 `deepseek_harness`（第一阶段仅 CLI） |
 | `--env` | `local` |
-| `--max-rounds` | Manage-Execute-Audit 循环的最大轮数；CLI 默认为 30 |
+| `--max-rounds` | Manage-Execute-Audit 循环的最大轮数；CLI 默认为 25 |
 | `--dashboard` | 启动实时监控和人工介入功能 |
 | `--no-dashboard` | 关闭项目配置中默认启用的 Dashboard |
 


### PR DESCRIPTION
## Summary
- update the English and Chinese configuration tables to show the actual default of 25 rounds
- update both CLI reference tables to the same value

## Evidence
DEFAULT_MAX_ROUNDS is 25 in src/lh_harness/types.py, run.max_rounds defaults to 25 in src/lh_harness/config.py, and the CLI derives its fallback and help text from that constant. The READMEs still documented 30.

## Validation
- git diff --check
- compared all four documented values against src/lh_harness/types.py and src/lh_harness/config.py

No runtime code is changed, so no test suite was run.