### PR TITLE
Recover from local role timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,6 +376,8 @@ cli_auditor  → auditor  → [run].agent / [run].model
 
 Every field above also has a CLI flag (`--agent`, `--max-rounds`, `--gui-executor-model`, `--auditor-timeout`, and so on) that overrides it for a single run. Run `lh-harness run --help` for the full list.
 
+If a Manager, Executor, or Auditor reaches its local episode timeout, the run keeps the partial trajectory and recorded task state, then lets the next Manager round inspect the real workspace and recover. The timeout remains an agent execution timeout; it is not treated as proof of a provider network failure. Repeated timed-out rounds still trigger the Dashboard's human-review gate.
+
 #### Manage computer-use plugins
 
 Computer-use setup is intentionally separate from task execution: `doctor` only reports status, and `lh-harness run` never installs, removes, or changes plugins. All changes go through `lh-harness plugin`.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -377,6 +377,8 @@ cli_auditor  → auditor  → [run].agent / [run].model
 
 上述每个字段都有对应的 CLI 参数（`--agent`、`--max-rounds`、`--gui-executor-model`、`--auditor-timeout` 等）可以对单次运行覆盖。完整列表见 `lh-harness run --help`。
 
+当 Manager、Executor 或 Auditor 达到本地 episode 超时时限时，Harness 会保留已有轨迹和任务状态，并让下一轮 Manager 检查真实 workspace 后继续恢复。本地 episode 超时会显示为“Agent 执行超时”，不会再被误判为 provider 网络故障；连续超时仍会触发 Dashboard 的人工复核门禁。
+
 #### 管理 computer-use 插件
 
 插件的安装与任务执行相互独立：`doctor` 只检查状态，`lh-harness run` 不会安装、卸载或修改任何插件。所有变更都通过 `lh-harness plugin` 完成。

--- a/src/lh_harness/manager.py
+++ b/src/lh_harness/manager.py
@@ -375,14 +375,17 @@ async def _run_impl(
             break
         manager_failure = classify_agent_runtime_failure(manager_result)
         if manager_failure is not None:
+            recoverable_timeout = manager_failure.kind == "timeout"
             plan_text = (
-                "Next: blocked\n\nReason:\n" + manager_failure.user_message
+                ("Next: invalid\n\nReason:\n" if recoverable_timeout else "Next: blocked\n\nReason:\n")
+                + manager_failure.user_message
                 if config.prompt_language == "en"
-                else "下一步: 阻塞\n\n阻塞原因:\n" + manager_failure.user_message
+                else ("下一步: 无效\n\n原因:\n" if recoverable_timeout else "下一步: 阻塞\n\n阻塞原因:\n")
+                + manager_failure.user_message
             )
             record = ManagedRound(
                 round_index=round_index,
-                next_step=MANAGER_NEXT_BLOCKED,
+                next_step=MANAGER_NEXT_INVALID if recoverable_timeout else MANAGER_NEXT_BLOCKED,
                 plan_text=plan_text,
                 harness_feedback=manager_failure.user_message,
                 task_state=current_task_state,
@@ -390,13 +393,12 @@ async def _run_impl(
                 manager_status=_failed_episode_status(
                     manager_result, manager_failure.user_message
                 ),
+                auditor_status={"invalid_plan": True} if recoverable_timeout else {},
             )
             _write_local(round_dir / "manager_plan.txt", plan_text)
             _write_local(round_dir / "harness_feedback.txt", manager_failure.user_message)
             rounds.append(record)
             await _record_round(env, config, role_dir, events_path, record)
-            gate.abort_reason = manager_failure.abort_reason
-            gate.failure_reason = manager_failure.user_message
             _append_event(
                 events_path,
                 "agent_runtime_failed",
@@ -420,6 +422,12 @@ async def _run_impl(
                 duration_ms=manager_result.duration_ms,
                 error=manager_failure.user_message,
             )
+            if recoverable_timeout:
+                if await _human_gate(gate, "progress", round_index, current_task_state):
+                    break
+                continue
+            gate.abort_reason = manager_failure.abort_reason
+            gate.failure_reason = manager_failure.user_message
             break
         plan_text = extract_role_manager_plan_text(_visible_output(manager_result)).strip()
         if not plan_text:
@@ -648,11 +656,12 @@ async def _run_impl(
             break
         executor_failure = classify_agent_runtime_failure(executor_result)
         if executor_failure is not None:
+            recoverable_timeout = executor_failure.kind == "timeout"
             record = ManagedRound(
                 round_index=round_index,
                 next_step=next_step,
                 plan_text=plan_text,
-                executor_output="",
+                executor_output=executor_output if recoverable_timeout else "",
                 harness_feedback=executor_failure.user_message,
                 task_state=current_task_state,
                 task_contract=current_task_contract,
@@ -665,8 +674,6 @@ async def _run_impl(
             _write_local(round_dir / "harness_feedback.txt", executor_failure.user_message)
             rounds.append(record)
             await _record_round(env, config, role_dir, events_path, record)
-            gate.abort_reason = executor_failure.abort_reason
-            gate.failure_reason = executor_failure.user_message
             _append_event(
                 events_path,
                 "agent_runtime_failed",
@@ -690,6 +697,12 @@ async def _run_impl(
                 duration_ms=executor_result.duration_ms,
                 error=executor_failure.user_message,
             )
+            if recoverable_timeout:
+                if await _human_gate(gate, "progress", round_index, current_task_state):
+                    break
+                continue
+            gate.abort_reason = executor_failure.abort_reason
+            gate.failure_reason = executor_failure.user_message
             break
         await _write_remote_round_text(env, config, round_index, "executor_output.txt", executor_output)
         _append_event(
@@ -782,6 +795,7 @@ async def _run_impl(
             break
         auditor_failure = classify_agent_runtime_failure(auditor_result)
         if auditor_failure is not None:
+            recoverable_timeout = auditor_failure.kind == "timeout"
             record = ManagedRound(
                 round_index=round_index,
                 next_step=next_step,
@@ -800,8 +814,6 @@ async def _run_impl(
             _write_local(round_dir / "harness_feedback.txt", auditor_failure.user_message)
             rounds.append(record)
             await _record_round(env, config, role_dir, events_path, record)
-            gate.abort_reason = auditor_failure.abort_reason
-            gate.failure_reason = auditor_failure.user_message
             _append_event(
                 events_path,
                 "agent_runtime_failed",
@@ -825,6 +837,12 @@ async def _run_impl(
                 duration_ms=auditor_result.duration_ms,
                 error=auditor_failure.user_message,
             )
+            if recoverable_timeout:
+                if await _human_gate(gate, "progress", round_index, current_task_state):
+                    break
+                continue
+            gate.abort_reason = auditor_failure.abort_reason
+            gate.failure_reason = auditor_failure.user_message
             break
         auditor_report, auditor_status = await _auditor_report_with_format_repair(
             env=env,
@@ -1690,7 +1708,7 @@ def _episode_status(result: EpisodeResult) -> dict[str, Any]:
 
 def _failed_episode_status(result: EpisodeResult, user_message: str) -> dict[str, Any]:
     status = _episode_status(result)
-    status["status"] = "error"
+    status["status"] = "timeout" if result.status == "timeout" else "error"
     status["error"] = user_message
     return status
 

--- a/src/lh_harness/provider_errors.py
+++ b/src/lh_harness/provider_errors.py
@@ -67,11 +67,13 @@ _CLASSIFIERS: tuple[tuple[str, re.Pattern[str], str], ...] = (
 
 
 def classify_agent_runtime_failure(result: EpisodeResult) -> AgentRuntimeFailure | None:
-    """Return a terminal failure only when the agent runtime itself failed.
+    """Return a failure only when the agent runtime itself failed.
 
     Tool commands run by an otherwise healthy Executor may fail as part of the
     task and must remain auditable task evidence.  We therefore require a
-    non-success episode status or a normalized hard runtime signal.
+    non-success episode status or a normalized hard runtime signal. Local
+    episode timeouts are classified separately so the manager can recover;
+    genuine provider failures remain terminal at the caller.
     """
 
     metadata = result.metadata if isinstance(result.metadata, dict) else {}
@@ -82,11 +84,17 @@ def classify_agent_runtime_failure(result: EpisodeResult) -> AgentRuntimeFailure
     combined = "\n".join(candidates)
     kind = "timeout" if result.status == "timeout" else "provider_error"
     label = "Agent 执行超时" if kind == "timeout" else "Agent provider 启动或运行失败"
-    for candidate_kind, pattern, candidate_label in _CLASSIFIERS:
-        if pattern.search(combined):
-            kind = candidate_kind
-            label = candidate_label
-            break
+    # A command episode that reaches its harness budget is a local timeout, not
+    # evidence that the provider connection failed. In particular, the
+    # adapter's own "Episode timed out after ..." message matches the generic
+    # network classifier below. Keep the explicit status authoritative so the
+    # manager can recover from the real workspace in a later round.
+    if result.status != "timeout":
+        for candidate_kind, pattern, candidate_label in _CLASSIFIERS:
+            if pattern.search(combined):
+                kind = candidate_kind
+                label = candidate_label
+                break
     message = next((item for item in candidates if _specific_message(item)), None)
     message = message or next(iter(candidates), "agent runtime failed")
     message = _clean(message, 1200)

--- a/tests/test_manager_hardening.py
+++ b/tests/test_manager_hardening.py
@@ -215,6 +215,117 @@ async def test_provider_failure_stops_without_round_limit_approval(tmp_path: Pat
 
 
 @pytest.mark.asyncio
+async def test_episode_timeout_is_preserved_and_recovers_in_the_next_round(tmp_path: Path) -> None:
+    outputs = iter(
+        (
+            EpisodeResult(status="timeout", error="Episode timed out after 10s."),
+            EpisodeResult(
+                status="done",
+                actions_log="Next: blocked\n\nReason:\nNeed operator input after recovery check.",
+            ),
+            EpisodeResult(status="done", actions_log="The run stopped after preserving its state."),
+        )
+    )
+
+    class SequencedAgent:
+        async def run_episode(self, _prompt, _env, _budget, live_trajectory_path=None):
+            return next(outputs)
+
+    config = HarnessConfig(
+        max_total_episodes=2,
+        manager_budget=EpisodeBudget(max_duration_seconds=10),
+        workspace_path=str(tmp_path / "workspace"),
+        harness_dir=str(tmp_path / "harness"),
+        log_dir=str(tmp_path / "logs"),
+    )
+    result = await run(
+        task="recover after a local episode timeout",
+        env=LocalEnvironment(str(tmp_path / "tmp")),
+        config=config,
+        agent=SequencedAgent(),
+    )
+
+    assert result["status"] == "blocked"
+    assert result["rounds_run"] == 2
+    assert result["failure_reason"] == ""
+    assert result["rounds"][0]["manager_status"]["status"] == "timeout"
+    assert result["rounds"][0]["harness_feedback"] == (
+        "Agent 执行超时：Episode timed out after 10s."
+    )
+
+
+@pytest.mark.asyncio
+async def test_executor_timeout_preserves_partial_output_for_recovery(tmp_path: Path) -> None:
+    outputs = iter(
+        (
+            EpisodeResult(status="done", actions_log="Next: cli\n\nCurrent Task State:\nwork pending"),
+            EpisodeResult(
+                status="timeout",
+                actions_log="executor changed part of the workspace",
+                error="Episode timed out after 10s.",
+            ),
+            EpisodeResult(status="done", actions_log="Next: blocked\n\nReason:\nrecovery checked"),
+            EpisodeResult(status="done", actions_log="Partial work was preserved."),
+        )
+    )
+
+    class SequencedAgent:
+        async def run_episode(self, _prompt, _env, _budget, live_trajectory_path=None):
+            return next(outputs)
+
+    result = await run(
+        task="recover an executor timeout",
+        env=LocalEnvironment(str(tmp_path / "tmp")),
+        config=HarnessConfig(
+            max_total_episodes=2,
+            workspace_path=str(tmp_path / "workspace"),
+            harness_dir=str(tmp_path / "harness"),
+            log_dir=str(tmp_path / "logs"),
+        ),
+        agent=SequencedAgent(),
+    )
+
+    first_round = result["rounds"][0]
+    assert result["rounds_run"] == 2
+    assert first_round["executor_status"]["status"] == "timeout"
+    assert first_round["executor_output"] == "executor changed part of the workspace"
+
+
+@pytest.mark.asyncio
+async def test_auditor_timeout_keeps_executor_result_and_recovers(tmp_path: Path) -> None:
+    outputs = iter(
+        (
+            EpisodeResult(status="done", actions_log="Next: cli\n\nCurrent Task State:\nwork pending"),
+            EpisodeResult(status="done", actions_log="executor completed the requested change"),
+            EpisodeResult(status="timeout", error="Episode timed out after 10s."),
+            EpisodeResult(status="done", actions_log="Next: blocked\n\nReason:\nrecovery checked"),
+            EpisodeResult(status="done", actions_log="The executor result was preserved."),
+        )
+    )
+
+    class SequencedAgent:
+        async def run_episode(self, _prompt, _env, _budget, live_trajectory_path=None):
+            return next(outputs)
+
+    result = await run(
+        task="recover an auditor timeout",
+        env=LocalEnvironment(str(tmp_path / "tmp")),
+        config=HarnessConfig(
+            max_total_episodes=2,
+            workspace_path=str(tmp_path / "workspace"),
+            harness_dir=str(tmp_path / "harness"),
+            log_dir=str(tmp_path / "logs"),
+        ),
+        agent=SequencedAgent(),
+    )
+
+    first_round = result["rounds"][0]
+    assert result["rounds_run"] == 2
+    assert first_round["auditor_status"]["status"] == "timeout"
+    assert first_round["executor_output"] == "executor completed the requested change"
+
+
+@pytest.mark.asyncio
 async def test_late_crash_report_preserves_completed_rounds(tmp_path: Path) -> None:
     outputs = iter(
         (

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -121,6 +121,17 @@ def test_invalid_model_failure_unwraps_nested_provider_json() -> None:
     assert "{\"type\"" not in failure.user_message
 
 
+def test_runtime_failure_classifier_keeps_local_episode_timeout_authoritative() -> None:
+    failure = classify_agent_runtime_failure(
+        EpisodeResult(status="timeout", error="Episode timed out after 1800s.")
+    )
+
+    assert failure is not None
+    assert failure.kind == "timeout"
+    assert failure.abort_reason == "provider_timeout"
+    assert failure.user_message == "Agent 执行超时：Episode timed out after 1800s."
+
+
 def test_chinese_invalid_api_key_is_classified_as_authentication() -> None:
     message = "API Error: 400 无效的api key"
     result = EpisodeResult(


### PR DESCRIPTION
## Summary

- keep an explicit local episode timeout authoritative instead of reclassifying its synthesized `timed out` text as a provider network failure
- preserve timeout status and partial Executor output, then let the next Manager round inspect the real workspace and recover
- apply the same recoverable control flow to Manager, Executor, and Auditor episodes
- document the behavior and add regression coverage for all three roles

## Root cause

`CommandAgentAdapter` correctly returned `EpisodeResult(status="timeout")` after the role budget elapsed, but the generic provider-error classifier matched the adapter's own `Episode timed out after ...` message with its network timeout regex. That changed the failure kind to `network`, causing the Manager to terminate the run as a provider failure.

## Impact

Local role timeouts now remain distinguishable from genuine authentication, model, quota, rate-limit, and provider-network failures. Partial work and task state remain available to the next Manager round, while repeated timeout rounds still reach the existing human-review gate.

This PR does not claim to fix a Headroom proxy stall itself; it fixes the Harness misclassification and destructive terminal handling exposed by issue #49.

Related to #49.

## Validation

- `203 passed, 1 skipped`
- Ruff checks passed
- `git diff --check` passed
- manual real-subprocess timeout comparison reproduced `network` on the base commit and `timeout` with preserved partial output on this branch
