### PR TITLE
Harden Web API control request boundaries

### DIFF
--- a/frontend/web/src/api.ts
+++ b/frontend/web/src/api.ts
@@ -238,23 +238,31 @@ export async function createRun(input: {
 }
 
 export async function refreshModels(): Promise<WebMeta> {
-  const response = await fetch('/api/models/refresh', { method: 'POST', headers: authHeaders() });
+  const response = await fetch('/api/models/refresh', {
+    method: 'POST', headers: { 'Content-Type': 'application/json', ...authHeaders() }, body: '{}',
+  });
   if (!response.ok) throw await responseError(response);
   return response.json() as Promise<WebMeta>;
 }
 
 export async function stopRun(runId: string, requestKey = idempotencyKey('stop')): Promise<void> {
-  const response = await fetch(`/api/runs/${encodeURIComponent(runId)}/stop`, { method: 'POST', headers: { ...authHeaders(), 'Idempotency-Key': requestKey } });
+  const response = await fetch(`/api/runs/${encodeURIComponent(runId)}/stop`, {
+    method: 'POST', headers: { 'Content-Type': 'application/json', ...authHeaders(), 'Idempotency-Key': requestKey }, body: '{}',
+  });
   if (!response.ok) throw await responseError(response);
 }
 
 export async function abortRun(runId: string, requestKey = idempotencyKey('abort')): Promise<void> {
-  const response = await fetch(`/api/runs/${encodeURIComponent(runId)}/abort`, { method: 'POST', headers: { ...authHeaders(), 'Idempotency-Key': requestKey } });
+  const response = await fetch(`/api/runs/${encodeURIComponent(runId)}/abort`, {
+    method: 'POST', headers: { 'Content-Type': 'application/json', ...authHeaders(), 'Idempotency-Key': requestKey }, body: '{}',
+  });
   if (!response.ok) throw await responseError(response);
 }
 
 export async function resumeRun(runId: string, requestKey = idempotencyKey('resume')): Promise<{ id: string }> {
-  const response = await fetch(`/api/runs/${encodeURIComponent(runId)}/resume`, { method: 'POST', headers: { ...authHeaders(), 'Idempotency-Key': requestKey } });
+  const response = await fetch(`/api/runs/${encodeURIComponent(runId)}/resume`, {
+    method: 'POST', headers: { 'Content-Type': 'application/json', ...authHeaders(), 'Idempotency-Key': requestKey }, body: '{}',
+  });
   if (!response.ok) throw await responseError(response);
   const data = await response.json() as { run: { id: string } };
   return data.run;

--- a/src/lh_harness/webapi/server.py
+++ b/src/lh_harness/webapi/server.py
@@ -136,6 +136,25 @@ def _is_json_content_type(value: str | None) -> bool:
     return media == "application/json"
 
 
+async def _cache_bounded_request_body(request: Request, limit: int) -> bool:
+    """Buffer at most ``limit`` bytes and replay them to the route handler.
+
+    ``Request.body()`` consumes the complete ASGI stream before its caller can
+    inspect the size.  Reading the documented streaming interface lets the
+    control plane reject an undeclared/chunked oversized body as soon as it
+    crosses the limit.  Starlette's middleware request wrapper replays the
+    cached body to ``call_next``.
+    """
+
+    body = bytearray()
+    async for chunk in request.stream():
+        if len(body) + len(chunk) > limit:
+            return False
+        body.extend(chunk)
+    request._body = bytes(body)
+    return True
+
+
 def _configured_token(explicit: str | None) -> str | None:
     value = explicit if explicit is not None else os.environ.get("LH_HARNESS_WEB_TOKEN")
     value = str(value or "").strip()
@@ -620,25 +639,6 @@ def create_app(
             request.headers.get("host", ""), bind_host
         ):
             return JSONResponse({"detail": "host is not allowed"}, status_code=403)
-        if request.method in {"POST", "PUT", "PATCH"} and request.url.path.startswith("/api/"):
-            content_type = request.headers.get("content-type")
-            content_length = request.headers.get("content-length")
-            if content_length is not None:
-                try:
-                    declared = int(content_length)
-                except ValueError:
-                    return JSONResponse({"detail": "invalid content-length"}, status_code=400)
-                if declared > _MAX_CONTROL_BODY_BYTES:
-                    return JSONResponse({"detail": "request body is too large"}, status_code=413)
-            body = await request.body()
-            if len(body) > _MAX_CONTROL_BODY_BYTES:
-                return JSONResponse({"detail": "request body is too large"}, status_code=413)
-            if body or content_type:
-                if not _is_json_content_type(content_type):
-                    return JSONResponse(
-                        {"detail": "request must be application/json"},
-                        status_code=415,
-                    )
         authenticated = _bearer_matches(request.headers.get("authorization"), token)
         if token and request.url.path.startswith("/api/") and not authenticated:
             return JSONResponse(
@@ -646,6 +646,25 @@ def create_app(
                 status_code=401,
                 headers={"WWW-Authenticate": "Bearer"},
             )
+        if request.method in {"POST", "PUT", "PATCH"} and request.url.path.startswith("/api/"):
+            content_type = request.headers.get("content-type")
+            if not _is_json_content_type(content_type):
+                return JSONResponse(
+                    {"detail": "request must be application/json"},
+                    status_code=415,
+                )
+            content_length = request.headers.get("content-length")
+            if content_length is not None:
+                try:
+                    declared = int(content_length)
+                except ValueError:
+                    return JSONResponse({"detail": "invalid content-length"}, status_code=400)
+                if declared < 0:
+                    return JSONResponse({"detail": "invalid content-length"}, status_code=400)
+                if declared > _MAX_CONTROL_BODY_BYTES:
+                    return JSONResponse({"detail": "request body is too large"}, status_code=413)
+            if not await _cache_bounded_request_body(request, _MAX_CONTROL_BODY_BYTES):
+                return JSONResponse({"detail": "request body is too large"}, status_code=413)
         response = await call_next(request)
         response.headers.setdefault("X-Content-Type-Options", "nosniff")
         response.headers.setdefault("X-Frame-Options", "SAMEORIGIN")

--- a/tests/supervisor/test_supervisor.py
+++ b/tests/supervisor/test_supervisor.py
@@ -47,7 +47,7 @@ def test_web_supervisor_exposes_create_and_lifecycle_routes(monkeypatch, tmp_pat
     assert created.status_code == 200
     run_id = created.json()["run"]["id"]
     assert client.get(f"/api/runs/{run_id}/status").json()["managed"] is True
-    stopped = client.post(f"/api/runs/{run_id}/stop")
+    stopped = client.post(f"/api/runs/{run_id}/stop", json={})
     assert stopped.status_code == 200
     assert stopped.json()["signal"] == "SIGTERM"
     process.returncode = -15
@@ -148,8 +148,16 @@ def test_web_create_and_resume_forward_idempotency_key(monkeypatch, tmp_path: Pa
     process.returncode = 1
     # A report-less fake exit is reconciled as failed and can be retried.
     assert client.get(f"/api/runs/{run_id}/status").status_code == 200
-    resumed = client.post(f"/api/runs/{run_id}/resume", headers={"Idempotency-Key": "api-resume-1"})
-    resumed_again = client.post(f"/api/runs/{run_id}/resume", headers={"Idempotency-Key": "api-resume-1"})
+    resumed = client.post(
+        f"/api/runs/{run_id}/resume",
+        headers={"Idempotency-Key": "api-resume-1"},
+        json={},
+    )
+    resumed_again = client.post(
+        f"/api/runs/{run_id}/resume",
+        headers={"Idempotency-Key": "api-resume-1"},
+        json={},
+    )
     assert resumed.status_code == resumed_again.status_code == 200
     assert resumed.json()["run"]["id"] == resumed_again.json()["run"]["id"]
     assert resumed_again.json()["run"]["idempotent"] is True

--- a/tests/webapi/test_hardening.py
+++ b/tests/webapi/test_hardening.py
@@ -613,7 +613,7 @@ def test_attached_api_rejects_foreign_run_paths(tmp_path: Path) -> None:
     client = TestClient(create_app(state=state, runs_root=root, run_id="run-1", supervisor=supervisor))
 
     assert client.get("/api/runs/run-2/snapshot").status_code == 404
-    assert client.post("/api/runs/run-2/stop").status_code == 404
+    assert client.post("/api/runs/run-2/stop", json={}).status_code == 404
 
 
 def test_loopback_host_header_rejects_dns_rebind(tmp_path: Path) -> None:
@@ -647,6 +647,10 @@ def test_control_posts_require_json_and_bound_body(tmp_path: Path) -> None:
         data={"instructions": "keep going"},
     ).status_code == 415
     assert client.post(
+        "/api/runs/run-1/stop",
+        content=b"",
+    ).status_code == 415
+    assert client.post(
         "/api/runs/run-1/instructions",
         content=b'{"instructions":"keep going"}',
         headers={"Content-Type": "application/json; charset=utf-8"},
@@ -660,6 +664,78 @@ def test_control_posts_require_json_and_bound_body(tmp_path: Path) -> None:
         },
     )
     assert oversized.status_code == 413
+
+
+async def _streaming_control_post(
+    app,
+    chunks: list[bytes],
+) -> tuple[int, int, int]:
+    pending = list(chunks)
+    receive_calls = 0
+    sent: list[dict] = []
+
+    async def receive() -> dict:
+        nonlocal receive_calls
+        receive_calls += 1
+        body = pending.pop(0)
+        return {"type": "http.request", "body": body, "more_body": bool(pending)}
+
+    async def send(message: dict) -> None:
+        sent.append(message)
+
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0"},
+        "http_version": "1.1",
+        "method": "POST",
+        "scheme": "http",
+        "path": "/api/models/refresh",
+        "raw_path": b"/api/models/refresh",
+        "query_string": b"",
+        "headers": [(b"host", b"127.0.0.1"), (b"content-type", b"application/json")],
+        "client": ("127.0.0.1", 50000),
+        "server": ("127.0.0.1", 8799),
+        "root_path": "",
+    }
+    await app(scope, receive, send)
+    status = next(message["status"] for message in sent if message["type"] == "http.response.start")
+    return status, receive_calls, len(pending)
+
+
+@pytest.mark.asyncio
+async def test_control_body_limit_stops_chunked_stream_early(tmp_path: Path) -> None:
+    root, state = _run(tmp_path)
+    app = create_app(state=state, runs_root=root, run_id="run-1")
+
+    status, receive_calls, remaining = await _streaming_control_post(
+        app,
+        [b"x" * (256 * 1024) for _ in range(10)],
+    )
+
+    assert status == 413
+    assert receive_calls == 5
+    assert remaining == 5
+
+
+@pytest.mark.asyncio
+async def test_control_auth_rejects_before_reading_body(tmp_path: Path) -> None:
+    root, state = _run(tmp_path)
+    app = create_app(
+        state=state,
+        runs_root=root,
+        run_id="run-1",
+        auth_token="secret",
+        bind_host="0.0.0.0",
+    )
+
+    status, receive_calls, remaining = await _streaming_control_post(
+        app,
+        [b"x" * (256 * 1024) for _ in range(10)],
+    )
+
+    assert status == 401
+    assert receive_calls == 0
+    assert remaining == 10
 
 
 def test_bearer_and_non_loopback_host_behavior(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- require `application/json` for every mutating `/api/` request, including bodyless lifecycle actions
- authenticate bearer-protected API requests before consuming their bodies
- stop reading undeclared/chunked request bodies as soon as they cross the 1 MiB control-plane limit
- update the Web client and supervisor tests to send explicit empty JSON for bodyless POSTs
- add adversarial regression coverage for empty-body CSRF bypasses, streaming limits, and auth-before-read ordering

## Why

This is a follow-up to #11. That PR added valuable Host, Content-Type, and body-size hardening, but empty POSTs without a Content-Type still bypassed the JSON requirement. Its `request.body()` call also buffered an entire undeclared body before checking the limit and ran before bearer authentication.

## User impact

Normal dashboard actions continue to work. Non-JSON state-changing requests now fail with 415, unauthenticated exposed requests fail before their bodies are read, and oversized chunked bodies are rejected after crossing the configured limit instead of being fully buffered.

## Validation

- focused Web API and supervisor tests: `40 passed`
- full Python suite without built frontend: `197 passed, 1 skipped`
- frontend TypeScript check and Vite production build: passed
- full Python suite with built frontend: `198 passed`
