### PR TITLE
fix(eval/harbor): set self.extra_env so env-driven config works on Harbor >=0.13

### DIFF
--- a/eval/TB-harness/Harness/src/harbor_agent.py
+++ b/eval/TB-harness/Harness/src/harbor_agent.py
@@ -122,6 +122,14 @@ class CuaHarnessClaudeCodeAgent(BaseAgent):
             **kwargs,
         )
 
+        # Harbor's factory passes ``extra_env`` into the agent constructor, but
+        # ``BaseAgent.__init__`` (Harbor >= 0.13) does not persist unknown kwargs,
+        # so ``self.extra_env`` is never set by ``super().__init__``. The reads
+        # below (and in subclasses) would then raise ``AttributeError``. Store it
+        # explicitly so env-driven configuration works regardless of the Harbor
+        # version in the environment.
+        self.extra_env = dict(extra_env or {})
+
         default_config = HarnessConfig()
         self._api_key = api_key
         self._base_url = base_url


### PR DESCRIPTION
## Problem
`CuaHarnessClaudeCodeAgent.__init__` passes `extra_env=extra_env` to `super().__init__()` and then reads `self.extra_env` right after (e.g. `env=self.extra_env` in the `_coerce_str` calls). Harbor's factory does pass `extra_env` into the agent constructor, but `harbor.agents.base.BaseAgent.__init__` (Harbor >= 0.13) does not persist unknown kwargs, so `self.extra_env` is never set.

Result: constructing the agent raises `AttributeError: 'CuaHarnessClaudeCodeAgent' object has no attribute 'extra_env'` before any task runs. This affects the Claude Code agent (and any subclass, e.g. a DeepSeek backend) whenever the installed Harbor doesn't store `extra_env`.

## Fix
Set `self.extra_env = dict(extra_env or {})` immediately after `super().__init__()`, so env-driven configuration works regardless of the Harbor version. Minimal, one-line addition; no behavior change when Harbor does store it.