### PR TITLE
Preserve completed rounds in crash reports

### DIFF
--- a/src/lh_harness/manager.py
+++ b/src/lh_harness/manager.py
@@ -114,6 +114,15 @@ def _invalid_plan_feedback(language: str) -> str:
     )
 
 
+@dataclass
+class _RunProgress:
+    """Mutable state retained by the worker boundary if the loop crashes."""
+
+    rounds: list[ManagedRound] = field(default_factory=list)
+    gate: _GateContext | None = None
+    started_at: float | None = None
+
+
 async def run(*args: Any, **kwargs: Any) -> dict[str, Any]:
     """Run the management loop and always leave a durable terminal record.
 
@@ -126,8 +135,9 @@ async def run(*args: Any, **kwargs: Any) -> dict[str, Any]:
 
     task = str(kwargs.get("task") or "")
     config = kwargs.get("config")
+    run_progress = _RunProgress()
     try:
-        return await _run_impl(*args, **kwargs)
+        return await _run_impl(*args, _run_progress=run_progress, **kwargs)
     except asyncio.CancelledError as exc:
         return _write_terminal_failure(
             config,
@@ -136,6 +146,7 @@ async def run(*args: Any, **kwargs: Any) -> dict[str, Any]:
             reason="worker task was cancelled",
             exc=exc,
             abort_reason="worker_cancelled",
+            progress=run_progress,
         )
     except BaseException as exc:  # worker boundary: persist even non-Exception failures
         # KeyboardInterrupt/SystemExit are intentionally converted to a
@@ -148,6 +159,7 @@ async def run(*args: Any, **kwargs: Any) -> dict[str, Any]:
             reason=f"management loop crashed: {exc}",
             exc=exc,
             abort_reason="worker_exception",
+            progress=run_progress,
         )
 
 
@@ -167,6 +179,7 @@ async def _run_impl(
     final_response_agent: AgentAdapter | None = None,
     human_hook: Callable[[dict[str, Any]], Awaitable[dict[str, Any]]] | None = None,
     progress: Callable[[str, dict[str, Any]], None] | None = None,
+    _run_progress: _RunProgress | None = None,
 ) -> dict[str, Any]:
     """Run the generic LongHorizon-Harness four-role management loop.
 
@@ -281,6 +294,12 @@ async def _run_impl(
         response_agent=final_response_agent or manager_agent,
         emit=emit,
     )
+    if _run_progress is not None:
+        # The list and gate are mutated in place, so the outer crash boundary
+        # always sees the latest completed rounds without checkpoint rewrites.
+        _run_progress.rounds = rounds
+        _run_progress.gate = gate
+        _run_progress.started_at = started
 
     while round_index < gate.round_budget:
         round_index += 1
@@ -1508,6 +1527,7 @@ def _write_terminal_failure(
     reason: str,
     exc: BaseException,
     abort_reason: str,
+    progress: _RunProgress | None = None,
 ) -> dict[str, Any]:
     """Best-effort local crash report and terminal event for the worker.
 
@@ -1547,11 +1567,45 @@ def _write_terminal_failure(
         "rounds_run": 0,
         "max_rounds": int(getattr(config, "max_total_episodes", 0) or 0),
         "abort_reason": abort_reason,
+        "failure_reason": reason,
         "error": reason,
+        "last_plan": "",
+        "current_task_state": "",
+        "current_task_contract": "",
+        "latest_auditor_report": "",
+        "final_response": "",
+        "rounds": [],
+        "elapsed_seconds": 0.0,
         "exception_type": type(exc).__name__,
         "traceback_tail": trace[-12000:],
         "supervisor_generated": False,
     }
+    if progress is not None:
+        rounds = list(progress.rounds)
+        latest = rounds[-1] if rounds else None
+        gate = progress.gate
+        report.update(
+            {
+                "completion_satisfied": bool(gate and gate.completion_satisfied),
+                "rounds_run": len(rounds),
+                "max_rounds": (
+                    gate.round_budget
+                    if gate is not None
+                    else int(getattr(config, "max_total_episodes", 0) or 0)
+                ),
+                "last_plan": latest.plan_text if latest is not None else "",
+                "current_task_state": latest.task_state if latest is not None else "",
+                "current_task_contract": latest.task_contract if latest is not None else "",
+                "latest_auditor_report": _latest_auditor_report_text(rounds),
+                "final_response": gate.final_response if gate is not None else "",
+                "rounds": [asdict(item) for item in rounds],
+                "elapsed_seconds": (
+                    round(max(0.0, time.monotonic() - progress.started_at), 3)
+                    if progress.started_at is not None
+                    else 0.0
+                ),
+            }
+        )
     encoded = json.dumps(report, ensure_ascii=False, indent=2) + "\n"
     for target in (report_path, role_report_path):
         try:

--- a/tests/test_manager_hardening.py
+++ b/tests/test_manager_hardening.py
@@ -212,3 +212,56 @@ async def test_provider_failure_stops_without_round_limit_approval(tmp_path: Pat
     assert failure["status"] == "failed"
     assert failure["episode_status"]["status"] == "error"
     assert failure["episode_status"]["error"] == f"模型不可用：{message}"
+
+
+@pytest.mark.asyncio
+async def test_late_crash_report_preserves_completed_rounds(tmp_path: Path) -> None:
+    outputs = iter(
+        (
+            "Next: cli\n\nCurrent Task State:\nwork pending",
+            "executor finished the requested work",
+            "Status: complete\nIntegrity: clean\nContract audit: aligned",
+            "Next: done\n\nCurrent Task State:\nwork finished",
+            "The requested work is complete.",
+        )
+    )
+
+    class SequencedAgent:
+        async def run_episode(self, _prompt, _env, _budget, live_trajectory_path=None):
+            return EpisodeResult(status="done", actions_log=next(outputs))
+
+    async def crashing_human_hook(context: dict[str, object]) -> dict[str, object]:
+        if context.get("outcome") == "completed":
+            raise RuntimeError("dashboard gate crashed after completion")
+        return {"action": "continue"}
+
+    log_dir = tmp_path / "logs"
+    config = HarnessConfig(
+        max_total_episodes=2,
+        manager_budget=EpisodeBudget(max_duration_seconds=10),
+        workspace_path=str(tmp_path / "workspace"),
+        harness_dir=str(tmp_path / "harness"),
+        log_dir=str(log_dir),
+    )
+
+    result = await run(
+        task="finish two managed rounds",
+        env=LocalEnvironment(str(tmp_path / "tmp")),
+        config=config,
+        agent=SequencedAgent(),
+        human_hook=crashing_human_hook,
+    )
+
+    assert result["status"] == "failed"
+    assert result["abort_reason"] == "worker_exception"
+    assert result["exception_type"] == "RuntimeError"
+    assert result["rounds_run"] == 2
+    assert [item["round_index"] for item in result["rounds"]] == [1, 2]
+    assert result["completion_satisfied"] is True
+    assert result["current_task_state"].endswith("work finished")
+    assert result["latest_auditor_report"].startswith("Status: complete")
+    assert result["final_response"] == "The requested work is complete."
+    assert result["elapsed_seconds"] >= 0
+
+    persisted = json.loads((log_dir / "report.json").read_text(encoding="utf-8"))
+    assert persisted == result


### PR DESCRIPTION
## Summary

- retain the live managed-round list and gate state at the outer worker boundary
- preserve completed rounds, task state, auditor evidence, final response, completion evidence, and elapsed time when a late exception produces `report.json`
- add an end-to-end regression that crashes the dashboard gate after two completed rounds

## Root cause

`run()` caught exceptions outside `_run_impl()`, but the failure writer only received `task` and `config`. If an exception occurred after work had completed but before the normal terminal report was written, `_write_terminal_failure()` had no access to `_run_impl()`'s in-memory `rounds` or gate state and generated a replacement report with `rounds_run: 0`.

The worker boundary now owns a small mutable progress holder. `_run_impl()` attaches its live round list and gate to that holder once initialized. Because those objects are mutated in place, the failure path can build a truthful failed report without checkpoint rewrites or reconstructing state from partial artifacts.

## User impact

A late dashboard, hook, filesystem, or post-processing exception still records the run as failed, but it no longer erases the work history. Operators retain the completed rounds, latest plan and task state, auditor report, final user response, completion evidence, and elapsed duration needed to diagnose or recover the run.

## Validation

- regression: two rounds complete, final response is written, then the human/dashboard gate raises; the returned and persisted reports retain both rounds
- Python: 192 passed
- frontend core: 47 passed
- frontend production build: passed
- `git diff --check`: passed

The primary EBADF cause in #42 was fixed by #45. This PR resolves the remaining crash-report preservation issue.

Closes #42.
