### PR TITLE
Fix stopped-run status and trajectory duplication

### DIFF
--- a/frontend/web/src/App.tsx
+++ b/frontend/web/src/App.tsx
@@ -807,14 +807,11 @@ export default function App() {
   function commitTrajectory(storageKey: string, requestKey: string, requestId: number, next: TrajectoryView, size?: number): void {
     if (trajectoryRequestSeq.current.get(requestKey) !== requestId) return;
     if (typeof size === 'number' && Number.isFinite(size)) trajectoryLoadedSizes.current.set(storageKey, size);
-    setTrajectories((current) => {
-      // A slower request can finish after a newer live poll. Keep the newer
-      // response unless the backend deliberately reports a reset/truncation.
-      const previous = current[storageKey];
-      if (previous && typeof next.raw_chars === 'number' && typeof previous.raw_chars === 'number'
-        && next.raw_chars < previous.raw_chars && !next.warning) return current;
-      return { ...current, [storageKey]: next };
-    });
+    // The request sequence above rejects responses that started before a newer
+    // poll.  Do not use payload length as a freshness signal: when a role ends,
+    // the backend rebuilds its live trajectory into a deduplicated normalized
+    // file, which can legitimately be shorter than the preceding live view.
+    setTrajectories((current) => ({ ...current, [storageKey]: next }));
   }
 
   useEffect(() => {

--- a/src/lh_harness/dashboard/state.py
+++ b/src/lh_harness/dashboard/state.py
@@ -28,7 +28,7 @@ from typing import Any
 
 from ..types import DEFAULT_LOG_DIR
 from ..supervisor.control_bus import ControlBus, _ensure_dir_fd_nofollow, _open_private_regular_at
-from ..supervisor.lifecycle import TERMINAL_STATUSES, canonical_lifecycle_status
+from ..supervisor.lifecycle import ACTIVE_STATUSES, TERMINAL_STATUSES, canonical_lifecycle_status
 from ..utils.run_boundary import safe_run_dir, safe_run_logs, safe_run_role, safe_run_rounds
 
 from ..agent_logs import parse_trajectory as parse_agent_trajectory
@@ -964,6 +964,29 @@ class DashboardState:
                 approval.resolved_at = time.time()
                 snapshot = approval.to_dict()
             self._persist_approval(snapshot)
+            if action == "stop":
+                # Resolving an end-of-round gate with "stop" is an explicit
+                # operator cancellation, not a worker crash.  Persist that
+                # intent before the blocking Manager hook is released so a
+                # fast worker exit cannot race Supervisor reconciliation and
+                # be misclassified as ``failed`` solely because incomplete
+                # runs deliberately return a non-zero process status.
+                now = time.time()
+
+                def mark_operator_stop(current: dict[str, Any]) -> dict[str, Any]:
+                    lifecycle = canonical_lifecycle_status(current.get("status"), default="")
+                    if lifecycle in TERMINAL_STATUSES:
+                        return current
+                    updated = {
+                        **current,
+                        "requested_action": "cancel",
+                        "operator_stop_requested_at": current.get("operator_stop_requested_at") or now,
+                    }
+                    if lifecycle in ACTIVE_STATUSES:
+                        updated["status"] = "stopping"
+                    return updated
+
+                self.control_bus.update_status(mark_operator_stop)
             self.control_bus.receipt(command, "applied", result={"approval_id": approval_id})
 
     def update_approval_context(self, approval_id: str, **updates: Any) -> bool:

--- a/src/lh_harness/trajectory_artifacts.py
+++ b/src/lh_harness/trajectory_artifacts.py
@@ -53,6 +53,7 @@ class StreamingTrajectoryArtifactWriter:
         self.step_count = 0
         self.total_bytes = 0
         self.screenshots: list[dict[str, Any]] = []
+        self.seen_tool_ids: set[str] = set()
         self.trajectory_path = round_dir / f"{role_name}_trajectory.jsonl"
         self.manifest_path = round_dir / f"{role_name}_screenshots.json"
         _remove_role_step_images(round_dir, role_name)
@@ -79,6 +80,18 @@ class StreamingTrajectoryArtifactWriter:
         for source_step in parse_trajectory(raw):
             if self.step_count >= _MAX_NORMALIZED_STEPS:
                 break
+            # Codex sends ``item.started`` and ``item.completed`` as separate
+            # JSONL records.  Parsing one streamed line at a time means the
+            # completion record defensively contains the tool call again, even
+            # though the earlier start record already materialised it.  Keep
+            # the first call and the later result so the live Dashboard shows
+            # one command card that transitions to completed.
+            if source_step.get("kind") == "tool_use":
+                tool_id = str(source_step.get("id") or "").strip()
+                if tool_id and tool_id in self.seen_tool_ids:
+                    continue
+                if tool_id:
+                    self.seen_tool_ids.add(tool_id)
             self.step_count += 1
             step, new_items, new_bytes = _materialize_step(
                 source_step,

--- a/tests/supervisor/test_hardening.py
+++ b/tests/supervisor/test_hardening.py
@@ -11,6 +11,7 @@ import pytest
 
 import lh_harness.supervisor.control_bus as control_bus
 import lh_harness.supervisor.service as supervisor_service
+from lh_harness.dashboard.state import ApprovalOption, DashboardState
 from lh_harness.supervisor.control_bus import ControlBus, RevisionConflict, iter_run_control_dirs
 from lh_harness.supervisor.service import IdempotencyConflict, RunSupervisor
 
@@ -43,6 +44,54 @@ def test_nonzero_worker_exit_is_failed_and_persists_crash_report(monkeypatch, tm
     assert status["report_status"] == "completed"
     crash = json.loads((run_dir / "logs" / "crash_report.json").read_text(encoding="utf-8"))
     assert crash["status"] == "failed"
+
+
+def test_end_at_approval_gate_is_cancelled_not_failed(monkeypatch, tmp_path: Path) -> None:
+    process = _Process()
+    monkeypatch.setattr("lh_harness.supervisor.service.subprocess.Popen", lambda *args, **kwargs: process)
+    runs_root = tmp_path / "runs"
+    supervisor = RunSupervisor(runs_root, workspace_root=tmp_path / "workspace")
+    created = supervisor.create_run(task="finish at the round limit")
+    run_dir = runs_root / created["id"]
+    logs = run_dir / "logs"
+    (logs / "role_management" / "rounds").mkdir(parents=True)
+    state = DashboardState(logs, runs_root=runs_root, control_enabled=True)
+    approval = state.create_approval(
+        title="Round limit reached",
+        options=[
+            ApprovalOption("continue", "Continue run"),
+            ApprovalOption("stop", "End run"),
+        ],
+        context={"phase": "end_of_round", "trigger": "max_rounds"},
+    )
+
+    assert state.resolve_approval(approval.approval_id, action="stop")
+    assert state.get_approval(approval.approval_id).action == "stop"
+    durable = ControlBus(run_dir).read_status()
+    assert durable["status"] == "stopping"
+    assert durable["requested_action"] == "cancel"
+
+    (logs / "report.json").write_text(
+        json.dumps(
+            {
+                "status": "incomplete",
+                "completion_satisfied": False,
+                "abort_reason": "max_rounds_exhausted",
+                "rounds": [{"round_index": 1}],
+                "final_response": "Useful final answer",
+            }
+        ),
+        encoding="utf-8",
+    )
+    process.returncode = 1
+
+    status = supervisor.status(created["id"])
+
+    assert status["status"] == "cancelled"
+    assert status["report_status"] == "incomplete"
+    assert status["exit_code"] == 1
+    assert "failure_reason" not in status
+    assert not (logs / "crash_report.json").exists()
 
 
 @pytest.mark.parametrize("completion_satisfied", [False, None])

--- a/tests/test_trajectory_artifacts.py
+++ b/tests/test_trajectory_artifacts.py
@@ -93,3 +93,41 @@ def test_streaming_writer_persists_screenshot_before_role_finishes(tmp_path: Pat
     normalized = (round_dir / "executor_trajectory.jsonl").read_text(encoding="utf-8")
     assert "executor_step_0002_01.png" in normalized
     assert "data:image" not in normalized
+
+
+def test_streaming_writer_pairs_codex_tool_start_and_completion_once(tmp_path: Path) -> None:
+    round_dir = tmp_path / "round_001"
+    live_path = round_dir / "executor_raw_trajectory.jsonl"
+    writer = StreamingTrajectoryArtifactWriter.from_live_path(live_path)
+    assert writer is not None
+    started = {
+        "type": "item.started",
+        "item": {
+            "id": "command-1",
+            "type": "command_execution",
+            "command": "/bin/zsh -lc pwd",
+            "status": "in_progress",
+        },
+    }
+    completed = {
+        "type": "item.completed",
+        "item": {
+            "id": "command-1",
+            "type": "command_execution",
+            "command": "/bin/zsh -lc pwd",
+            "status": "completed",
+            "exit_code": 0,
+            "aggregated_output": "/tmp/workspace\n",
+        },
+    }
+
+    writer.consume_line(json.dumps(started))
+    writer.consume_line(json.dumps(completed))
+
+    records = [
+        json.loads(line)
+        for line in (round_dir / "executor_trajectory.jsonl").read_text(encoding="utf-8").splitlines()
+    ]
+    assert [record["kind"] for record in records] == ["tool_use", "tool_result"]
+    assert records[0]["id"] == records[1]["tool_use_id"] == "command-1"
+    assert records[1]["status"] == "completed"


### PR DESCRIPTION
## What changed

- Treat an operator choosing **End run** at an approval gate as an explicit cancellation, so an incomplete worker's non-zero exit is shown as **Stopped** instead of **Failed**.
- Preserve real worker failures as failures and avoid generating a crash report for an intentional gate stop.
- Deduplicate Codex `item.started` / `item.completed` tool calls while the trajectory is still streaming.
- Let the Web client accept the shorter normalized trajectory written at role completion; request sequencing remains the stale-response guard.

## Why

A run that reached its configured round limit could already contain a clean audit and a useful final response. Choosing **End run** released the Manager gate without persisting the operator's stop intent, so Supervisor interpreted the expected non-zero incomplete exit as a crash. Separately, line-by-line live parsing emitted the same Codex tool call twice, and the client retained that duplicate because the finalized normalized payload was shorter.

## User impact

- Ended round-limit runs now display **Stopped / 已停止**, while their report, completed rounds, audit, and final response remain available.
- Real crashes still display **Failed**.
- Commands and tool calls appear once, with their completion result paired into the same activity card.

## Validation

- `uv run --extra test pytest -q` — 200 passed
- `npm test` — 47 passed
- `npm run build` — production TypeScript/Vite build passed
- Browser verification confirmed **已停止 · 已同步** and a single command card in the final trajectory.
