### PR TITLE
Prevent dashboard FD double-close

### DIFF
--- a/src/lh_harness/dashboard/state.py
+++ b/src/lh_harness/dashboard/state.py
@@ -1124,22 +1124,23 @@ def _open_nofollow(path: Path, *, directory: bool = False, strict_parent: bool =
                 os.O_RDONLY | directory_flag | nofollow | cloexec,
                 dir_fd=current_fd,
             )
-            os.close(current_fd)
-            current_fd = next_fd
+            # Transfer ownership before closing the previous directory.  If
+            # close itself raises, the final cleanup must own ``next_fd`` and
+            # must never retry the same numeric descriptor after another
+            # thread may have reused it.
+            previous_fd, current_fd = current_fd, next_fd
+            os.close(previous_fd)
         final_component = components[-1]
         if final_component in {"", ".", ".."}:
             raise OSError("unsafe path component")
-        try:
-            result_fd = os.open(final_component, flags, dir_fd=current_fd)
-        finally:
-            os.close(current_fd)
-        return result_fd
-    except BaseException:
-        try:
-            os.close(current_fd)
-        except OSError:
-            pass
-        raise
+
+        return os.open(final_component, flags, dir_fd=current_fd)
+    finally:
+        # This is the sole cleanup path for the owned parent descriptor.  The
+        # old nested finally/except pair closed it twice when the final open
+        # failed, allowing a concurrent subprocess pipe that reused the number
+        # to be closed out from under Popen.
+        os.close(current_fd)
 
 
 def _read_file_bounded(

--- a/tests/webapi/test_hardening.py
+++ b/tests/webapi/test_hardening.py
@@ -12,6 +12,7 @@ import pytest
 pytest.importorskip("fastapi")
 from fastapi.testclient import TestClient
 
+import lh_harness.dashboard.state as dashboard_state
 from lh_harness.dashboard.state import DashboardState
 from lh_harness.webapi.events import EventTailer
 from lh_harness.webapi.server import create_app
@@ -33,6 +34,67 @@ def _run(tmp_path: Path) -> tuple[Path, DashboardState]:
 def _ws_auth_protocols(token: str) -> list[str]:
     encoded = base64.urlsafe_b64encode(token.encode("utf-8")).decode("ascii").rstrip("=")
     return ["lh-harness-auth.v1", f"lh-harness-token.{encoded}"]
+
+
+def test_dashboard_missing_file_does_not_close_a_reused_parent_fd(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed final open must close its parent descriptor exactly once.
+
+    Dashboard snapshots routinely probe files that do not exist yet.  Model
+    another thread reusing the parent descriptor between cleanup paths: the
+    replacement must remain open after the expected FileNotFoundError.
+    """
+
+    if not getattr(os, "O_NOFOLLOW", 0) or os.open not in getattr(os, "supports_dir_fd", set()):
+        pytest.skip("secure descriptor-relative opens are unavailable")
+
+    target = tmp_path.resolve() / "missing-final-response.txt"
+    real_open = os.open
+    real_close = os.close
+    source_fd = real_open(os.devnull, os.O_RDONLY)
+    final_parent_fd: dict[str, int] = {}
+    replacement_fd: dict[str, int] = {}
+
+    def tracking_open(path, flags, *args, **kwargs):
+        try:
+            return real_open(path, flags, *args, **kwargs)
+        except FileNotFoundError:
+            if path == target.name and isinstance(kwargs.get("dir_fd"), int):
+                final_parent_fd["fd"] = kwargs["dir_fd"]
+            raise
+
+    def reusing_close(fd: int) -> None:
+        if fd == final_parent_fd.get("fd") and "fd" not in replacement_fd:
+            real_close(fd)
+            os.dup2(source_fd, fd)
+            replacement_fd["fd"] = fd
+            return
+        real_close(fd)
+
+    monkeypatch.setattr(os, "open", tracking_open)
+    monkeypatch.setattr(os, "close", reusing_close)
+    os.supports_dir_fd.add(tracking_open)
+    try:
+        with pytest.raises(FileNotFoundError):
+            dashboard_state._open_nofollow(target, strict_parent=True)
+    finally:
+        os.supports_dir_fd.discard(tracking_open)
+        monkeypatch.undo()
+
+    replacement = replacement_fd.get("fd")
+    try:
+        assert replacement is not None
+        os.fstat(replacement)
+    finally:
+        for fd in {source_fd, replacement}:
+            if fd is None:
+                continue
+            try:
+                real_close(fd)
+            except OSError:
+                pass
 
 
 def test_event_tail_is_absolute_and_bad_records_are_diagnostic(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- close Dashboard path-walk parent descriptors exactly once
- transfer descriptor ownership before cleanup
- add a deterministic regression that forces descriptor-number reuse

## Root cause

Dashboard snapshot polling probes files such as `final_response.txt` before they exist. When the final `os.open(..., dir_fd=current_fd)` failed, `_open_nofollow` closed `current_fd` in an inner `finally`, then closed the same numeric descriptor again in the outer exception handler. A concurrent `subprocess.Popen()` could reuse that descriptor number between the two closes, causing its newly-created pipe to be closed and later surfacing as `EBADF`.

This fixes the root descriptor-lifetime bug behind #32. PR #33 remains useful as defense in depth around workspace-watcher snapshot failures, but it cannot cover `Popen()` or other unrelated FD consumers.

## User impact

- prevents sporadic subprocess/control-bus/workspace snapshot `EBADF` failures during long runs with embedded Dashboard polling
- preserves the existing `openat` / `O_NOFOLLOW` path hardening

## Validation

- deterministic regression fails on the old implementation and passes with this fix
- Python 3.11 and 3.14: 191 passed
- `tests/webapi/test_hardening.py`: 27 passed
- frontend core: 47 passed
- frontend production build: passed
- `git diff --check`: passed

Addresses #32.
