### PR TITLE
feat: add cost-aware executor tier routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,7 +376,30 @@ cli_auditor  → auditor  → [run].agent / [run].model / [run].reasoning_effort
 | `[run.roles.cli_auditor]` | `auditor` | CLI audit |
 | `[run.roles.final_response]` | `manager` | The closing reply written for you |
 
-Every field above also has a CLI flag (`--agent`, `--max-rounds`, `--gui-executor-model`, `--auditor-timeout`, and so on) that overrides it for a single run. Run `lh-harness run --help` for the full list.
+Executor routing can choose a low-cost tier first and move a repeatedly rejected subtask to a stronger backend. This example is ready to copy; the parent executor table is optional, but is useful as the fallback for tier fields that are omitted:
+
+```toml
+[run.roles.executor]
+agent = "codex"
+model = "gpt-5.6-sol"
+
+[run.roles.executor.cheap]
+model = "gpt-5.6-luna"
+
+[run.roles.executor.strong]
+agent = "claude_code"
+
+[run.executor_routing]
+default_tier = "cheap"
+escalate_after_failures = 2
+escalation_tier = "strong"
+```
+
+The Manager may choose an initial tier for a GUI or CLI subtask; omitting it selects `default_tier`, while explicitly requesting `escalation_tier` uses it immediately. A subtask is identified by its route plus the normalized `Task:` text. Only a successfully parsed final Auditor result with `Status: incomplete` or `Status: blocked` increments its failure count. Reaching the threshold changes the **next** execution of that same subtask, and escalation then remains sticky even if the Manager requests the cheaper tier. `Status: complete`, a new task, or a GUI/CLI route change resets the state. Provider errors, timeouts, cancellations, and rejected format repairs do not count; a plan without `Task:` gets a per-round identity and cannot accumulate failures across rounds.
+
+Tier fields fall back independently. If a tier omits `agent`, it inherits the concrete GUI/CLI executor chain shown above. An explicit tier `model` is always used. Repeating the route's effective `agent` while omitting `model` inherits the route model; changing `agent` while omitting `model` makes the new backend use its own default instead of inheriting a model from another backend. An empty tier table inherits both route fields. Tier tables are currently project-config-only. Tier names are 1-64 ASCII letters, digits, `_`, or `-`, and must start with a letter or digit. The ordinary role, timeout, and run fields still have CLI flags (`--agent`, `--max-rounds`, `--gui-executor-model`, `--auditor-timeout`, and so on); run `lh-harness run --help` for that list.
+
+Each executor attempt or rejected routing plan stores an `executor_routing` record in the round ledger (`rounds.jsonl` and per-round `round.json`), routing events, and the final `report.json` under `rounds`, including its task id, requested and selected tier, reason, and failure counts. Dashboard **Resume** starts a new run with `resume_kind = "retry"`: it preserves the task/config reference, rereads the current project configuration, and starts routing counts at zero. It is not checkpoint rehydration.
 
 If a Manager, Executor, or Auditor reaches its local episode timeout, the run keeps the partial trajectory and recorded task state, then lets the next Manager round inspect the real workspace and recover. The timeout remains an agent execution timeout; it is not treated as proof of a provider network failure. Repeated timed-out rounds still trigger the Dashboard's human-review gate.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -377,7 +377,30 @@ cli_auditor  → auditor  → [run].agent / [run].model / [run].reasoning_effort
 | `[run.roles.cli_auditor]` | `auditor` | CLI 验收 |
 | `[run.roles.final_response]` | `manager` | 写给你的最终回复 |
 
-上述每个字段都有对应的 CLI 参数（`--agent`、`--max-rounds`、`--gui-executor-model`、`--auditor-timeout` 等）可以对单次运行覆盖。完整列表见 `lh-harness run --help`。
+Executor 路由可以先使用低成本层级，并在同一子任务连续未通过时切换到更强的后端。下面的配置可以直接复制；父级 executor 表是可选的，但适合作为各 tier 省略字段时的回退来源：
+
+```toml
+[run.roles.executor]
+agent = "codex"
+model = "gpt-5.6-sol"
+
+[run.roles.executor.cheap]
+model = "gpt-5.6-luna"
+
+[run.roles.executor.strong]
+agent = "claude_code"
+
+[run.executor_routing]
+default_tier = "cheap"
+escalate_after_failures = 2
+escalation_tier = "strong"
+```
+
+Manager 可以为 GUI 或 CLI 子任务选择初始 tier；省略时使用 `default_tier`，显式请求 `escalation_tier` 时立即使用。子任务身份由 route 与规范化后的 `Task:` 文本共同确定。只有成功解析的最终 Auditor 结果为 `Status: incomplete` 或 `Status: blocked` 才会增加失败次数。达到阈值后，从同一子任务的**下一次**执行开始升级；升级具有粘性，即使 Manager 再请求低成本 tier 也不会降级。`Status: complete`、新任务或 GUI/CLI route 变化会重置状态。Provider 错误、超时、取消和未通过的格式修复都不计数；缺少 `Task:` 的计划每轮使用独立身份，不会跨轮累计。
+
+Tier 的字段分别回退。tier 未设置 `agent` 时，沿用上方 GUI/CLI executor 的具体回退链；显式配置的 tier `model` 始终生效。tier 显式重复 route 的有效 `agent` 且省略 `model` 时继承 route model；更换 `agent` 但省略 `model` 时，新后端使用自身默认模型，不会错误继承其他后端的模型。空 tier 表同时继承 route 的两个字段。tier 表目前只能写在项目配置中；tier 名必须由 1-64 位 ASCII 字母、数字、`_` 或 `-` 组成，且首位必须是字母或数字。普通角色、超时与 run 字段仍有 CLI 参数（如 `--agent`、`--max-rounds`、`--gui-executor-model`、`--auditor-timeout`）；完整列表见 `lh-harness run --help`。
+
+每次实际 executor 尝试或被拒绝的路由计划，都会在 round ledger（`rounds.jsonl` 与每轮的 `round.json`）、路由事件以及最终 `report.json` 的 `rounds` 中记录 `executor_routing`，包含 task id、请求/实际 tier、选择原因和失败计数。Dashboard 的 **Resume** 会以 `resume_kind = "retry"` 启动一个新 run：保留任务与配置引用，重新读取当前项目配置，并让路由计数从零开始；它不是 checkpoint 状态恢复。
 
 当 Manager、Executor 或 Auditor 达到本地 episode 超时时限时，Harness 会保留已有轨迹和任务状态，并让下一轮 Manager 检查真实 workspace 后继续恢复。本地 episode 超时会显示为“Agent 执行超时”，不会再被误判为 provider 网络故障；连续超时仍会触发 Dashboard 的人工复核门禁。
 

--- a/src/lh_harness/cli.py
+++ b/src/lh_harness/cli.py
@@ -15,7 +15,7 @@ import traceback
 import uuid
 import webbrowser
 from pathlib import Path
-from typing import TYPE_CHECKING, Awaitable, Iterable
+from typing import TYPE_CHECKING, Awaitable, Callable, Iterable
 
 from . import HOMEPAGE, ISSUES_URL, __version__
 from .config import (
@@ -418,6 +418,12 @@ def main(argv: list[str] | None = None) -> int:
         )
 
     run_parser = add_command("run", "Run a long-horizon task through role-managed LongHorizon-Harness")
+    # Executor tiers are project-config-only: carry the parsed objects through
+    # argparse without exposing a fixed set of flags for arbitrary tier names.
+    run_parser.set_defaults(
+        executor_tiers=run_default("executor_tiers"),
+        executor_routing=run_default("executor_routing"),
+    )
     run_parser.add_argument("--task", required=True, help="Task text or @path")
     run_parser.add_argument(
         "--agent",
@@ -1626,6 +1632,7 @@ def _run_command(args: argparse.Namespace) -> int:
         harness_dir=harness_dir,
         log_dir=log_dir,
         prompt_language=args.prompt_language,
+        executor_routing=getattr(args, "executor_routing", None),
     )
     env = _build_env(args.env, tmp_dir=str(run_dir / "tmp"))
 
@@ -1716,7 +1723,7 @@ def _run_command(args: argparse.Namespace) -> int:
         if not args.dashboard_no_open:
             _open_browser_when_ready(dashboard_handle.url)
 
-    agent_cache: dict[tuple[str, str, str | None], object] = {}
+    agent_cache: dict[tuple[str, str, str | None, str | None], object] = {}
     plugin_mcp_cache: dict[str, str | None] = {}
 
     def resolve_mcp_config(agent_name: str) -> str | None:
@@ -1744,20 +1751,23 @@ def _run_command(args: argparse.Namespace) -> int:
                 plugin_mcp_cache[agent_name] = config or None
         return plugin_mcp_cache[agent_name]
 
-    def build_role_agent(role: str, *, permission_role: str | None = None):
-        # Agent and model resolve independently down the same fallback chain, so
-        # mixing backends never sends one backend the other's model id. The
-        # permission role is part of the cache key: two Claude roles using the
-        # same model must never share a differently privileged adapter.
-        name = _resolve_role_option(args, role, "agent")
-        model = _resolve_role_model(args, role)
-        effort = _resolve_role_reasoning_effort(args, role, name)
-        effective_permission_role = permission_role or role
-        key = (effective_permission_role, name, model, effort)
+    def build_bound_agent(
+        permission_role: str,
+        name: str,
+        model: str | None,
+        *,
+        reasoning_role: str | None = None,
+    ):
+        # The permission role is part of the cache key: adapters with identical
+        # provider bindings must not be shared across GUI and CLI sandboxes.
+        effort = _resolve_role_reasoning_effort(
+            args, reasoning_role or permission_role, name
+        )
+        key = (permission_role, name, model, effort)
         if key not in agent_cache:
             agent_cache[key] = _build_agent(
                 name,
-                role=effective_permission_role,
+                role=permission_role,
                 model=model,
                 api_key=args.api_key,
                 base_url=args.base_url,
@@ -1771,11 +1781,19 @@ def _run_command(args: argparse.Namespace) -> int:
             )
         return agent_cache[key]
 
+    def build_role_agent(role: str, *, permission_role: str | None = None):
+        # Agent and model resolve independently down the same fallback chain, so
+        # mixing backends never sends one backend the other's model id.
+        return build_bound_agent(
+            permission_role or role,
+            _resolve_role_option(args, role, "agent"),
+            _resolve_role_model(args, role),
+            reasoning_role=role,
+        )
+
     try:
         role_agents = {
             "manager_agent": build_role_agent("manager"),
-            "gui_executor_agent": build_role_agent("gui_executor"),
-            "cli_executor_agent": build_role_agent("cli_executor"),
             "gui_auditor_agent": build_role_agent("gui_auditor"),
             "cli_auditor_agent": build_role_agent("cli_auditor"),
             # Format repair sees only the previous auditor text and has no tools.
@@ -1787,6 +1805,7 @@ def _run_command(args: argparse.Namespace) -> int:
             ),
             "final_response_agent": build_role_agent("final_response"),
         }
+        role_agents.update(_build_executor_agent_kwargs(args, build_bound_agent))
     except BaseException as exc:
         _write_bootstrap_failure(log_dir, task, exc, max_rounds=max_rounds)
         print(f"Worker failed during agent setup: {exc}", file=sys.stderr)
@@ -2072,6 +2091,65 @@ def _resolve_role_reasoning_effort(
             return None
         current = _ROLE_PARENTS[current]
     return getattr(args, "reasoning_effort", None)
+
+
+def _resolve_executor_tier_binding(
+    args: argparse.Namespace,
+    route_role: str,
+    tier_spec: dict[str, str],
+) -> tuple[str, str | None]:
+    """Resolve one tier without carrying a model across a backend switch."""
+
+    route_agent = _resolve_role_option(args, route_role, "agent")
+    route_model = _resolve_role_model(args, route_role)
+    tier_agent = tier_spec.get("agent")
+    tier_model = tier_spec.get("model")
+    if tier_agent is None:
+        return route_agent, tier_model if tier_model is not None else route_model
+    if tier_model is not None:
+        return tier_agent, tier_model
+    # Repeating the effective backend preserves field-level inheritance. An
+    # actual provider switch starts a new model namespace and uses its default.
+    return tier_agent, route_model if tier_agent == route_agent else None
+
+
+def _build_executor_agent_kwargs(
+    args: argparse.Namespace,
+    build_agent: Callable[[str, str, str | None], object],
+) -> dict[str, object]:
+    """Build legacy singular executors or configured tier maps."""
+
+    if getattr(args, "executor_routing", None) is None:
+        return {
+            "gui_executor_agent": build_agent(
+                "gui_executor",
+                _resolve_role_option(args, "gui_executor", "agent"),
+                _resolve_role_model(args, "gui_executor"),
+            ),
+            "cli_executor_agent": build_agent(
+                "cli_executor",
+                _resolve_role_option(args, "cli_executor", "agent"),
+                _resolve_role_model(args, "cli_executor"),
+            ),
+        }
+
+    tier_specs = getattr(args, "executor_tiers", None)
+    if not isinstance(tier_specs, dict) or not tier_specs:
+        raise ValueError("executor routing requires configured executor tiers")
+
+    result: dict[str, object] = {}
+    for route_role, keyword in (
+        ("gui_executor", "gui_executor_agents"),
+        ("cli_executor", "cli_executor_agents"),
+    ):
+        result[keyword] = {
+            tier: build_agent(
+                route_role,
+                *_resolve_executor_tier_binding(args, route_role, tier_spec),
+            )
+            for tier, tier_spec in tier_specs.items()
+        }
+    return result
 
 
 def _public_role_configs_from_args(

--- a/src/lh_harness/config.py
+++ b/src/lh_harness/config.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 import importlib
+import re
 from pathlib import Path
 from typing import Any
 
-from .types import MAX_ROUNDS
+from .types import ExecutorRoutingConfig, MAX_ROUNDS
 
 try:
     tomllib = importlib.import_module("tomllib")
@@ -45,6 +46,7 @@ _RUN_KEYS = {
     "dashboard_port",
     "roles",
     "timeouts",
+    "executor_routing",
 }
 _STRING_KEYS = {
     "model",
@@ -56,6 +58,12 @@ _STRING_KEYS = {
     "claude_mcp_config",
     "codex_mcp_config",
 }
+_EXECUTOR_ROUTING_KEYS = {
+    "default_tier",
+    "escalate_after_failures",
+    "escalation_tier",
+}
+_EXECUTOR_TIER_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$")
 
 CONFIG_TEMPLATE = """# LongHorizon-Harness project defaults.
 # Explicit CLI arguments override these values.
@@ -114,6 +122,21 @@ auditor = 300
 [run.roles.executor]
 # agent = "codex"
 # model = "gpt-5.6-sol"
+
+# Optional cost-aware executor routing. Tier-specific fields override the
+# parent executor role; omitted fields inherit from [run.roles.executor].
+# [run.roles.executor.cheap]
+# agent = "deepseek_harness"
+# model = "deepseek-v4-flash"
+#
+# [run.roles.executor.strong]
+# agent = "codex"
+# model = "gpt-5.6-sol"
+#
+# [run.executor_routing]
+# default_tier = "cheap"
+# escalate_after_failures = 2
+# escalation_tier = "strong"
 
 [run.roles.gui_executor]
 # agent = "codex"
@@ -227,7 +250,9 @@ def _flatten_run_table(run: dict[str, Any]) -> dict[str, Any]:
     for role, values in roles.items():
         if not isinstance(values, dict):
             raise ProjectConfigError(f"[run.roles.{role}] must be a TOML table")
-        unknown_role_keys = set(values) - {"agent", "model", "reasoning_effort"}
+        role_keys = {"agent", "model", "reasoning_effort"}
+        tier_names = set(values) - role_keys if role == "executor" else set()
+        unknown_role_keys = set(values) - role_keys - tier_names
         if unknown_role_keys:
             raise ProjectConfigError(
                 f"unknown [run.roles.{role}] key(s): {_names(unknown_role_keys)}"
@@ -244,6 +269,34 @@ def _flatten_run_table(run: dict[str, Any]) -> dict[str, Any]:
             defaults[f"{role}_reasoning_effort"] = _reasoning_effort(
                 values["reasoning_effort"], f"run.roles.{role}.reasoning_effort"
             )
+        if role == "executor" and tier_names:
+            defaults["executor_tiers"] = _executor_tiers(values, tier_names)
+
+    routing_value = run.get("executor_routing")
+    routing = _executor_routing(routing_value) if routing_value is not None else None
+    tiers = defaults.get("executor_tiers")
+    if tiers is not None and routing is None:
+        raise ProjectConfigError(
+            "run.executor_routing is required when run.roles.executor tiers are configured"
+        )
+    if routing is not None:
+        if tiers is None:
+            raise ProjectConfigError(
+                "run.roles.executor must configure at least two tiers when run.executor_routing is configured"
+            )
+        if len(tiers) < 2:
+            raise ProjectConfigError(
+                "run.roles.executor must configure at least two tiers when run.executor_routing is configured"
+            )
+        if routing.default_tier not in tiers:
+            raise ProjectConfigError(
+                "run.executor_routing.default_tier must reference a configured run.roles.executor tier"
+            )
+        if routing.escalation_tier not in tiers:
+            raise ProjectConfigError(
+                "run.executor_routing.escalation_tier must reference a configured run.roles.executor tier"
+            )
+        defaults["executor_routing"] = routing
 
     timeouts = run.get("timeouts", {})
     if not isinstance(timeouts, dict):
@@ -254,6 +307,72 @@ def _flatten_run_table(run: dict[str, Any]) -> dict[str, Any]:
     for role, value in timeouts.items():
         defaults[f"{role}_timeout"] = _positive_int(value, f"run.timeouts.{role}")
     return defaults
+
+
+def _executor_tiers(
+    executor_role: dict[str, Any], tier_names: set[str]
+) -> dict[str, dict[str, str]]:
+    tiers: dict[str, dict[str, str]] = {}
+    for tier_name in sorted(tier_names):
+        tier_path = f"run.roles.executor.{tier_name}"
+        if not _EXECUTOR_TIER_PATTERN.fullmatch(tier_name):
+            raise ProjectConfigError(
+                f"{tier_path} must use a 1-64 character tier name containing only letters, digits, '_' or '-', starting with a letter or digit"
+            )
+        value = executor_role[tier_name]
+        if not isinstance(value, dict):
+            raise ProjectConfigError(f"[{tier_path}] must be a TOML table")
+        unknown = set(value) - {"agent", "model"}
+        if unknown:
+            raise ProjectConfigError(
+                f"unknown [{tier_path}] key(s): {_names(unknown)}"
+            )
+        parsed: dict[str, str] = {}
+        if "agent" in value:
+            parsed["agent"] = _choice(
+                value["agent"], f"{tier_path}.agent", _AGENT_CHOICES
+            )
+        if "model" in value:
+            parsed["model"] = _string(value["model"], f"{tier_path}.model")
+        tiers[tier_name] = parsed
+    return tiers
+
+
+def _executor_routing(value: Any) -> ExecutorRoutingConfig:
+    path = "run.executor_routing"
+    if not isinstance(value, dict):
+        raise ProjectConfigError(f"[{path}] must be a TOML table")
+    unknown = set(value) - _EXECUTOR_ROUTING_KEYS
+    if unknown:
+        raise ProjectConfigError(f"unknown [{path}] key(s): {_names(unknown)}")
+    missing = _EXECUTOR_ROUTING_KEYS - set(value)
+    if missing:
+        raise ProjectConfigError(f"missing [{path}] key(s): {_names(missing)}")
+    default_tier = _tier_reference(value["default_tier"], f"{path}.default_tier")
+    escalation_tier = _tier_reference(
+        value["escalation_tier"], f"{path}.escalation_tier"
+    )
+    failures = _positive_int(
+        value["escalate_after_failures"], f"{path}.escalate_after_failures"
+    )
+    if default_tier == escalation_tier:
+        raise ProjectConfigError(
+            "run.executor_routing.default_tier and run.executor_routing.escalation_tier must be different"
+        )
+    return ExecutorRoutingConfig(
+        default_tier=default_tier,
+        escalate_after_failures=failures,
+        escalation_tier=escalation_tier,
+    )
+
+
+def _tier_reference(value: Any, name: str) -> str:
+    result = _string(value, name)
+    if not _EXECUTOR_TIER_PATTERN.fullmatch(result):
+        raise ProjectConfigError(
+            f"{name} must name a configured executor tier using letters, digits, '_' or '-'"
+        )
+    return result
 
 
 def _string(value: Any, name: str) -> str:

--- a/src/lh_harness/executor_routing.py
+++ b/src/lh_harness/executor_routing.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, replace
+import hashlib
+import re
+from typing import Literal
+
+from .types import ExecutorRoutingConfig, RoleNextStep
+
+RoutingSelectionReason = Literal[
+    "default",
+    "manager",
+    "manager_escalation",
+    "automatic_escalation",
+    "invalid",
+]
+RoutingAuditSignal = Literal[
+    "pending",
+    "complete",
+    "incomplete",
+    "blocked",
+    "not_counted",
+]
+_EXECUTOR_TIER_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$")
+
+
+@dataclass(frozen=True)
+class ExecutorRoutingDecision:
+    enabled: bool
+    task_id: str
+    task_present: bool
+    requested_tier: str | None
+    selected_tier: str | None
+    selection_reason: RoutingSelectionReason
+    failures_before: int
+    failures_after: int
+    escalation_active: bool
+    audit_signal: RoutingAuditSignal = "pending"
+
+    def to_dict(self) -> dict[str, object]:
+        return asdict(self)
+
+
+class ExecutorRouter:
+    def __init__(self, tiers: set[str], policy: ExecutorRoutingConfig) -> None:
+        invalid_tiers = [tier for tier in tiers if not is_valid_executor_tier_name(tier)]
+        if invalid_tiers:
+            raise ValueError(
+                "Executor tier names must use 1-64 ASCII letters, digits, '_' or '-': "
+                + ", ".join(sorted(repr(tier) for tier in invalid_tiers))
+            )
+        if policy.default_tier not in tiers or policy.escalation_tier not in tiers:
+            raise ValueError("Executor routing policy must reference configured tiers")
+        self.tiers = frozenset(tiers)
+        self.policy = policy
+        self._active_task_id: str | None = None
+        self._failure_count = 0
+        self._escalation_active = False
+
+    def select(
+        self,
+        *,
+        next_step: RoleNextStep,
+        task_text: str,
+        requested_tier: str | None,
+        round_index: int,
+    ) -> ExecutorRoutingDecision:
+        task_id, task_present = executor_task_identity(
+            next_step=next_step,
+            task_text=task_text,
+            round_index=round_index,
+        )
+        same_task = task_id == self._active_task_id
+        failures = self._failure_count if same_task else 0
+        escalated = self._escalation_active if same_task else False
+
+        if requested_tier == "" or (
+            requested_tier is not None and requested_tier not in self.tiers
+        ):
+            return ExecutorRoutingDecision(
+                enabled=True,
+                task_id=task_id,
+                task_present=task_present,
+                requested_tier=requested_tier,
+                selected_tier=None,
+                selection_reason="invalid",
+                failures_before=failures,
+                failures_after=failures,
+                escalation_active=escalated,
+                audit_signal="not_counted",
+            )
+
+        if escalated:
+            selected_tier = self.policy.escalation_tier
+            selection_reason: RoutingSelectionReason = (
+                "manager_escalation"
+                if requested_tier == self.policy.escalation_tier
+                else "automatic_escalation"
+            )
+        elif requested_tier is None:
+            selected_tier = self.policy.default_tier
+            selection_reason = "default"
+        elif requested_tier == self.policy.escalation_tier:
+            selected_tier = requested_tier
+            selection_reason = "manager_escalation"
+            escalated = True
+        else:
+            selected_tier = requested_tier
+            selection_reason = "manager"
+
+        self._active_task_id = task_id
+        self._failure_count = failures
+        self._escalation_active = escalated
+        return ExecutorRoutingDecision(
+            enabled=True,
+            task_id=task_id,
+            task_present=task_present,
+            requested_tier=requested_tier,
+            selected_tier=selected_tier,
+            selection_reason=selection_reason,
+            failures_before=failures,
+            failures_after=failures,
+            escalation_active=escalated,
+        )
+
+    def observe(
+        self,
+        decision: ExecutorRoutingDecision,
+        signal: Literal["complete", "incomplete", "blocked", "not_counted"],
+    ) -> ExecutorRoutingDecision:
+        if decision.selected_tier is None or decision.task_id != self._active_task_id:
+            return replace(decision, audit_signal="not_counted")
+        if signal == "complete":
+            self._active_task_id = None
+            self._failure_count = 0
+            self._escalation_active = False
+            return replace(
+                decision,
+                failures_after=0,
+                escalation_active=False,
+                audit_signal="complete",
+            )
+        if signal in {"incomplete", "blocked"}:
+            self._failure_count += 1
+            if self._failure_count >= self.policy.escalate_after_failures:
+                self._escalation_active = True
+            return replace(
+                decision,
+                failures_after=self._failure_count,
+                escalation_active=self._escalation_active,
+                audit_signal=signal,
+            )
+        return replace(
+            decision,
+            failures_after=self._failure_count,
+            escalation_active=self._escalation_active,
+            audit_signal="not_counted",
+        )
+
+
+def executor_task_identity(
+    *, next_step: RoleNextStep, task_text: str, round_index: int
+) -> tuple[str, bool]:
+    normalized = re.sub(r"\s+", " ", str(task_text or "")).strip()
+    task_present = bool(normalized)
+    identity_text = (
+        f"{next_step}\n{normalized}"
+        if task_present
+        else f"{next_step}\n<missing-task-round-{round_index}>"
+    )
+    return hashlib.sha256(identity_text.encode("utf-8")).hexdigest(), task_present
+
+
+def is_valid_executor_tier_name(value: object) -> bool:
+    return isinstance(value, str) and _EXECUTOR_TIER_NAME_RE.fullmatch(value) is not None
+
+
+def disabled_routing_decision(
+    *, next_step: RoleNextStep, task_text: str, round_index: int
+) -> ExecutorRoutingDecision:
+    task_id, task_present = executor_task_identity(
+        next_step=next_step,
+        task_text=task_text,
+        round_index=round_index,
+    )
+    return ExecutorRoutingDecision(
+        enabled=False,
+        task_id=task_id,
+        task_present=task_present,
+        requested_tier=None,
+        selected_tier=None,
+        selection_reason="default",
+        failures_before=0,
+        failures_after=0,
+        escalation_active=False,
+    )
+
+
+def mark_not_counted(decision: ExecutorRoutingDecision) -> ExecutorRoutingDecision:
+    return replace(decision, audit_signal="not_counted")

--- a/src/lh_harness/manager.py
+++ b/src/lh_harness/manager.py
@@ -9,10 +9,10 @@ import logging
 import os
 import stat as stat_module
 import time
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass, field, replace
 import traceback
 from pathlib import Path
-from typing import Any, Awaitable, Callable
+from typing import Any, Awaitable, Callable, Literal
 
 from .adapters.base import AgentAdapter
 from .agent_logs import (
@@ -21,6 +21,12 @@ from .agent_logs import (
 )
 from .environment.base import Environment
 from .environment.remote_files import ensure_remote_dir, write_remote_text
+from .executor_routing import (
+    ExecutorRouter,
+    ExecutorRoutingDecision,
+    disabled_routing_decision,
+    is_valid_executor_tier_name,
+)
 from .runtime_signals import hard_signal_labels
 from .provider_errors import classify_agent_runtime_failure
 from .trajectory_artifacts import persist_trajectory_artifacts
@@ -39,7 +45,9 @@ from .role_prompts import (
     extract_role_manager_plan_text,
     extract_related_report_refs,
     extract_role_manager_answer_choices,
+    extract_role_manager_executor_tier,
     extract_role_manager_question,
+    extract_role_manager_task,
     extract_role_task_contract,
     extract_role_task_state,
     format_related_auditor_reports,
@@ -175,6 +183,8 @@ async def _run_impl(
     manager_agent: AgentAdapter | None = None,
     gui_executor_agent: AgentAdapter | None = None,
     cli_executor_agent: AgentAdapter | None = None,
+    gui_executor_agents: dict[str, AgentAdapter] | None = None,
+    cli_executor_agents: dict[str, AgentAdapter] | None = None,
     gui_auditor_agent: AgentAdapter | None = None,
     cli_auditor_agent: AgentAdapter | None = None,
     auditor_format_repair_agent: AgentAdapter | None = None,
@@ -219,6 +229,46 @@ async def _run_impl(
         except Exception:  # progress reporting must never break a run
             logger.debug("progress callback failed for %s", event, exc_info=True)
 
+    routing_policy = config.executor_routing
+    routing_enabled = routing_policy is not None
+    if routing_enabled:
+        if gui_executor_agents is None or cli_executor_agents is None:
+            raise ValueError(
+                "Executor routing requires both GUI and CLI executor tier maps"
+            )
+        gui_tiers = set(gui_executor_agents)
+        cli_tiers = set(cli_executor_agents)
+        if gui_tiers != cli_tiers:
+            raise ValueError("GUI and CLI executor tier maps must have identical keys")
+        if any(not is_valid_executor_tier_name(tier) for tier in gui_tiers):
+            raise ValueError(
+                "Executor tier map keys must use 1-64 ASCII letters, digits, '_' or '-'"
+            )
+        assert routing_policy is not None
+        required_tiers = {
+            routing_policy.default_tier,
+            routing_policy.escalation_tier,
+        }
+        missing_tiers = required_tiers - gui_tiers
+        if missing_tiers:
+            raise ValueError(
+                "Executor tier maps are missing configured routing tier(s): "
+                + ", ".join(sorted(missing_tiers))
+            )
+        if any(agent is None for agent in gui_executor_agents.values()) or any(
+            agent is None for agent in cli_executor_agents.values()
+        ):
+            raise ValueError("Executor tier maps cannot contain empty agent bindings")
+        available_executor_tiers = gui_tiers
+        executor_router: ExecutorRouter | None = ExecutorRouter(
+            available_executor_tiers, routing_policy
+        )
+    else:
+        if gui_executor_agents is not None or cli_executor_agents is not None:
+            raise ValueError("Executor tier maps require an executor routing policy")
+        available_executor_tiers = set()
+        executor_router = None
+
     # Role binding is resolved once at startup so the main loop can stay focused
     # on state transitions instead of adapter fallback logic.
     manager_agent = manager_agent or agent
@@ -226,16 +276,10 @@ async def _run_impl(
     cli_executor_agent = cli_executor_agent or agent
     gui_auditor_agent = gui_auditor_agent or auditor_agent or agent
     cli_auditor_agent = cli_auditor_agent or auditor_agent or agent
-    if any(
-        role_agent is None
-        for role_agent in (
-            manager_agent,
-            gui_executor_agent,
-            cli_executor_agent,
-            gui_auditor_agent,
-            cli_auditor_agent,
-        )
-    ):
+    required_role_agents = [manager_agent, gui_auditor_agent, cli_auditor_agent]
+    if not routing_enabled:
+        required_role_agents.extend((gui_executor_agent, cli_executor_agent))
+    if any(role_agent is None for role_agent in required_role_agents):
         raise ValueError("Every role needs an agent, or a default agent must be provided")
 
     # Every role reads one explicit budget. Keeping the resolved budgets in the
@@ -296,6 +340,17 @@ async def _run_impl(
             "auditor_budget": _budget_to_dict(auditor_budget),
             "resumed": bool(resume),
             "resumed_rounds": len(rounds),
+            "executor_routing": {
+                "enabled": routing_enabled,
+                "available_tiers": sorted(available_executor_tiers),
+                "default_tier": routing_policy.default_tier if routing_policy else None,
+                "escalate_after_failures": (
+                    routing_policy.escalate_after_failures if routing_policy else None
+                ),
+                "escalation_tier": (
+                    routing_policy.escalation_tier if routing_policy else None
+                ),
+            },
         },
     )
     if resume:
@@ -357,6 +412,8 @@ async def _run_impl(
             task_state=current_task_state,
             task_contract=current_task_contract,
             round_budget=gate.round_budget,
+            executor_tiers={tier: {} for tier in available_executor_tiers},
+            executor_routing=routing_policy,
             language=config.prompt_language,
             max_history_chars=config.role_history_chars,
         )
@@ -499,6 +556,22 @@ async def _run_impl(
         await _write_remote_round_text(env, config, round_index, "task_contract.txt", current_task_contract)
 
         next_step = parse_role_manager_next_step(plan_text)
+        routing_decision: ExecutorRoutingDecision | None = None
+        if next_step in {MANAGER_NEXT_GUI, MANAGER_NEXT_CLI}:
+            manager_task = extract_role_manager_task(plan_text)
+            if executor_router is None:
+                routing_decision = disabled_routing_decision(
+                    next_step=next_step,
+                    task_text=manager_task,
+                    round_index=round_index,
+                )
+            else:
+                routing_decision = executor_router.select(
+                    next_step=next_step,
+                    task_text=manager_task,
+                    requested_tier=extract_role_manager_executor_tier(plan_text),
+                    round_index=round_index,
+                )
         last_plan = plan_text
         _append_event(
             events_path,
@@ -510,6 +583,9 @@ async def _run_impl(
                 "task_state_chars": len(current_task_state),
                 "task_contract_chars": len(current_task_contract),
                 "related_report_refs": related_report_refs,
+                "executor_routing": (
+                    routing_decision.to_dict() if routing_decision is not None else None
+                ),
                 **_episode_event_fields(manager_result, event_status="completed"),
             },
         )
@@ -622,13 +698,71 @@ async def _run_impl(
                 break
             continue
 
-        executor_agent, executor_budget = _executor_binding(
-            next_step=next_step,
-            gui_executor_agent=gui_executor_agent,
-            cli_executor_agent=cli_executor_agent,
-            gui_executor_budget=gui_executor_budget,
-            cli_executor_budget=cli_executor_budget,
-        )
+        if (
+            routing_decision is not None
+            and routing_decision.enabled
+            and routing_decision.selected_tier is None
+        ):
+            allowed = ", ".join(sorted(available_executor_tiers))
+            requested = routing_decision.requested_tier
+            repair_report = (
+                f"Invalid executor tier {requested!r}. Allowed executor tiers: {allowed}. "
+                "Emit one non-empty allowed tier immediately after the GUI/CLI route, or omit the field to use the default."
+                if config.prompt_language == "en"
+                else f"执行器层级 {requested!r} 无效。允许的执行器层级: {allowed}。"
+                "请在 GUI/CLI 路由后输出一个非空的允许层级，或省略该字段以使用默认层级。"
+            )
+            record = ManagedRound(
+                round_index=round_index,
+                next_step=MANAGER_NEXT_INVALID,
+                plan_text=plan_text,
+                harness_feedback=repair_report,
+                task_state=current_task_state,
+                task_contract=current_task_contract,
+                related_report_refs=related_report_refs,
+                manager_status=_episode_status(manager_result),
+                auditor_status={"invalid_plan": True, "invalid_executor_tier": True},
+                executor_routing=routing_decision.to_dict(),
+            )
+            _write_local(round_dir / "harness_feedback.txt", repair_report)
+            await _write_remote_round_text(
+                env, config, round_index, "harness_feedback.txt", repair_report
+            )
+            rounds.append(record)
+            await _record_round(env, config, role_dir, events_path, record)
+            _append_event(
+                events_path,
+                "executor_routing_rejected",
+                {"round": round_index, "executor_routing": routing_decision.to_dict()},
+            )
+            if await _human_gate(gate, "progress", round_index, current_task_state):
+                break
+            continue
+
+        assert routing_decision is not None
+        if routing_enabled:
+            assert routing_decision.selected_tier is not None
+            tier_agents = (
+                gui_executor_agents
+                if next_step == MANAGER_NEXT_GUI
+                else cli_executor_agents
+            )
+            assert tier_agents is not None
+            executor_agent = tier_agents[routing_decision.selected_tier]
+            executor_budget = (
+                gui_executor_budget
+                if next_step == MANAGER_NEXT_GUI
+                else cli_executor_budget
+            )
+        else:
+            assert gui_executor_agent is not None and cli_executor_agent is not None
+            executor_agent, executor_budget = _executor_binding(
+                next_step=next_step,
+                gui_executor_agent=gui_executor_agent,
+                cli_executor_agent=cli_executor_agent,
+                gui_executor_budget=gui_executor_budget,
+                cli_executor_budget=cli_executor_budget,
+            )
         auditor_for_step = gui_auditor_agent if next_step == MANAGER_NEXT_GUI else cli_auditor_agent
         related_auditor_reports = format_related_auditor_reports(
             rounds,
@@ -654,7 +788,7 @@ async def _run_impl(
         _append_event(
             events_path,
             "executor_role_start",
-            {"round": round_index, "role": next_step, "prompt_chars": len(executor_prompt), "budget": _budget_to_dict(executor_budget)},
+            {"round": round_index, "role": next_step, "prompt_chars": len(executor_prompt), "budget": _budget_to_dict(executor_budget), "executor_routing": routing_decision.to_dict()},
         )
         emit("role_start", round=round_index, role=f"{next_step}_executor")
 
@@ -683,6 +817,9 @@ async def _run_impl(
         executor_output = _visible_output(executor_result).strip() or "(executor agent produced no readable natural-language output)"
         _write_local(round_dir / "executor_output.txt", executor_output)
         if executor_result.status == "cancelled":
+            routing_decision = _observe_executor_routing(
+                executor_router, routing_decision, "not_counted"
+            )
             record = ManagedRound(
                 round_index=round_index,
                 next_step=next_step,
@@ -692,6 +829,7 @@ async def _run_impl(
                 task_contract=current_task_contract,
                 related_report_refs=related_report_refs,
                 executor_status=_episode_status(executor_result),
+                executor_routing=routing_decision.to_dict(),
             )
             rounds.append(record)
             await _record_round(env, config, role_dir, events_path, record)
@@ -702,6 +840,7 @@ async def _run_impl(
                 {
                     "round": round_index,
                     "phase": "executor",
+                    "executor_routing": routing_decision.to_dict(),
                     **_episode_event_fields(executor_result, event_status="cancelled"),
                 },
             )
@@ -709,6 +848,9 @@ async def _run_impl(
         executor_failure = classify_agent_runtime_failure(executor_result)
         if executor_failure is not None:
             recoverable_timeout = executor_failure.kind == "timeout"
+            routing_decision = _observe_executor_routing(
+                executor_router, routing_decision, "not_counted"
+            )
             record = ManagedRound(
                 round_index=round_index,
                 next_step=next_step,
@@ -722,6 +864,7 @@ async def _run_impl(
                 executor_status=_failed_episode_status(
                     executor_result, executor_failure.user_message
                 ),
+                executor_routing=routing_decision.to_dict(),
             )
             _write_local(round_dir / "harness_feedback.txt", executor_failure.user_message)
             rounds.append(record)
@@ -734,6 +877,7 @@ async def _run_impl(
                     "phase": "executor",
                     "kind": executor_failure.kind,
                     "message": executor_failure.message,
+                    "executor_routing": routing_decision.to_dict(),
                     **_episode_event_fields(
                         executor_result,
                         event_status="failed",
@@ -764,6 +908,7 @@ async def _run_impl(
                 "round": round_index,
                 "role": next_step,
                 "output_chars": len(executor_output),
+                "executor_routing": routing_decision.to_dict(),
                 **_episode_event_fields(executor_result, event_status="completed"),
             },
         )
@@ -794,7 +939,7 @@ async def _run_impl(
         _append_event(
             events_path,
             "auditor_role_start",
-            {"round": round_index, "role": next_step, "prompt_chars": len(auditor_prompt), "budget": _budget_to_dict(auditor_budget)},
+            {"round": round_index, "role": next_step, "prompt_chars": len(auditor_prompt), "budget": _budget_to_dict(auditor_budget), "executor_routing": routing_decision.to_dict()},
         )
         emit("role_start", round=round_index, role=f"{next_step}_auditor")
 
@@ -821,6 +966,9 @@ async def _run_impl(
             final_screenshot=auditor_final_screenshot,
         )
         if auditor_result.status == "cancelled":
+            routing_decision = _observe_executor_routing(
+                executor_router, routing_decision, "not_counted"
+            )
             record = ManagedRound(
                 round_index=round_index,
                 next_step=next_step,
@@ -831,6 +979,7 @@ async def _run_impl(
                 related_report_refs=related_report_refs,
                 executor_status=_episode_status(executor_result),
                 auditor_status=_episode_status(auditor_result),
+                executor_routing=routing_decision.to_dict(),
             )
             rounds.append(record)
             await _record_round(env, config, role_dir, events_path, record)
@@ -841,6 +990,7 @@ async def _run_impl(
                 {
                     "round": round_index,
                     "phase": "auditor",
+                    "executor_routing": routing_decision.to_dict(),
                     **_episode_event_fields(auditor_result, event_status="cancelled"),
                 },
             )
@@ -848,6 +998,9 @@ async def _run_impl(
         auditor_failure = classify_agent_runtime_failure(auditor_result)
         if auditor_failure is not None:
             recoverable_timeout = auditor_failure.kind == "timeout"
+            routing_decision = _observe_executor_routing(
+                executor_router, routing_decision, "not_counted"
+            )
             record = ManagedRound(
                 round_index=round_index,
                 next_step=next_step,
@@ -862,6 +1015,7 @@ async def _run_impl(
                 auditor_status=_failed_episode_status(
                     auditor_result, auditor_failure.user_message
                 ),
+                executor_routing=routing_decision.to_dict(),
             )
             _write_local(round_dir / "harness_feedback.txt", auditor_failure.user_message)
             rounds.append(record)
@@ -874,6 +1028,7 @@ async def _run_impl(
                     "phase": "auditor",
                     "kind": auditor_failure.kind,
                     "message": auditor_failure.message,
+                    "executor_routing": routing_decision.to_dict(),
                     **_episode_event_fields(
                         auditor_result,
                         event_status="failed",
@@ -912,6 +1067,9 @@ async def _run_impl(
         )
         repair_status = auditor_status.get("format_repair_status")
         if isinstance(repair_status, dict) and repair_status.get("status") == "cancelled":
+            routing_decision = _observe_executor_routing(
+                executor_router, routing_decision, "not_counted"
+            )
             record = ManagedRound(
                 round_index=round_index,
                 next_step=next_step,
@@ -922,6 +1080,7 @@ async def _run_impl(
                 related_report_refs=related_report_refs,
                 executor_status=_episode_status(executor_result),
                 auditor_status=auditor_status,
+                executor_routing=routing_decision.to_dict(),
             )
             rounds.append(record)
             await _record_round(env, config, role_dir, events_path, record)
@@ -934,11 +1093,28 @@ async def _run_impl(
                     "phase": "auditor_format_repair",
                     "status": "cancelled",
                     "episode_status": repair_status,
+                    "executor_routing": routing_decision.to_dict(),
                 },
             )
             break
         _write_local(round_dir / "auditor_report.txt", auditor_report)
         await _write_remote_round_text(env, config, round_index, "auditor_report.txt", auditor_report)
+
+        audit = parse_audit_report(
+            auditor_report, round_index, language=config.prompt_language
+        )
+        repair_attempted = bool(auditor_status.get("format_repair_attempted"))
+        audit_accepted = not repair_attempted or bool(
+            auditor_status.get("format_repair_accepted")
+        )
+        routing_signal = (
+            audit.status
+            if audit_accepted and audit.status in {"complete", "incomplete", "blocked"}
+            else "not_counted"
+        )
+        routing_decision = _observe_executor_routing(
+            executor_router, routing_decision, routing_signal
+        )
 
         record = ManagedRound(
             round_index=round_index,
@@ -951,6 +1127,7 @@ async def _run_impl(
             related_report_refs=related_report_refs,
             executor_status=_episode_status(executor_result),
             auditor_status=auditor_status,
+            executor_routing=routing_decision.to_dict(),
         )
         rounds.append(record)
         await _record_round(env, config, role_dir, events_path, record)
@@ -961,10 +1138,10 @@ async def _run_impl(
                 "round": round_index,
                 "role": next_step,
                 "report_chars": len(auditor_report),
+                "executor_routing": routing_decision.to_dict(),
                 **_episode_event_fields(auditor_result, event_status="completed"),
             },
         )
-        audit = parse_audit_report(auditor_report, round_index, language=config.prompt_language)
         emit(
             "role_done",
             round=round_index,
@@ -1219,6 +1396,18 @@ def _executor_binding(
     if next_step == MANAGER_NEXT_GUI:
         return gui_executor_agent, gui_executor_budget
     return cli_executor_agent, cli_executor_budget
+
+
+def _observe_executor_routing(
+    router: ExecutorRouter | None,
+    decision: ExecutorRoutingDecision,
+    signal: Literal["complete", "incomplete", "blocked", "not_counted"],
+) -> ExecutorRoutingDecision:
+    if router is None:
+        return replace(decision, audit_signal=signal)
+    if signal not in {"complete", "incomplete", "blocked", "not_counted"}:
+        raise ValueError(f"unsupported executor routing audit signal: {signal}")
+    return router.observe(decision, signal)
 
 
 async def _run_role_episode(

--- a/src/lh_harness/role_prompts.py
+++ b/src/lh_harness/role_prompts.py
@@ -14,7 +14,7 @@ from .prompt_texts import (
     TASK_CONTRACT_RULES,
     USER_CLARIFICATION_NOTE,
 )
-from .types import ManagedRound, PromptLanguage, RoleNextStep
+from .types import ExecutorRoutingConfig, ManagedRound, PromptLanguage, RoleNextStep
 
 MANAGER_NEXT_GUI: RoleNextStep = "gui"
 MANAGER_NEXT_CLI: RoleNextStep = "cli"
@@ -48,6 +48,8 @@ def build_role_manager_prompt(
     task_state: str = "",
     task_contract: str = "",
     round_budget: int | None = None,
+    executor_tiers: dict[str, dict[str, str]] | None = None,
+    executor_routing: ExecutorRoutingConfig | None = None,
     language: str = "en",
     max_history_chars: int = 36_000,
 ) -> str:
@@ -58,6 +60,11 @@ def build_role_manager_prompt(
         rounds, max_chars=max_history_chars, language=lang
     )
     harness_feedback = format_harness_feedback_context(rounds, max_chars=max_history_chars)
+    routing_policy = _format_executor_routing_policy(
+        executor_tiers=executor_tiers,
+        executor_routing=executor_routing,
+        language=lang,
+    )
     if lang == "en":
         return f"""\
 {MANAGER_INSTRUCTIONS[lang].strip()}
@@ -90,6 +97,8 @@ Round budget:
 - Configured round limit: {configured_budget}
 - Rounds remaining, including this one: {remaining_rounds}
 - If only one round remains, do not schedule a prerequisite-only subtask that deliberately postpones core requirements. Route the most complete executable subtask possible, or ask/block when completion is impossible.
+
+{routing_policy}
 
 Output only the next management result.
 """
@@ -125,8 +134,36 @@ harness 任务管理反馈（不是审计，只用于协议或完成请求修正
 - 包含本轮在内的剩余轮次: {remaining_rounds}
 - 如果只剩一轮，不得安排一个明确推迟核心要求的纯前置子任务；应路由当前可完成的最完整子任务，无法完成时使用 ask 或 blocked。
 
+{routing_policy}
+
 只输出下一步任务管理结果。
 """
+
+
+def _format_executor_routing_policy(
+    *,
+    executor_tiers: dict[str, dict[str, str]] | None,
+    executor_routing: ExecutorRoutingConfig | None,
+    language: PromptLanguage,
+) -> str:
+    if executor_routing is None:
+        return ""
+    tier_names = ", ".join(sorted((executor_tiers or {}).keys()))
+    if language == "en":
+        return f"""\
+Executor routing policy:
+- Allowed executor tiers: {tier_names or "(none configured)"}
+- Default tier when `Executor tier:` is omitted: {executor_routing.default_tier}
+- Automatic escalation: after {executor_routing.escalate_after_failures} successfully parsed `Status: incomplete` or `Status: blocked` verdicts for the same subtask, the harness may force tier {executor_routing.escalation_tier}. Provider/runtime failures, timeouts, and format-repair failures do not count.
+- GUI/CLI output schema: immediately after the route line and before `Task:`, you may add `Executor tier: <name>` to select the initial tier. Omitting it uses the default; naming {executor_routing.escalation_tier} uses it immediately.
+- Output only an allowed tier name. Never add `Executor tier:` to ask/done/blocked routes."""
+    return f"""\
+执行器路由策略:
+- 允许的执行器层级: {tier_names or "（未配置）"}
+- 省略 `执行器层级:` 时的默认层级: {executor_routing.default_tier}
+- 自动升级: 同一子任务出现 {executor_routing.escalate_after_failures} 次成功解析的 `状态: incomplete` 或 `状态: blocked` 结论后，harness 可以强制使用层级 {executor_routing.escalation_tier}。provider/runtime 失败、超时和格式修复失败不计数。
+- GUI/CLI 输出格式: 路由行后、`任务:` 前可以紧接 `执行器层级: <名称>` 来选择初始层级；省略时使用默认层级，填写 {executor_routing.escalation_tier} 会立即使用该层级。
+- 只能输出允许的层级名称。请示用户/完成/阻塞路由绝不能添加 `执行器层级:`。"""
 
 
 def build_role_executor_prompt(
@@ -478,33 +515,285 @@ def format_audit_findings(
     return _clip_preserve("\n\n".join(sections), max_chars)
 
 
-def parse_role_manager_next_step(text: str) -> RoleNextStep:
-    for line in str(text or "").splitlines():
-        normalized = line.strip().strip("*").replace(" ", "").replace("　", "").lower()
-        # Models commonly append a short rationale after the required route,
-        # e.g. `Next: done — all constraints passed`. Treat only an explicitly
-        # delimited suffix as commentary so prose such as `Next: done later`
-        # remains invalid.
-        normalized = re.split(r"(?:—|–|--|//|#|[（(])", normalized, maxsplit=1)[0]
-        if normalized in {"下一步:gui任务", "下一步：gui任务", "next:gui"}:
-            return MANAGER_NEXT_GUI
-        if normalized in {"下一步:cli任务", "下一步：cli任务", "next:cli"}:
-            return MANAGER_NEXT_CLI
-        if normalized in {"下一步:请示用户", "下一步：请示用户", "下一步:请示", "下一步：请示", "下一步:询问用户", "下一步：询问用户", "next:ask"}:
-            return MANAGER_NEXT_ASK
-        if normalized in {"下一步:完成", "下一步：完成", "next:done", "next:complete"}:
-            return MANAGER_NEXT_DONE
-        if normalized in {"下一步:阻塞", "下一步：阻塞", "next:blocked"}:
-            return MANAGER_NEXT_BLOCKED
+def _parse_role_manager_route_line(line: str) -> RoleNextStep:
+    normalized = str(line or "").strip().strip("*").replace(" ", "").replace("　", "").lower()
+    # Models commonly append a short rationale after the required route,
+    # e.g. `Next: done — all constraints passed`. Treat only an explicitly
+    # delimited suffix as commentary so prose such as `Next: done later`
+    # remains invalid.
+    normalized = re.split(r"(?:—|–|--|//|#|[（(])", normalized, maxsplit=1)[0]
+    if normalized in {"下一步:gui任务", "下一步：gui任务", "next:gui"}:
+        return MANAGER_NEXT_GUI
+    if normalized in {"下一步:cli任务", "下一步：cli任务", "next:cli"}:
+        return MANAGER_NEXT_CLI
+    if normalized in {"下一步:请示用户", "下一步：请示用户", "下一步:请示", "下一步：请示", "下一步:询问用户", "下一步：询问用户", "next:ask"}:
+        return MANAGER_NEXT_ASK
+    if normalized in {"下一步:完成", "下一步：完成", "next:done", "next:complete"}:
+        return MANAGER_NEXT_DONE
+    if normalized in {"下一步:阻塞", "下一步：阻塞", "next:blocked"}:
+        return MANAGER_NEXT_BLOCKED
     return MANAGER_NEXT_INVALID
+
+
+def parse_role_manager_next_step(text: str) -> RoleNextStep:
+    """Return the same structural route authority used by tier/task parsing."""
+
+    lines = str(text or "").splitlines()
+    authority = _last_manager_route(lines)
+    if authority is not None:
+        return authority[1]
+    return MANAGER_NEXT_INVALID
+
+
+_EXECUTOR_TIER_HEADER_RE = re.compile(
+    r"(?i)^(?:\*\*)?\s*(?:executor\s+tier|执行器层级)\s*[:：]\s*(?:\*\*)?\s*(.*)$"
+)
+_MANAGER_TASK_HEADER_RE = re.compile(
+    r"(?i)^(?:\*\*)?\s*(?:task|任务)\s*[:：]\s*(?:\*\*)?\s*(.*)$"
+)
+_MANAGER_SUBTASK_BOUNDARY_RE = re.compile(
+    r"(?i)^(?:\*\*)?\s*(?:acceptance\s+criteria|related\s+audit\s+reports"
+    r"|related\s+audited\s+state|boundaries|验收标准|相关审计报告|相关已审计状态|边界)\s*[:：]"
+)
+_MANAGER_BOUNDARIES_HEADER_RE = re.compile(
+    r"(?i)^(?:\*\*)?\s*(?:boundaries|边界)\s*[:：]"
+)
+_MANAGER_BLOCK_START_RE = re.compile(
+    r"(?i)^(?:\*\*)?\s*(?:current\s+task\s+state|当前任务状态)\s*[:：]"
+)
+_MANAGER_TASK_CONTRACT_HEADER_RE = re.compile(
+    r"(?i)^(?:\*\*)?\s*(?:task\s+contract|任务契约|任务语义合同)\s*[:：]"
+)
+_MANAGER_DEPENDENCY_HEADER_RE = re.compile(
+    r"(?i)^(?:\*\*)?\s*(?:dependency\s+assessment|依赖判断)\s*[:：]"
+)
+_MANAGER_BLOCK_SEPARATOR_RE = re.compile(r"^\s*(?:-{3,}|={3,})\s*$")
+
+
+def extract_role_manager_executor_tier(plan_text: str) -> str | None:
+    """Return the optional tier header from the final executable route block.
+
+    ``None`` means the manager omitted the header. An explicitly empty header
+    remains ``""`` so the runtime can reject it instead of silently selecting
+    a default tier.
+    """
+
+    lines = str(plan_text or "").splitlines()
+    route_index = _last_executable_route_index(lines)
+    if route_index is None:
+        return None
+    for line in lines[route_index + 1 :]:
+        if not line.strip():
+            continue
+        match = _EXECUTOR_TIER_HEADER_RE.match(line.strip())
+        return match.group(1).strip() if match else None
+    return None
+
+
+def extract_role_manager_task(plan_text: str) -> str:
+    """Return the Task body from the final executable manager route block."""
+
+    lines = str(plan_text or "").splitlines()
+    route_index = _last_executable_route_index(lines)
+    if route_index is None:
+        return ""
+
+    cursor = route_index + 1
+    while cursor < len(lines) and not lines[cursor].strip():
+        cursor += 1
+    if cursor < len(lines) and _EXECUTOR_TIER_HEADER_RE.match(lines[cursor].strip()):
+        cursor += 1
+        while cursor < len(lines) and not lines[cursor].strip():
+            cursor += 1
+    if cursor >= len(lines):
+        return ""
+    task_match = _MANAGER_TASK_HEADER_RE.match(lines[cursor].strip())
+    if task_match is None:
+        return ""
+
+    collected: list[str] = []
+    inline = task_match.group(1).strip()
+    if inline:
+        collected.append(inline)
+    for line in lines[cursor + 1 :]:
+        if _MANAGER_SUBTASK_BOUNDARY_RE.match(line.strip()):
+            break
+        collected.append(line.rstrip())
+    return "\n".join(collected).strip()
+
+
+def _last_executable_route_index(lines: list[str]) -> int | None:
+    route = _last_manager_route(lines)
+    if route is None or route[1] not in {MANAGER_NEXT_GUI, MANAGER_NEXT_CLI}:
+        return None
+    return route[0]
+
+
+def _last_manager_route(
+    lines: list[str],
+) -> tuple[int, RoleNextStep, int] | None:
+    """Return the final authoritative route and its manager-block start.
+
+    Once an executable route is accepted, every following subtask section is
+    payload. Route-shaped literals inside Task, acceptance criteria, related
+    evidence, or boundaries cannot silently replace the controlling route.
+    """
+
+    last_route: tuple[int, RoleNextStep, int] | None = None
+    candidate_block_start: int | None = None
+    candidate_stage = 0  # 1=current state, 2=task contract, 3=dependency
+    candidate_short = False
+    payload_locked = False
+    boundaries_seen = False
+    index = 0
+    while index < len(lines):
+        stripped = lines[index].strip()
+        if payload_locked:
+            if _MANAGER_BOUNDARIES_HEADER_RE.match(stripped):
+                boundaries_seen = True
+            if boundaries_seen and _MANAGER_BLOCK_SEPARATOR_RE.match(stripped):
+                payload_locked = False
+                boundaries_seen = False
+                candidate_block_start = None
+                candidate_stage = 0
+                candidate_short = False
+                index += 1
+                continue
+            if _MANAGER_BLOCK_START_RE.match(stripped):
+                candidate_block_start = index
+                candidate_stage = 1
+                candidate_short = False
+                index += 1
+                continue
+            if candidate_stage == 1 and _MANAGER_TASK_CONTRACT_HEADER_RE.match(stripped):
+                candidate_stage = 2
+                index += 1
+                continue
+            if candidate_stage == 2 and _MANAGER_DEPENDENCY_HEADER_RE.match(stripped):
+                candidate_stage = 3
+                index += 1
+                continue
+            route = _parse_role_manager_route_line(lines[index])
+            if candidate_stage != 3 or route == MANAGER_NEXT_INVALID:
+                index += 1
+                continue
+            if route in {MANAGER_NEXT_GUI, MANAGER_NEXT_CLI}:
+                valid_start, _ = _subtask_protocol_start(lines, index)
+                if not valid_start:
+                    index += 1
+                    continue
+            last_route = (
+                index,
+                route,
+                candidate_block_start if candidate_block_start is not None else index,
+            )
+            candidate_block_start = None
+            candidate_stage = 0
+            candidate_short = False
+            boundaries_seen = False
+            index += 1
+            continue
+
+        if _MANAGER_BLOCK_START_RE.match(stripped):
+            candidate_block_start = index
+            candidate_stage = 1
+            candidate_short = False
+            index += 1
+            continue
+        if candidate_stage == 0 and _MANAGER_TASK_CONTRACT_HEADER_RE.match(stripped):
+            # Backward-compatible initial block: old transcripts can begin at
+            # Task contract, but this short form never reopens locked payload.
+            candidate_block_start = index
+            candidate_stage = 2
+            candidate_short = True
+            index += 1
+            continue
+        if candidate_stage == 1 and _MANAGER_TASK_CONTRACT_HEADER_RE.match(stripped):
+            candidate_stage = 2
+            index += 1
+            continue
+        if candidate_stage == 2 and _MANAGER_DEPENDENCY_HEADER_RE.match(stripped):
+            candidate_stage = 3
+            index += 1
+            continue
+        route = _parse_role_manager_route_line(lines[index])
+        if route == MANAGER_NEXT_INVALID:
+            index += 1
+            continue
+        if candidate_stage not in {0, 3} and not (
+            candidate_short and candidate_stage == 2
+        ):
+            index += 1
+            continue
+        if route in {MANAGER_NEXT_GUI, MANAGER_NEXT_CLI}:
+            valid_start, _ = _subtask_protocol_start(lines, index)
+            if not valid_start:
+                index += 1
+                continue
+            last_route = (
+                index,
+                route,
+                candidate_block_start if candidate_block_start is not None else index,
+            )
+            payload_locked = True
+            boundaries_seen = False
+            candidate_block_start = None
+            candidate_stage = 0
+            candidate_short = False
+            index += 1
+            continue
+        last_route = (
+            index,
+            route,
+            candidate_block_start if candidate_block_start is not None else index,
+        )
+        payload_locked = True
+        boundaries_seen = False
+        candidate_block_start = None
+        candidate_stage = 0
+        candidate_short = False
+        index += 1
+    return last_route
+
+
+def _subtask_protocol_start(
+    lines: list[str], route_index: int
+) -> tuple[bool, int | None]:
+    cursor = route_index + 1
+    while cursor < len(lines) and not lines[cursor].strip():
+        cursor += 1
+    if cursor >= len(lines):
+        return False, None
+    first_protocol_line = lines[cursor].strip()
+    if _MANAGER_BLOCK_START_RE.match(first_protocol_line):
+        # Legacy short plans put the maintained state after the route and may
+        # omit Task entirely. This form is authoritative only when the state
+        # header immediately follows the top-level executable route.
+        return True, None
+    if _MANAGER_TASK_HEADER_RE.match(first_protocol_line):
+        return True, cursor
+    if not _EXECUTOR_TIER_HEADER_RE.match(first_protocol_line):
+        return False, None
+    cursor += 1
+    while cursor < len(lines) and not lines[cursor].strip():
+        cursor += 1
+    task_index = (
+        cursor
+        if cursor < len(lines) and _MANAGER_TASK_HEADER_RE.match(lines[cursor].strip())
+        else None
+    )
+    return True, task_index
 
 
 def extract_role_manager_question(plan_text: str) -> str:
     """Return the `问题:` block from a `下一步: 请示用户` plan (question for the human)."""
     lines = str(plan_text or "").splitlines()
+    authority = _last_manager_route(lines)
+    if authority is None or authority[1] != MANAGER_NEXT_ASK:
+        return ""
     collecting = False
     collected: list[str] = []
-    for line in lines:
+    for line in lines[authority[0] + 1 :]:
         head = line.strip().strip("*").replace(" ", "").replace("　", "")
         if not collecting:
             if head.startswith(("问题:", "问题：")) or re.match(r"(?i)^question\s*:", line.strip().strip("*")):
@@ -529,7 +818,11 @@ def extract_role_manager_answer_choices(plan_text: str) -> list[str]:
     question is clearly yes/no, falls back to ``["是", "否"]``. Empty means the
     human just types a free-form answer.
     """
-    for line in str(plan_text or "").splitlines():
+    lines = str(plan_text or "").splitlines()
+    authority = _last_manager_route(lines)
+    if authority is None or authority[1] != MANAGER_NEXT_ASK:
+        return []
+    for line in lines[authority[0] + 1 :]:
         stripped = line.strip().strip("*")
         m = re.match(r"(?i)^\s*(?:选项|choices)\s*[:：]\s*(.+)$", stripped)
         if m:
@@ -546,11 +839,6 @@ def extract_role_manager_answer_choices(plan_text: str) -> list[str]:
     return []
 
 
-_MANAGER_ROUTE_LINE_RE = re.compile(
-    r"(?im)^\s*(?:\*\*)?\s*(?:下一步\s*[:：]\s*(?:GUI任务|CLI任务|请示用户|请示|询问用户|完成|阻塞)|next\s*:\s*(?:gui|cli|ask|done|complete|blocked))"
-)
-
-
 def extract_role_manager_plan_text(text: str) -> str:
     """Return the final state+route block from a noisy assistant transcript.
 
@@ -559,39 +847,13 @@ def extract_role_manager_plan_text(text: str) -> str:
     task-state plus route block, not wrapper transcript headings.
     """
     raw = str(text or "").strip()
-    matches = list(_MANAGER_ROUTE_LINE_RE.finditer(raw))
-    if not matches:
+    lines = raw.splitlines()
+    authority = _last_manager_route(lines)
+    if authority is None:
         return raw
-    route_start = matches[-1].start()
-    starts = [
-        position
-        for position in (
-            raw.rfind("当前任务状态", 0, route_start),
-            raw.lower().rfind("current task state", 0, route_start),
-            raw.rfind("任务契约", 0, route_start),
-            raw.lower().rfind("task contract", 0, route_start),
-        )
-        if position >= 0
-    ]
-    if starts:
-        return raw[min(starts):].strip()
-    return raw[route_start:].strip()
+    return "\n".join(lines[authority[2] :]).strip()
 
 
-_TASK_STATE_HEADER_RE = re.compile(r"(?im)^\s*(?:\*\*)?\s*(?:当前任务状态|current\s+task\s+state)\s*[:：]")
-_TASK_STATE_BOUNDARY_RE = re.compile(
-    r"(?im)^\s*(?:\*\*)?\s*(?:任务契约|task\s+contract|依赖判断|dependency\s+assessment"
-    r"|下一步\s*[:：]\s*(?:GUI任务|CLI任务|请示用户|请示|询问用户|完成|阻塞)"
-    r"|next\s*:\s*(?:gui|cli|ask|done|complete|blocked))"
-)
-_TASK_CONTRACT_HEADER_RE = re.compile(
-    r"(?im)^\s*(?:\*\*)?\s*(?:任务契约|任务语义合同|task\s+contract)\s*[:：]"
-)
-_TASK_CONTRACT_BOUNDARY_RE = re.compile(
-    r"(?im)^\s*(?:\*\*)?\s*(?:依赖判断|dependency\s+assessment"
-    r"|下一步\s*[:：]\s*(?:GUI任务|CLI任务|请示用户|请示|询问用户|完成|阻塞)"
-    r"|next\s*:\s*(?:gui|cli|ask|done|complete|blocked))"
-)
 _RELATED_REPORT_SECTION_RE = re.compile(
     r"(?ims)^\s*(?:\*\*)?\s*(?:相关(?:审计报告|已审计状态)|related\s+(?:audit\s+reports|audited\s+state))\s*[:：]\s*(.*?)(?=^\s*(?:\*\*)?\s*(?:边界|任务|验收标准|下一步|boundaries|task|acceptance\s+criteria|next)\s*[:：]|\Z)"
 )
@@ -601,31 +863,57 @@ _ROUND_REF_RE = re.compile(
 
 
 def extract_role_task_state(text: str, *, fallback: str = "") -> str:
-    raw = str(text or "").strip()
-    match = _TASK_STATE_HEADER_RE.search(raw)
-    if not match:
+    lines = str(text or "").splitlines()
+    authority = _last_manager_route(lines)
+    if authority is None:
         return fallback.strip()
-    boundary = _TASK_STATE_BOUNDARY_RE.search(raw, match.end())
-    end = boundary.start() if boundary else len(raw)
-    state = raw[match.start() : end].strip()
+    state_index, contract_index, _ = _manager_protocol_section_indices(
+        lines, authority
+    )
+    if state_index is None:
+        return fallback.strip()
+    end = (
+        contract_index
+        if contract_index is not None
+        else authority[0]
+        if state_index < authority[0]
+        else len(lines)
+    )
+    state = "\n".join(lines[state_index:end]).strip()
     return state or fallback.strip()
 
 
 def extract_role_task_contract(text: str, *, fallback: str = "") -> str:
-    raw = str(text or "").strip()
-    match = _TASK_CONTRACT_HEADER_RE.search(raw)
-    if not match:
+    lines = str(text or "").splitlines()
+    authority = _last_manager_route(lines)
+    if authority is None:
         return fallback.strip()
-    boundary = _TASK_CONTRACT_BOUNDARY_RE.search(raw, match.end())
-    end = boundary.start() if boundary else len(raw)
-    contract = raw[match.start() : end].strip()
+    _, contract_index, dependency_index = _manager_protocol_section_indices(
+        lines, authority
+    )
+    if contract_index is None:
+        return fallback.strip()
+    end = (
+        dependency_index
+        if dependency_index is not None
+        else authority[0]
+        if contract_index < authority[0]
+        else len(lines)
+    )
+    contract = "\n".join(lines[contract_index:end]).strip()
     return contract or fallback.strip()
 
 
 def extract_related_report_refs(text: str) -> list[str]:
-    raw = str(text or "")
+    lines = str(text or "").splitlines()
+    authority = _last_manager_route(lines)
+    if authority is None or authority[1] not in {MANAGER_NEXT_GUI, MANAGER_NEXT_CLI}:
+        return []
+    raw = "\n".join(lines[authority[0] + 1 :])
     sections = [m.group(1) for m in _RELATED_REPORT_SECTION_RE.finditer(raw)]
-    search_text = "\n".join(sections) if sections else raw
+    if not sections:
+        return []
+    search_text = "\n".join(sections)
     refs: list[str] = []
     seen: set[int] = set()
     for match in _ROUND_REF_RE.finditer(search_text):
@@ -638,6 +926,52 @@ def extract_related_report_refs(text: str) -> list[str]:
         seen.add(number)
         refs.append(f"round_{number:03d}")
     return refs
+
+
+def _manager_protocol_section_indices(
+    lines: list[str], authority: tuple[int, RoleNextStep, int]
+) -> tuple[int | None, int | None, int | None]:
+    """Locate structural state/contract/dependency headers for one authority."""
+
+    state_index: int | None = None
+    contract_index: int | None = None
+    dependency_index: int | None = None
+    for index in range(authority[2], authority[0]):
+        stripped = lines[index].strip()
+        if state_index is None and _MANAGER_BLOCK_START_RE.match(stripped):
+            state_index = index
+            continue
+        if contract_index is None and _MANAGER_TASK_CONTRACT_HEADER_RE.match(stripped):
+            contract_index = index
+            continue
+        if (
+            contract_index is not None
+            and dependency_index is None
+            and _MANAGER_DEPENDENCY_HEADER_RE.match(stripped)
+        ):
+            dependency_index = index
+    if state_index is None:
+        cursor = authority[0] + 1
+        while cursor < len(lines) and not lines[cursor].strip():
+            cursor += 1
+        if cursor < len(lines) and _MANAGER_BLOCK_START_RE.match(
+            lines[cursor].strip()
+        ):
+            state_index = cursor
+            for index in range(cursor + 1, len(lines)):
+                stripped = lines[index].strip()
+                if contract_index is None and _MANAGER_TASK_CONTRACT_HEADER_RE.match(
+                    stripped
+                ):
+                    contract_index = index
+                    continue
+                if (
+                    contract_index is not None
+                    and dependency_index is None
+                    and _MANAGER_DEPENDENCY_HEADER_RE.match(stripped)
+                ):
+                    dependency_index = index
+    return state_index, contract_index, dependency_index
 
 
 def format_related_auditor_reports(

--- a/src/lh_harness/types.py
+++ b/src/lh_harness/types.py
@@ -62,6 +62,31 @@ class EpisodeBudget:
             raise ValueError("max_duration_seconds must be at least 1")
 
 
+@dataclass(frozen=True)
+class ExecutorRoutingConfig:
+    default_tier: str
+    escalate_after_failures: int
+    escalation_tier: str
+
+    def __post_init__(self) -> None:
+        for name, value in (
+            ("default_tier", self.default_tier),
+            ("escalation_tier", self.escalation_tier),
+        ):
+            if not isinstance(value, str) or not value.strip():
+                raise ValueError(f"{name} must be a non-empty string")
+            if value != value.strip():
+                raise ValueError(f"{name} must not have leading or trailing whitespace")
+        if self.default_tier == self.escalation_tier:
+            raise ValueError("default_tier and escalation_tier must be different")
+        if (
+            isinstance(self.escalate_after_failures, bool)
+            or not isinstance(self.escalate_after_failures, int)
+            or self.escalate_after_failures < 1
+        ):
+            raise ValueError("escalate_after_failures must be an integer of at least 1")
+
+
 @dataclass
 class EpisodeResult:
     status: Literal["done", "timeout", "error", "cancelled"]
@@ -102,6 +127,7 @@ class ManagedRound:
     manager_status: dict[str, Any] = field(default_factory=dict)
     executor_status: dict[str, Any] = field(default_factory=dict)
     auditor_status: dict[str, Any] = field(default_factory=dict)
+    executor_routing: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass
@@ -124,6 +150,7 @@ class HarnessConfig:
     # English is the production default; Chinese remains available for
     # OSWorldv2-compatible role prompts and operator-facing control headers.
     prompt_language: PromptLanguage = "en"
+    executor_routing: ExecutorRoutingConfig | None = None
 
 
 def audit_report_to_dict(report: AuditReport) -> dict[str, Any]:

--- a/tests/test_executor_routing.py
+++ b/tests/test_executor_routing.py
@@ -1,0 +1,2200 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import FrozenInstanceError
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from lh_harness.config import ProjectConfigError, create_project_config, load_run_defaults
+from lh_harness.executor_routing import ExecutorRouter, executor_task_identity
+import lh_harness.cli as cli
+import lh_harness.manager as manager_runtime
+from lh_harness.role_prompts import (
+    MANAGER_NEXT_ASK,
+    MANAGER_NEXT_BLOCKED,
+    MANAGER_NEXT_CLI,
+    MANAGER_NEXT_DONE,
+    MANAGER_NEXT_GUI,
+    build_role_manager_prompt,
+    extract_related_report_refs,
+    extract_role_manager_answer_choices,
+    extract_role_manager_executor_tier,
+    extract_role_manager_plan_text,
+    extract_role_manager_question,
+    extract_role_manager_task,
+    extract_role_task_contract,
+    extract_role_task_state,
+    parse_role_manager_next_step,
+)
+from lh_harness.types import EpisodeResult, ExecutorRoutingConfig, HarnessConfig
+
+
+def _cli_binding_args(**overrides: object) -> SimpleNamespace:
+    values: dict[str, object] = {
+        "agent": "codex",
+        "model": "global-codex-model",
+        "executor_agent": None,
+        "executor_model": None,
+        "gui_executor_agent": None,
+        "gui_executor_model": None,
+        "cli_executor_agent": None,
+        "cli_executor_model": None,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def _load(tmp_path: Path, content: str) -> dict[str, object]:
+    path = tmp_path / "config.toml"
+    path.write_text(content, encoding="utf-8")
+    return load_run_defaults(path)
+
+
+def _tiered_config(
+    *,
+    default_tier: str = "cheap",
+    escalation_tier: str = "strong",
+    failures: str = "2",
+    routing_extra: str = "",
+    tier_extra: str = "",
+) -> str:
+    return f"""
+[run.roles.executor]
+agent = "codex"
+model = "parent-model"
+
+[run.roles.executor.cheap]
+model = "cheap-model"
+{tier_extra}
+
+[run.roles.executor.strong]
+agent = "deepseek_harness"
+
+[run.executor_routing]
+default_tier = "{default_tier}"
+escalate_after_failures = {failures}
+escalation_tier = "{escalation_tier}"
+{routing_extra}
+"""
+
+
+def test_legacy_single_executor_and_generated_defaults_do_not_enable_routing(
+    tmp_path: Path,
+) -> None:
+    legacy = _load(
+        tmp_path,
+        """
+[run]
+agent = "codex"
+
+[run.roles.executor]
+agent = "opencode"
+model = "legacy-model"
+""",
+    )
+
+    assert legacy["executor_agent"] == "opencode"
+    assert legacy["executor_model"] == "legacy-model"
+    assert "executor_tiers" not in legacy
+    assert "executor_routing" not in legacy
+
+    generated = tmp_path / "generated.toml"
+    create_project_config(generated)
+    generated_defaults = load_run_defaults(generated)
+    assert "executor_tiers" not in generated_defaults
+    assert "executor_routing" not in generated_defaults
+
+
+def test_parent_executor_and_mixed_backend_tiers_are_preserved(tmp_path: Path) -> None:
+    defaults = _load(tmp_path, _tiered_config())
+
+    assert defaults["executor_agent"] == "codex"
+    assert defaults["executor_model"] == "parent-model"
+    assert defaults["executor_tiers"] == {
+        "cheap": {"model": "cheap-model"},
+        "strong": {"agent": "deepseek_harness"},
+    }
+    assert defaults["executor_routing"] == ExecutorRoutingConfig(
+        default_tier="cheap",
+        escalate_after_failures=2,
+        escalation_tier="strong",
+    )
+
+
+@pytest.mark.parametrize(
+    ("content", "message"),
+    (
+        (
+            """
+[run.roles.executor.cheap]
+model = "cheap-model"
+[run.roles.executor.strong]
+model = "strong-model"
+""",
+            "run.executor_routing is required",
+        ),
+        (
+            """
+[run.executor_routing]
+default_tier = "cheap"
+escalate_after_failures = 2
+escalation_tier = "strong"
+""",
+            "run.roles.executor must configure at least two tiers",
+        ),
+        (
+            """
+[run.roles.executor.cheap]
+model = "cheap-model"
+[run.executor_routing]
+default_tier = "cheap"
+escalate_after_failures = 2
+escalation_tier = "strong"
+""",
+            "run.roles.executor must configure at least two tiers",
+        ),
+        (
+            _tiered_config(escalation_tier="cheap"),
+            "run.executor_routing.default_tier and run.executor_routing.escalation_tier",
+        ),
+        (
+            _tiered_config(default_tier="missing"),
+            "run.executor_routing.default_tier",
+        ),
+        (
+            _tiered_config(escalation_tier="missing"),
+            "run.executor_routing.escalation_tier",
+        ),
+    ),
+)
+def test_cross_table_routing_contract_is_strict(
+    tmp_path: Path, content: str, message: str
+) -> None:
+    with pytest.raises(ProjectConfigError, match=message):
+        _load(tmp_path, content)
+
+
+@pytest.mark.parametrize(
+    ("content", "message"),
+    (
+        (
+            _tiered_config(routing_extra='typo = "value"'),
+            r"unknown \[run.executor_routing\] key\(s\): typo",
+        ),
+        (
+            _tiered_config(tier_extra='temperature = "low"'),
+            r"unknown \[run.roles.executor.cheap\] key\(s\): temperature",
+        ),
+        (
+            _tiered_config(tier_extra='agent = "unsupported"'),
+            "run.roles.executor.cheap.agent",
+        ),
+        (
+            """
+[run.roles.executor]
+cheap = "not-a-table"
+strong = { model = "strong-model" }
+[run.executor_routing]
+default_tier = "cheap"
+escalate_after_failures = 2
+escalation_tier = "strong"
+""",
+            r"\[run.roles.executor.cheap\] must be a TOML table",
+        ),
+        (
+            """
+[run.roles.executor." bad"]
+model = "cheap-model"
+[run.roles.executor.strong]
+model = "strong-model"
+[run.executor_routing]
+default_tier = " bad"
+escalate_after_failures = 2
+escalation_tier = "strong"
+""",
+            "run.roles.executor. bad",
+        ),
+        (
+            """
+[run.roles.executor.cheap]
+model = ""
+[run.roles.executor.strong]
+model = "strong-model"
+[run.executor_routing]
+default_tier = "cheap"
+escalate_after_failures = 2
+escalation_tier = "strong"
+""",
+            "run.roles.executor.cheap.model",
+        ),
+        (_tiered_config(failures="true"), "run.executor_routing.escalate_after_failures"),
+        (_tiered_config(failures="0"), "run.executor_routing.escalate_after_failures"),
+    ),
+)
+def test_invalid_routing_values_report_their_toml_path(
+    tmp_path: Path, content: str, message: str
+) -> None:
+    with pytest.raises(ProjectConfigError, match=message):
+        _load(tmp_path, content)
+
+
+def test_routing_table_requires_every_field(tmp_path: Path) -> None:
+    with pytest.raises(
+        ProjectConfigError,
+        match=r"missing \[run.executor_routing\] key\(s\): escalation_tier",
+    ):
+        _load(
+            tmp_path,
+            """
+[run.roles.executor.cheap]
+model = "cheap-model"
+[run.roles.executor.strong]
+model = "strong-model"
+[run.executor_routing]
+default_tier = "cheap"
+escalate_after_failures = 2
+""",
+        )
+
+
+def test_harness_config_remains_backward_compatible_and_routing_is_frozen() -> None:
+    legacy = HarnessConfig()
+    assert legacy.executor_routing is None
+
+    routing = ExecutorRoutingConfig("cheap", 2, "strong")
+    configured = HarnessConfig(executor_routing=routing)
+    assert configured.executor_routing is routing
+    with pytest.raises(FrozenInstanceError):
+        routing.default_tier = "strong"  # type: ignore[misc]
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    (
+        {"default_tier": "", "escalate_after_failures": 1, "escalation_tier": "strong"},
+        {"default_tier": " cheap", "escalate_after_failures": 1, "escalation_tier": "strong"},
+        {"default_tier": "cheap", "escalate_after_failures": 1, "escalation_tier": "  "},
+        {"default_tier": "cheap", "escalate_after_failures": 1, "escalation_tier": "cheap"},
+        {"default_tier": "cheap", "escalate_after_failures": True, "escalation_tier": "strong"},
+        {"default_tier": "cheap", "escalate_after_failures": 0, "escalation_tier": "strong"},
+        {"default_tier": "cheap", "escalate_after_failures": 1.5, "escalation_tier": "strong"},
+    ),
+)
+def test_executor_routing_dataclass_rejects_invalid_values(
+    kwargs: dict[str, object],
+) -> None:
+    with pytest.raises(ValueError):
+        ExecutorRoutingConfig(**kwargs)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("language", ("en", "zh"))
+def test_manager_prompt_omits_tier_policy_when_routing_is_disabled(language: str) -> None:
+    prompt = build_role_manager_prompt(
+        task="Complete the task.",
+        rounds=[],
+        round_index=1,
+        language=language,
+    )
+
+    assert "Executor routing policy:" not in prompt
+    assert "执行器路由策略:" not in prompt
+    assert "Allowed executor tiers:" not in prompt
+    assert "允许的执行器层级:" not in prompt
+    assert "Executor tier:" not in prompt
+    assert "执行器层级:" not in prompt
+
+
+@pytest.mark.parametrize(
+    ("language", "expected"),
+    (
+        (
+            "en",
+            (
+                "Executor routing policy:",
+                "Allowed executor tiers: cheap, strong",
+                "Default tier when `Executor tier:` is omitted: cheap",
+                "2 successfully parsed `Status: incomplete` or `Status: blocked` verdicts",
+                "force tier strong",
+                "naming strong uses it immediately",
+                "Provider/runtime failures, timeouts, and format-repair failures do not count",
+            ),
+        ),
+        (
+            "zh",
+            (
+                "执行器路由策略:",
+                "允许的执行器层级: cheap, strong",
+                "省略 `执行器层级:` 时的默认层级: cheap",
+                "2 次成功解析的 `状态: incomplete` 或 `状态: blocked` 结论",
+                "强制使用层级 strong",
+                "填写 strong 会立即使用该层级",
+                "provider/runtime 失败、超时和格式修复失败不计数",
+            ),
+        ),
+    ),
+)
+def test_manager_prompt_explains_enabled_routing_policy(
+    language: str, expected: tuple[str, ...]
+) -> None:
+    prompt = build_role_manager_prompt(
+        task="Complete the task.",
+        rounds=[],
+        round_index=1,
+        executor_tiers={"strong": {"model": "strong"}, "cheap": {"model": "cheap"}},
+        executor_routing=ExecutorRoutingConfig("cheap", 2, "strong"),
+        language=language,
+    )
+
+    for marker in expected:
+        assert marker in prompt
+
+
+@pytest.mark.parametrize(
+    ("plan", "expected"),
+    (
+        ("Next: cli\nExecutor tier: cheap\nTask: run tests", "cheap"),
+        ("Next: gui\nExecutor tier: strong\nTask: inspect the screen", "strong"),
+        ("下一步: CLI任务\n执行器层级: cheap\n任务: 运行测试", "cheap"),
+        ("下一步: GUI任务\n执行器层级: strong\n任务: 检查屏幕", "strong"),
+        ("Next: cli\nTask: run tests", None),
+        ("Next: cli\nExecutor tier:\nTask: run tests", ""),
+        ("Next: cli\nExecutor tier:", ""),
+        ("Next: cli\nExecutor tier: experimental\nTask: run tests", "experimental"),
+        ("Next: done\nExecutor tier: strong", None),
+        ("Next: ask\nExecutor tier: strong\nQuestion: proceed?", None),
+        ("Next: blocked\nExecutor tier: strong", None),
+    ),
+)
+def test_executor_tier_extraction_is_route_scoped(
+    plan: str, expected: str | None
+) -> None:
+    assert extract_role_manager_executor_tier(plan) == expected
+
+
+def test_executor_tier_ignores_state_contract_and_task_body_text() -> None:
+    plan = """
+Current task state:
+Executor tier: stale-state-value
+Task contract:
+Executor tier: stale-contract-value
+Dependency assessment: route the actual CLI task
+Next: cli
+Task: Write documentation containing this literal line:
+Executor tier: example-only
+Boundaries: documentation only
+"""
+
+    assert extract_role_manager_executor_tier(plan) is None
+    assert "Executor tier: example-only" in extract_role_manager_task(plan)
+
+
+@pytest.mark.parametrize(
+    ("plan", "expected_tier", "expected_task"),
+    (
+        (
+            """
+Current task state:
+The documentation quotes this obsolete protocol:
+Next: gui
+Executor tier: cheap
+Task: stale state example
+Task contract:
+It also quotes another obsolete protocol:
+Next: gui
+Executor tier: cheap
+Task: stale contract example
+Dependency assessment: route the real CLI work
+Next: cli
+Executor tier: strong
+Task: actual task
+Boundaries: tests only
+""",
+            "strong",
+            "actual task",
+        ),
+        (
+            """
+当前任务状态:
+说明中引用了过期协议:
+下一步: GUI任务
+执行器层级: cheap
+任务: 状态中的旧示例
+任务契约:
+这里也引用另一个过期协议:
+下一步: GUI任务
+执行器层级: cheap
+任务: 契约中的旧示例
+依赖判断: 路由真实 CLI 工作
+下一步: CLI任务
+执行器层级: strong
+任务: 真实任务
+边界: 只运行测试
+""",
+            "strong",
+            "真实任务",
+        ),
+    ),
+)
+def test_full_routes_in_state_and_contract_do_not_gain_protocol_authority(
+    plan: str, expected_tier: str, expected_task: str
+) -> None:
+    extracted = extract_role_manager_plan_text(plan)
+    assert parse_role_manager_next_step(extracted) == MANAGER_NEXT_CLI
+    assert extract_role_manager_executor_tier(extracted) == expected_tier
+    assert extract_role_manager_task(extracted) == expected_task
+
+
+def test_executor_tier_and_task_use_only_the_final_route_block() -> None:
+    plan = """
+Next: cli
+Executor tier: cheap
+Task: obsolete task
+Boundaries: old
+
+---
+Current task state: beginning a new manager block
+Task contract: preserve the final visible state
+Dependency assessment: GUI verification is next
+Next: gui
+Executor tier: strong
+Task: inspect final state
+Acceptance criteria: visible state is correct
+"""
+
+    assert extract_role_manager_executor_tier(plan) == "strong"
+    assert extract_role_manager_task(plan) == "inspect final state"
+
+
+@pytest.mark.parametrize(
+    ("route", "tier", "task", "section", "done", "ask", "nested_route", "nested_tier", "nested_task"),
+    (
+        (
+            "Next: cli",
+            "Executor tier: strong",
+            "Task: update docs",
+            "Acceptance criteria",
+            "Next: done",
+            "Next: ask",
+            "Next: gui",
+            "Executor tier: cheap",
+            "Task: nested example",
+        ),
+        (
+            "Next: cli",
+            "Executor tier: strong",
+            "Task: update docs",
+            "Related audit reports",
+            "Next: done",
+            "Next: ask",
+            "Next: gui",
+            "Executor tier: cheap",
+            "Task: nested example",
+        ),
+        (
+            "Next: cli",
+            "Executor tier: strong",
+            "Task: update docs",
+            "Related audited state",
+            "Next: done",
+            "Next: ask",
+            "Next: gui",
+            "Executor tier: cheap",
+            "Task: nested example",
+        ),
+        (
+            "Next: cli",
+            "Executor tier: strong",
+            "Task: update docs",
+            "Boundaries",
+            "Next: done",
+            "Next: ask",
+            "Next: gui",
+            "Executor tier: cheap",
+            "Task: nested example",
+        ),
+        (
+            "下一步: CLI任务",
+            "执行器层级: strong",
+            "任务: 更新文档",
+            "验收标准",
+            "下一步: 完成",
+            "下一步: 请示用户",
+            "下一步: GUI任务",
+            "执行器层级: cheap",
+            "任务: 嵌套示例",
+        ),
+        (
+            "下一步: CLI任务",
+            "执行器层级: strong",
+            "任务: 更新文档",
+            "相关审计报告",
+            "下一步: 完成",
+            "下一步: 请示用户",
+            "下一步: GUI任务",
+            "执行器层级: cheap",
+            "任务: 嵌套示例",
+        ),
+        (
+            "下一步: CLI任务",
+            "执行器层级: strong",
+            "任务: 更新文档",
+            "相关已审计状态",
+            "下一步: 完成",
+            "下一步: 请示用户",
+            "下一步: GUI任务",
+            "执行器层级: cheap",
+            "任务: 嵌套示例",
+        ),
+        (
+            "下一步: CLI任务",
+            "执行器层级: strong",
+            "任务: 更新文档",
+            "边界",
+            "下一步: 完成",
+            "下一步: 请示用户",
+            "下一步: GUI任务",
+            "执行器层级: cheap",
+            "任务: 嵌套示例",
+        ),
+    ),
+)
+def test_all_subtask_sections_lock_route_literals_and_nested_protocols(
+    route: str,
+    tier: str,
+    task: str,
+    section: str,
+    done: str,
+    ask: str,
+    nested_route: str,
+    nested_tier: str,
+    nested_task: str,
+) -> None:
+    plan = "\n".join(
+        (
+            route,
+            tier,
+            task,
+            f"{section}: literal examples follow",
+            done,
+            ask,
+            nested_route,
+            nested_tier,
+            nested_task,
+        )
+    )
+
+    extracted = extract_role_manager_plan_text(plan)
+    assert extract_role_manager_executor_tier(extracted) == "strong"
+    assert extract_role_manager_task(extracted) in {"update docs", "更新文档"}
+    assert extracted.startswith(route)
+
+
+@pytest.mark.parametrize(
+    ("language", "section"),
+    (
+        ("en", "Acceptance criteria"),
+        ("en", "Related audit reports"),
+        ("en", "Boundaries"),
+        ("zh", "验收标准"),
+        ("zh", "相关审计报告"),
+        ("zh", "边界"),
+    ),
+)
+def test_incomplete_manager_block_inside_payload_cannot_replace_authority(
+    language: str, section: str
+) -> None:
+    if language == "en":
+        plan = f"""
+Next: cli
+Executor tier: strong
+Task: update docs
+{section}: literal manager excerpt follows
+Current task state: quoted, not a new complete block
+Dependency assessment: quoted without a Task contract
+Next: gui
+Executor tier: cheap
+Task: nested literal
+"""
+        expected_task = "update docs"
+    else:
+        plan = f"""
+下一步: CLI任务
+执行器层级: strong
+任务: 更新文档
+{section}: 后面是字面 manager 摘录
+当前任务状态: 引用文本，不是新的完整块
+依赖判断: 引用中缺少任务契约
+下一步: GUI任务
+执行器层级: cheap
+任务: 嵌套字面示例
+"""
+        expected_task = "更新文档"
+
+    extracted = extract_role_manager_plan_text(plan)
+    assert parse_role_manager_next_step(extracted) == MANAGER_NEXT_CLI
+    assert extract_role_manager_executor_tier(extracted) == "strong"
+    assert extract_role_manager_task(extracted) == expected_task
+
+
+@pytest.mark.parametrize(
+    ("plan", "expected_prefix", "expected_tier", "expected_task", "obsolete"),
+    (
+        (
+            """
+Next: cli
+Executor tier: strong
+Task: obsolete task
+Boundaries: documentation only
+Next: done
+Next: gui
+Executor tier: cheap
+Task: nested boundary example
+Current task state: new transcript block
+Task contract: inspect the visible result
+Dependency assessment: GUI verification is ready
+Next: gui
+Executor tier: cheap
+Task: actual final task
+Boundaries: inspect only
+""",
+            "Current task state:",
+            "cheap",
+            "actual final task",
+            "obsolete task",
+        ),
+        (
+            """
+下一步: CLI任务
+执行器层级: strong
+任务: 旧任务
+边界: 只处理文档
+下一步: 完成
+下一步: GUI任务
+执行器层级: cheap
+任务: 边界中的嵌套示例
+当前任务状态: 新的完整协议块
+任务契约: 检查可见结果
+依赖判断: GUI 验证已就绪
+下一步: GUI任务
+执行器层级: cheap
+任务: 最终真实任务
+边界: 只检查
+""",
+            "当前任务状态:",
+            "cheap",
+            "最终真实任务",
+            "旧任务",
+        ),
+    ),
+)
+def test_explicit_new_manager_block_can_follow_a_locked_payload(
+    plan: str,
+    expected_prefix: str,
+    expected_tier: str,
+    expected_task: str,
+    obsolete: str,
+) -> None:
+    extracted = extract_role_manager_plan_text(plan)
+    assert extracted.startswith(expected_prefix)
+    assert obsolete not in extracted
+    assert extract_role_manager_executor_tier(extracted) == expected_tier
+    assert extract_role_manager_task(extracted) == expected_task
+
+
+def test_initial_legacy_contract_block_is_preserved_without_current_state() -> None:
+    plan = """
+wrapper prose that is not part of the manager protocol
+Task contract: preserve the requested artifact
+Dependency assessment: CLI work is ready
+Next: cli
+Executor tier: strong
+Task: run the final tests
+Boundaries: tests only
+"""
+
+    extracted = extract_role_manager_plan_text(plan)
+    assert extracted.startswith("Task contract: preserve the requested artifact")
+    assert parse_role_manager_next_step(extracted) == MANAGER_NEXT_CLI
+    assert extract_role_manager_executor_tier(extracted) == "strong"
+    assert extract_role_manager_task(extracted) == "run the final tests"
+
+
+@pytest.mark.parametrize(
+    ("plan", "expected_route", "expected_state", "expected_contract"),
+    (
+        (
+            """Next: cli
+Current task state:
+CLI work remains.
+Task contract:
+Preserve the requested behavior.
+""",
+            MANAGER_NEXT_CLI,
+            "CLI work remains.",
+            "Preserve the requested behavior.",
+        ),
+        (
+            """Next: gui
+Current task state:
+Visual verification remains.
+""",
+            MANAGER_NEXT_GUI,
+            "Visual verification remains.",
+            "prior contract",
+        ),
+        (
+            """下一步: CLI任务
+当前任务状态:
+仍需执行 CLI 工作。
+任务契约:
+保留请求的行为。
+""",
+            MANAGER_NEXT_CLI,
+            "仍需执行 CLI 工作。",
+            "保留请求的行为。",
+        ),
+        (
+            """下一步: GUI任务
+当前任务状态:
+仍需视觉验证。
+""",
+            MANAGER_NEXT_GUI,
+            "仍需视觉验证。",
+            "prior contract",
+        ),
+    ),
+)
+def test_legacy_route_first_short_plan_restores_state_and_optional_contract(
+    plan: str,
+    expected_route: str,
+    expected_state: str,
+    expected_contract: str,
+) -> None:
+    extracted = extract_role_manager_plan_text(plan)
+    assert parse_role_manager_next_step(extracted) == expected_route
+    assert expected_state in extract_role_task_state(extracted)
+    assert extract_role_task_contract(extracted, fallback="prior contract").endswith(
+        expected_contract
+    )
+    assert extract_role_manager_task(extracted) == ""
+
+
+@pytest.mark.parametrize(
+    ("plan", "expected_state"),
+    (
+        ("Next: done\nCurrent task state:\nAll work is verified.\n", "All work is verified."),
+        ("下一步: 完成\n当前任务状态:\n全部工作已经验证。\n", "全部工作已经验证。"),
+    ),
+)
+def test_terminal_route_first_short_plan_restores_state(
+    plan: str, expected_state: str
+) -> None:
+    assert parse_role_manager_next_step(plan) == MANAGER_NEXT_DONE
+    assert expected_state in extract_role_task_state(plan)
+
+
+def test_route_first_state_payload_cannot_replace_top_level_authority() -> None:
+    plan = """Next: cli
+Current task state:
+The retained state quotes a non-authoritative payload route:
+Next: gui
+Executor tier: strong
+Task: quoted payload only
+"""
+
+    assert parse_role_manager_next_step(plan) == MANAGER_NEXT_CLI
+    assert extract_role_manager_executor_tier(plan) is None
+    assert "Next: gui" in extract_role_task_state(plan)
+
+
+def test_enabled_routing_gives_legacy_missing_tasks_per_round_identities() -> None:
+    router = _router(threshold=1)
+    plan = "Next: cli\nCurrent task state:\nCLI work remains.\n"
+    next_step = parse_role_manager_next_step(plan)
+    task = extract_role_manager_task(plan)
+
+    first = router.select(
+        next_step=next_step,
+        task_text=task,
+        requested_tier=extract_role_manager_executor_tier(plan),
+        round_index=1,
+    )
+    router.observe(first, "blocked")
+    second = router.select(
+        next_step=next_step,
+        task_text=task,
+        requested_tier=extract_role_manager_executor_tier(plan),
+        round_index=2,
+    )
+
+    assert next_step == MANAGER_NEXT_CLI
+    assert task == ""
+    assert first.task_present is False
+    assert second.task_present is False
+    assert first.task_id != second.task_id
+    assert second.failures_before == 0
+    assert second.selected_tier == "cheap"
+
+
+@pytest.mark.parametrize("language", ("en", "zh"))
+@pytest.mark.parametrize(
+    "expected_route",
+    (
+        MANAGER_NEXT_GUI,
+        MANAGER_NEXT_CLI,
+        MANAGER_NEXT_ASK,
+        MANAGER_NEXT_DONE,
+        MANAGER_NEXT_BLOCKED,
+    ),
+)
+def test_all_manager_fields_share_final_structural_authority(
+    language: str, expected_route: str
+) -> None:
+    if language == "en":
+        prefix = """noisy transcript wrapper
+Current task state:
+Verified state includes literal protocol examples:
+Next: gui
+Question: fake state question
+Choices: wrong | worse
+Related audit reports: round_001
+state tail survives
+Task contract:
+Keep this literal terminal route in the contract:
+Next: blocked
+Question: fake contract question
+Choices: bad | worse
+Related audit reports: round_001
+contract tail survives
+Dependency assessment:
+This dependency prose mentions a non-protocol route:
+Next: gui
+dependency tail survives
+"""
+        if expected_route in {MANAGER_NEXT_GUI, MANAGER_NEXT_CLI}:
+            route_line = "Next: gui" if expected_route == MANAGER_NEXT_GUI else "Next: cli"
+            tail = f"""{route_line}
+Executor tier: strong
+Task: actual executable task
+Acceptance criteria: preserve these literal examples
+Next: done
+Question: fake acceptance question
+Choices: wrong | worse
+Next: gui
+Executor tier: cheap
+Task: nested acceptance example
+Related audit reports: round_003 for the actual dependency
+Related audited state: round_003 remains relevant
+Boundaries: literal nested route below is not authoritative
+Next: blocked
+"""
+        elif expected_route == MANAGER_NEXT_ASK:
+            tail = """Next: ask
+Question: proceed with the actual choice?
+Choices: yes | no
+Related audit reports: round_003 must not attach to a terminal route
+"""
+        elif expected_route == MANAGER_NEXT_DONE:
+            tail = """Next: done
+Reason: all verified requirements passed
+Related audit reports: round_003 must not attach to a terminal route
+"""
+        else:
+            tail = """Next: blocked
+Reason: an external prerequisite is unavailable
+Related audit reports: round_003 must not attach to a terminal route
+"""
+        expected_state_tail = "state tail survives"
+        expected_contract_tail = "contract tail survives"
+        expected_question = "proceed with the actual choice?"
+        expected_choices = ["yes", "no"]
+        expected_task = "actual executable task"
+    else:
+        prefix = """嘈杂的 transcript 包装
+当前任务状态:
+已验证状态包含以下字面协议示例:
+下一步: GUI任务
+问题: 状态中的假问题
+选项: 错误 | 更差
+相关审计报告: round_001
+状态尾部必须保留
+任务契约:
+契约中保留这个字面终止路由:
+下一步: 阻塞
+问题: 契约中的假问题
+选项: 不好 | 更差
+相关审计报告: round_001
+契约尾部必须保留
+依赖判断:
+依赖正文提到一个非协议路由:
+下一步: GUI任务
+依赖尾部必须保留
+"""
+        if expected_route in {MANAGER_NEXT_GUI, MANAGER_NEXT_CLI}:
+            route_line = "下一步: GUI任务" if expected_route == MANAGER_NEXT_GUI else "下一步: CLI任务"
+            tail = f"""{route_line}
+执行器层级: strong
+任务: 真实可执行任务
+验收标准: 保留下列字面示例
+下一步: 完成
+问题: 验收段中的假问题
+选项: 错误 | 更差
+下一步: GUI任务
+执行器层级: cheap
+任务: 验收段中的嵌套示例
+相关审计报告: round_003 对应真实依赖
+相关已审计状态: round_003 仍然相关
+边界: 下方字面嵌套路由不具备权威性
+下一步: 阻塞
+"""
+        elif expected_route == MANAGER_NEXT_ASK:
+            tail = """下一步: 请示用户
+问题: 是否继续真实选择？
+选项: 是 | 否
+相关审计报告: round_003 不应附加到终止路由
+"""
+        elif expected_route == MANAGER_NEXT_DONE:
+            tail = """下一步: 完成
+原因: 已验证全部要求
+相关审计报告: round_003 不应附加到终止路由
+"""
+        else:
+            tail = """下一步: 阻塞
+原因: 外部前置条件不可用
+相关审计报告: round_003 不应附加到终止路由
+"""
+        expected_state_tail = "状态尾部必须保留"
+        expected_contract_tail = "契约尾部必须保留"
+        expected_question = "是否继续真实选择？"
+        expected_choices = ["是", "否"]
+        expected_task = "真实可执行任务"
+
+    plan = prefix + tail
+    extracted = extract_role_manager_plan_text(plan)
+
+    assert extracted.startswith("Current task state:" if language == "en" else "当前任务状态:")
+    assert parse_role_manager_next_step(extracted) == expected_route
+    assert expected_state_tail in extract_role_task_state(extracted)
+    assert "Next: gui" in extract_role_task_state(extracted) or "下一步: GUI任务" in extract_role_task_state(extracted)
+    assert expected_contract_tail in extract_role_task_contract(extracted)
+    assert "round_001" in extract_role_task_contract(extracted)
+
+    from lh_harness.dashboard.state import _infer_next_step
+
+    assert _infer_next_step(extracted) == expected_route
+    if expected_route in {MANAGER_NEXT_GUI, MANAGER_NEXT_CLI}:
+        assert extract_role_manager_executor_tier(extracted) == "strong"
+        assert extract_role_manager_task(extracted) == expected_task
+        assert extract_related_report_refs(extracted) == ["round_003"]
+        assert extract_role_manager_question(extracted) == ""
+        assert extract_role_manager_answer_choices(extracted) == []
+    elif expected_route == MANAGER_NEXT_ASK:
+        assert extract_role_manager_executor_tier(extracted) is None
+        assert extract_role_manager_task(extracted) == ""
+        assert extract_role_manager_question(extracted) == expected_question
+        assert extract_role_manager_answer_choices(extracted) == expected_choices
+        assert extract_related_report_refs(extracted) == []
+    else:
+        assert extract_role_manager_executor_tier(extracted) is None
+        assert extract_role_manager_task(extracted) == ""
+        assert extract_role_manager_question(extracted) == ""
+        assert extract_role_manager_answer_choices(extracted) == []
+        assert extract_related_report_refs(extracted) == []
+
+
+@pytest.mark.parametrize("language", ("en", "zh"))
+def test_related_refs_require_authoritative_executable_section(language: str) -> None:
+    plan = (
+        """Current task state:
+Related audit reports: round_001 is only state prose
+Task contract: preserve the result
+Dependency assessment: CLI work is ready
+Next: cli
+Task: execute without related context
+Boundaries: tests only
+"""
+        if language == "en"
+        else """当前任务状态:
+相关审计报告: round_001 只是状态正文
+任务契约: 保留结果
+依赖判断: CLI 工作已就绪
+下一步: CLI任务
+任务: 不带相关上下文执行
+边界: 只运行测试
+"""
+    )
+    assert extract_related_report_refs(plan) == []
+
+
+@pytest.mark.parametrize(
+    ("plan", "expected_question", "expected_choices"),
+    (
+        (
+            """Current task state:
+Choices: wrong | worse
+Task contract: preserve the actual question
+Dependency assessment: ask the user
+Next: ask
+Question: whether to continue yes/no?
+""",
+            "whether to continue yes/no?",
+            ["Yes", "No"],
+        ),
+        (
+            """当前任务状态:
+选项: 错误 | 更差
+任务契约: 保留真实问题
+依赖判断: 请示用户
+下一步: 请示用户
+问题: 是否继续？
+""",
+            "是否继续？",
+            ["是", "否"],
+        ),
+    ),
+)
+def test_yes_no_fallback_uses_only_authoritative_question(
+    plan: str, expected_question: str, expected_choices: list[str]
+) -> None:
+    assert extract_role_manager_question(plan) == expected_question
+    assert extract_role_manager_answer_choices(plan) == expected_choices
+
+
+def test_legacy_contract_without_dependency_keeps_contract_and_route() -> None:
+    plan = """Task contract: legacy contract without dependency
+Next: cli
+Task: run legacy task
+Boundaries: task only
+"""
+    extracted = extract_role_manager_plan_text(plan)
+    assert extracted.startswith("Task contract: legacy contract without dependency")
+    assert parse_role_manager_next_step(extracted) == MANAGER_NEXT_CLI
+    assert "legacy contract without dependency" in extract_role_task_contract(extracted)
+
+
+@pytest.mark.parametrize(
+    ("plan", "expected_tier", "expected_task"),
+    (
+        (
+            """
+Next: cli
+Executor tier: cheap
+Task:
+Document this literal protocol example:
+Next: cli
+This line is quoted task content, not a new route block.
+Boundaries: documentation only
+""",
+            "cheap",
+            "Document this literal protocol example:\nNext: cli\nThis line is quoted task content, not a new route block.",
+        ),
+        (
+            """
+下一步: GUI任务
+执行器层级: strong
+任务:
+在说明中保留下列字面示例:
+下一步: GUI任务
+这只是任务正文，不是新路由块。
+边界: 只核对说明
+""",
+            "strong",
+            "在说明中保留下列字面示例:\n下一步: GUI任务\n这只是任务正文，不是新路由块。",
+        ),
+    ),
+)
+def test_route_like_task_body_lines_do_not_replace_the_outer_route(
+    plan: str, expected_tier: str, expected_task: str
+) -> None:
+    assert extract_role_manager_executor_tier(plan) == expected_tier
+    assert extract_role_manager_task(plan) == expected_task
+
+
+@pytest.mark.parametrize(
+    ("plan", "expected_tier", "task_markers"),
+    (
+        (
+            """
+Next: cli
+Executor tier: cheap
+Task:
+Document these literal route examples:
+Next: done
+Next: ask
+Next: blocked
+Next: gui
+Executor tier: strong
+Task: nested example only
+The nested block is still documentation payload.
+Boundaries: documentation only
+""",
+            "cheap",
+            ("Next: done", "Next: ask", "Next: blocked", "Task: nested example only"),
+        ),
+        (
+            """
+下一步: GUI任务
+执行器层级: strong
+任务:
+保留下列字面路由示例:
+下一步: 完成
+下一步: 请示用户
+下一步: 阻塞
+下一步: CLI任务
+执行器层级: cheap
+任务: 仅为嵌套示例
+嵌套块仍属于任务正文。
+边界: 只处理说明文字
+""",
+            "strong",
+            ("下一步: 完成", "下一步: 请示用户", "下一步: 阻塞", "任务: 仅为嵌套示例"),
+        ),
+    ),
+)
+def test_task_payload_locks_all_nested_route_protocols_until_a_boundary(
+    plan: str, expected_tier: str, task_markers: tuple[str, ...]
+) -> None:
+    assert extract_role_manager_executor_tier(plan) == expected_tier
+    task = extract_role_manager_task(plan)
+    for marker in task_markers:
+        assert marker in task
+
+
+@pytest.mark.parametrize(
+    ("plan", "expected"),
+    (
+        ("Next: cli\nTask: run the focused tests", "run the focused tests"),
+        (
+            "Next: gui\nTask:\nOpen the settings page.\nVerify the saved value.\nBoundaries: no other changes",
+            "Open the settings page.\nVerify the saved value.",
+        ),
+        ("下一步: CLI任务\n任务: 运行聚焦测试\n验收标准: 全部通过", "运行聚焦测试"),
+        (
+            "下一步: GUI任务\n执行器层级: strong\n任务:\n打开设置页。\n核对保存值。\n相关审计报告: round_001",
+            "打开设置页。\n核对保存值。",
+        ),
+        ("Next: cli\nExecutor tier: cheap\nBoundaries: tests only", ""),
+        ("Next: done\nTask: should not be executable", ""),
+    ),
+)
+def test_manager_task_extraction_is_narrow_and_bounded(plan: str, expected: str) -> None:
+    assert extract_role_manager_task(plan) == expected
+
+
+def _router(*, threshold: int = 2) -> ExecutorRouter:
+    return ExecutorRouter(
+        {"cheap", "strong"},
+        ExecutorRoutingConfig("cheap", threshold, "strong"),
+    )
+
+
+@pytest.mark.parametrize("tier", (" premium ", "premium!", "x" * 65))
+def test_router_rejects_noncanonical_programmatic_tier_names(tier: str) -> None:
+    with pytest.raises(ValueError, match="1-64 ASCII"):
+        ExecutorRouter(
+            {"cheap", "strong", tier},
+            ExecutorRoutingConfig("cheap", 2, "strong"),
+        )
+
+
+def test_router_default_and_explicit_escalation_selection() -> None:
+    router = _router()
+    default = router.select(
+        next_step=MANAGER_NEXT_CLI,
+        task_text="run focused tests",
+        requested_tier=None,
+        round_index=1,
+    )
+    strong = router.select(
+        next_step=MANAGER_NEXT_GUI,
+        task_text="inspect the screen",
+        requested_tier="strong",
+        round_index=2,
+    )
+
+    assert (default.selected_tier, default.selection_reason) == ("cheap", "default")
+    assert (strong.selected_tier, strong.selection_reason) == (
+        "strong",
+        "manager_escalation",
+    )
+    assert strong.escalation_active is True
+
+
+def test_router_explicit_escalation_is_sticky_against_a_downgrade_request() -> None:
+    router = _router()
+    strong = router.select(
+        next_step=MANAGER_NEXT_CLI,
+        task_text="same task",
+        requested_tier="strong",
+        round_index=1,
+    )
+    retry = router.select(
+        next_step=MANAGER_NEXT_CLI,
+        task_text="same task",
+        requested_tier="cheap",
+        round_index=2,
+    )
+
+    assert strong.selected_tier == "strong"
+    assert retry.selected_tier == "strong"
+    assert retry.selection_reason == "automatic_escalation"
+
+
+def test_router_escalates_on_the_run_after_the_threshold_and_stays_sticky() -> None:
+    router = _router(threshold=2)
+    first = router.select(
+        next_step=MANAGER_NEXT_CLI,
+        task_text="same task",
+        requested_tier=None,
+        round_index=1,
+    )
+    first = router.observe(first, "incomplete")
+    second = router.select(
+        next_step=MANAGER_NEXT_CLI,
+        task_text="  same   task ",
+        requested_tier="cheap",
+        round_index=2,
+    )
+    second = router.observe(second, "blocked")
+    third = router.select(
+        next_step=MANAGER_NEXT_CLI,
+        task_text="same task",
+        requested_tier="cheap",
+        round_index=3,
+    )
+
+    assert first.failures_after == 1
+    assert second.selected_tier == "cheap"
+    assert second.failures_after == 2
+    assert second.escalation_active is True
+    assert third.selected_tier == "strong"
+    assert third.selection_reason == "automatic_escalation"
+    assert third.failures_before == 2
+
+
+def test_router_new_task_route_change_and_pass_reset_to_default() -> None:
+    router = _router(threshold=1)
+    cli = router.select(
+        next_step=MANAGER_NEXT_CLI,
+        task_text="same words",
+        requested_tier=None,
+        round_index=1,
+    )
+    router.observe(cli, "incomplete")
+    gui = router.select(
+        next_step=MANAGER_NEXT_GUI,
+        task_text="same words",
+        requested_tier=None,
+        round_index=2,
+    )
+    completed = router.observe(gui, "complete")
+    next_task = router.select(
+        next_step=MANAGER_NEXT_GUI,
+        task_text="same words",
+        requested_tier=None,
+        round_index=3,
+    )
+
+    assert gui.selected_tier == "cheap"
+    assert gui.failures_before == 0
+    assert completed.audit_signal == "complete"
+    assert completed.failures_after == 0
+    assert next_task.selected_tier == "cheap"
+    assert next_task.failures_before == 0
+
+
+def test_router_invalid_tier_is_atomic_and_does_not_reset_active_task() -> None:
+    router = _router(threshold=2)
+    first = router.select(
+        next_step=MANAGER_NEXT_CLI,
+        task_text="active task",
+        requested_tier=None,
+        round_index=1,
+    )
+    router.observe(first, "incomplete")
+    rejected = router.select(
+        next_step=MANAGER_NEXT_GUI,
+        task_text="different task",
+        requested_tier="unknown",
+        round_index=2,
+    )
+    resumed = router.select(
+        next_step=MANAGER_NEXT_CLI,
+        task_text="active task",
+        requested_tier=None,
+        round_index=3,
+    )
+
+    assert rejected.selection_reason == "invalid"
+    assert rejected.selected_tier is None
+    assert resumed.failures_before == 1
+
+
+def test_router_empty_tasks_never_accumulate_across_rounds() -> None:
+    router = _router(threshold=1)
+    first = router.select(
+        next_step=MANAGER_NEXT_CLI,
+        task_text="",
+        requested_tier=None,
+        round_index=1,
+    )
+    router.observe(first, "blocked")
+    second = router.select(
+        next_step=MANAGER_NEXT_CLI,
+        task_text="   ",
+        requested_tier=None,
+        round_index=2,
+    )
+
+    assert first.task_present is False
+    assert second.task_present is False
+    assert first.task_id != second.task_id
+    assert second.failures_before == 0
+    assert second.selected_tier == "cheap"
+
+
+def test_router_not_counted_signal_preserves_failures_without_clearing() -> None:
+    router = _router(threshold=2)
+    first = router.select(
+        next_step=MANAGER_NEXT_CLI,
+        task_text="active task",
+        requested_tier=None,
+        round_index=1,
+    )
+    router.observe(first, "incomplete")
+    timeout = router.select(
+        next_step=MANAGER_NEXT_CLI,
+        task_text="active task",
+        requested_tier=None,
+        round_index=2,
+    )
+    timeout = router.observe(timeout, "not_counted")
+    retry = router.select(
+        next_step=MANAGER_NEXT_CLI,
+        task_text="active task",
+        requested_tier=None,
+        round_index=3,
+    )
+
+    assert timeout.audit_signal == "not_counted"
+    assert timeout.failures_after == 1
+    assert retry.failures_before == 1
+    assert retry.selected_tier == "cheap"
+
+
+def test_task_identity_normalizes_whitespace_but_includes_route() -> None:
+    first, _ = executor_task_identity(
+        next_step=MANAGER_NEXT_CLI, task_text="run\n focused   tests", round_index=1
+    )
+    normalized, _ = executor_task_identity(
+        next_step=MANAGER_NEXT_CLI, task_text="run focused tests", round_index=9
+    )
+    gui, _ = executor_task_identity(
+        next_step=MANAGER_NEXT_GUI, task_text="run focused tests", round_index=1
+    )
+
+    assert first == normalized
+    assert first != gui
+
+
+class _QueueAgent:
+    def __init__(
+        self,
+        name: str,
+        outputs: list[str | EpisodeResult],
+        calls: list[str] | None = None,
+    ) -> None:
+        self.name = name
+        self.outputs = list(outputs)
+        self.prompts: list[str] = []
+        self.calls = calls
+
+    async def run_episode(self, prompt, _env, _budget, live_trajectory_path=None):
+        self.prompts.append(prompt)
+        if self.calls is not None:
+            self.calls.append(self.name)
+        output = self.outputs.pop(0)
+        if isinstance(output, EpisodeResult):
+            return output
+        return EpisodeResult(status="done", actions_log=output)
+
+
+def _patch_kernel_boundaries(monkeypatch: pytest.MonkeyPatch):
+    events: list[tuple[str, dict[str, object]]] = []
+    records: list[object] = []
+
+    async def noop_async(*_args, **_kwargs):
+        return None
+
+    async def record_round(_env, _config, _role_dir, _events_path, record):
+        records.append(record)
+
+    async def no_gate(*_args, **_kwargs):
+        return False
+
+    monkeypatch.setattr(manager_runtime, "_ensure_dir_nofollow", lambda *_a, **_k: None)
+    monkeypatch.setattr(manager_runtime, "_ensure_remote_layout", noop_async)
+    monkeypatch.setattr(manager_runtime, "_write_remote_round_text", noop_async)
+    monkeypatch.setattr(manager_runtime, "_write_remote_text", noop_async)
+    monkeypatch.setattr(manager_runtime, "_write_local", lambda *_a, **_k: None)
+    monkeypatch.setattr(manager_runtime, "_save_role_result", lambda *_a, **_k: {})
+    monkeypatch.setattr(manager_runtime, "_capture_environment_screenshot", noop_async)
+    monkeypatch.setattr(manager_runtime, "_merge_episode_logs", lambda *_a, **_k: None)
+    monkeypatch.setattr(manager_runtime, "_record_round", record_round)
+    monkeypatch.setattr(manager_runtime, "_human_gate", no_gate)
+    monkeypatch.setattr(
+        manager_runtime,
+        "_append_event",
+        lambda _path, event, payload: events.append((event, payload)),
+    )
+    return events, records
+
+
+def _routing_config(tmp_path: Path, *, rounds: int) -> HarnessConfig:
+    return HarnessConfig(
+        max_total_episodes=rounds,
+        workspace_path=str(tmp_path / "workspace"),
+        harness_dir=str(tmp_path / "harness"),
+        log_dir=str(tmp_path / "logs"),
+        executor_routing=ExecutorRoutingConfig("cheap", 2, "strong"),
+    )
+
+
+def _audit(status: str) -> str:
+    return (
+        f"Status: {status}\n"
+        "Integrity: clean\n"
+        "Contract audit: aligned\n"
+        "Acceptance-constraint backcheck: no blocking constraints\n"
+        "State update for manager: verified"
+    )
+
+
+def test_kernel_uses_one_authority_for_route_tier_and_task(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    events, records = _patch_kernel_boundaries(monkeypatch)
+    calls: list[str] = []
+    manager = _QueueAgent(
+        "manager",
+        [
+            """
+Current task state:
+The documentation quotes an obsolete route:
+Next: gui
+Executor tier: cheap
+Task: stale state example
+Task contract:
+Preserve the real CLI deliverable; this is another quoted route:
+Next: gui
+Executor tier: cheap
+Task: stale contract example
+Dependency assessment: the real CLI work is ready
+Next: cli
+Executor tier: strong
+Task: actual CLI task
+Boundaries: tests only
+"""
+        ],
+    )
+    auditor = _QueueAgent("auditor", [_audit("complete")])
+    gui_cheap = _QueueAgent("gui-cheap", [], calls)
+    gui_strong = _QueueAgent("gui-strong", [], calls)
+    cli_cheap = _QueueAgent("cli-cheap", [], calls)
+    cli_strong = _QueueAgent("cli-strong", ["done"], calls)
+
+    asyncio.run(
+        manager_runtime._run_impl(
+            task="unified parser authority",
+            env=object(),
+            config=_routing_config(tmp_path, rounds=1),
+            manager_agent=manager,
+            gui_executor_agents={"cheap": gui_cheap, "strong": gui_strong},
+            cli_executor_agents={"cheap": cli_cheap, "strong": cli_strong},
+            gui_auditor_agent=auditor,
+            cli_auditor_agent=auditor,
+        )
+    )
+
+    assert calls == ["cli-strong"]
+    assert records[0].next_step == MANAGER_NEXT_CLI
+    assert records[0].executor_routing["selected_tier"] == "strong"
+    assert records[0].executor_routing["task_present"] is True
+    manager_done = next(
+        payload for event, payload in events if event == "manager_round_done"
+    )
+    assert manager_done["next_step"] == MANAGER_NEXT_CLI
+    assert manager_done["executor_routing"]["selected_tier"] == "strong"
+
+
+def test_kernel_ask_gate_uses_authoritative_question_and_choices(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _events, records = _patch_kernel_boundaries(monkeypatch)
+    captured: list[dict[str, object]] = []
+
+    async def capture_gate(
+        _gate,
+        reason,
+        round_index,
+        _task_state,
+        **kwargs,
+    ) -> bool:
+        captured.append({"reason": reason, "round": round_index, **kwargs})
+        return True
+
+    monkeypatch.setattr(manager_runtime, "_human_gate", capture_gate)
+    manager = _QueueAgent(
+        "manager",
+        [
+            """
+Current task state:
+Question: fake state question
+Choices: wrong | worse
+Task contract:
+Question: fake contract question
+Choices: bad | worse
+Dependency assessment: a human decision is required
+Next: ask
+Question: proceed with the actual operation?
+Choices: approve | reject
+"""
+        ],
+    )
+    unused = _QueueAgent("unused", [])
+
+    asyncio.run(
+        manager_runtime._run_impl(
+            task="ask with one authority",
+            env=object(),
+            config=_routing_config(tmp_path, rounds=1),
+            manager_agent=manager,
+            gui_executor_agents={"cheap": unused, "strong": unused},
+            cli_executor_agents={"cheap": unused, "strong": unused},
+            gui_auditor_agent=unused,
+            cli_auditor_agent=unused,
+        )
+    )
+
+    assert captured == [
+        {
+            "reason": "ask",
+            "round": 1,
+            "question": "proceed with the actual operation?",
+            "answers": ["approve", "reject"],
+        }
+    ]
+    assert records[0].next_step == MANAGER_NEXT_ASK
+
+
+def test_kernel_executor_prompt_uses_only_route_selected_related_report(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _events, records = _patch_kernel_boundaries(monkeypatch)
+    manager = _QueueAgent(
+        "manager",
+        [
+            "Next: cli\nTask: establish first audited context",
+            "Next: cli\nTask: establish second audited context",
+            """
+Current task state:
+Related audit reports: round_001 is a state-only fake reference
+Task contract:
+Preserve the selected audit boundary; round_001 is contract prose
+Dependency assessment: use only the explicitly related second report
+Next: cli
+Task: consume selected related context
+Related audit reports: round_002 because it is the actual dependency
+Boundaries: do not inject unselected reports
+""",
+        ],
+    )
+    executor = _QueueAgent("executor", ["one", "two", "three"])
+    auditor = _QueueAgent(
+        "auditor",
+        [
+            _audit("incomplete") + "\nAUDIT_MARKER_ONE",
+            _audit("incomplete") + "\nAUDIT_MARKER_TWO",
+            _audit("incomplete") + "\nAUDIT_MARKER_THREE",
+        ],
+    )
+
+    asyncio.run(
+        manager_runtime._run_impl(
+            task="related report authority",
+            env=object(),
+            config=_routing_config(tmp_path, rounds=3),
+            manager_agent=manager,
+            gui_executor_agents={"cheap": executor, "strong": executor},
+            cli_executor_agents={"cheap": executor, "strong": executor},
+            gui_auditor_agent=auditor,
+            cli_auditor_agent=auditor,
+        )
+    )
+
+    assert records[2].related_report_refs == ["round_002"]
+    assert "AUDIT_MARKER_TWO" in executor.prompts[2]
+    assert "AUDIT_MARKER_ONE" not in executor.prompts[2]
+
+
+def test_kernel_routes_cheap_cheap_strong_and_persists_metadata(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    events, records = _patch_kernel_boundaries(monkeypatch)
+    calls: list[str] = []
+    plans = ["Next: cli\nTask: same subtask"] * 3
+    manager = _QueueAgent("manager", plans)
+    auditor = _QueueAgent("auditor", [_audit("incomplete"), _audit("blocked"), _audit("complete")])
+    cheap = _QueueAgent("cheap", ["cheap done", "cheap done"], calls)
+    strong = _QueueAgent("strong", ["strong done"], calls)
+
+    report = asyncio.run(
+        manager_runtime._run_impl(
+            task="route by cost",
+            env=object(),
+            config=_routing_config(tmp_path, rounds=3),
+            manager_agent=manager,
+            gui_executor_agents={"cheap": cheap, "strong": strong},
+            cli_executor_agents={"cheap": cheap, "strong": strong},
+            gui_auditor_agent=auditor,
+            cli_auditor_agent=auditor,
+        )
+    )
+
+    assert calls == ["cheap", "cheap", "strong"]
+    assert [item.executor_routing["selected_tier"] for item in records] == [
+        "cheap",
+        "cheap",
+        "strong",
+    ]
+    assert [item.executor_routing["audit_signal"] for item in records] == [
+        "incomplete",
+        "blocked",
+        "complete",
+    ]
+    assert records[1].executor_routing["failures_after"] == 2
+    assert records[2].executor_routing["selection_reason"] == "automatic_escalation"
+    assert report["rounds"][2]["executor_routing"]["selected_tier"] == "strong"
+    start = next(payload for event, payload in events if event == "role_harness_start")
+    assert start["executor_routing"]["available_tiers"] == ["cheap", "strong"]
+    audit_done = [payload for event, payload in events if event == "auditor_role_done"]
+    assert audit_done[-1]["executor_routing"]["audit_signal"] == "complete"
+
+
+def test_kernel_honors_manager_strong_new_task_reset_and_gui_map(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _events, records = _patch_kernel_boundaries(monkeypatch)
+    calls: list[str] = []
+    manager = _QueueAgent(
+        "manager",
+        [
+            "Next: cli\nExecutor tier: strong\nTask: first task",
+            "Next: cli\nTask: different task",
+            "Next: gui\nTask: visual task",
+        ],
+    )
+    auditor = _QueueAgent("auditor", [_audit("incomplete")] * 3)
+    cli_cheap = _QueueAgent("cli-cheap", ["done"], calls)
+    cli_strong = _QueueAgent("cli-strong", ["done"], calls)
+    gui_cheap = _QueueAgent("gui-cheap", ["done"], calls)
+    gui_strong = _QueueAgent("gui-strong", [], calls)
+
+    asyncio.run(
+        manager_runtime._run_impl(
+            task="mixed routes",
+            env=object(),
+            config=_routing_config(tmp_path, rounds=3),
+            manager_agent=manager,
+            gui_executor_agents={"cheap": gui_cheap, "strong": gui_strong},
+            cli_executor_agents={"cheap": cli_cheap, "strong": cli_strong},
+            gui_auditor_agent=auditor,
+            cli_auditor_agent=auditor,
+        )
+    )
+
+    assert calls == ["cli-strong", "cli-cheap", "gui-cheap"]
+    assert records[0].executor_routing["selection_reason"] == "manager_escalation"
+    assert records[1].executor_routing["failures_before"] == 0
+    assert records[2].executor_routing["failures_before"] == 0
+
+
+def test_kernel_rejects_unknown_tier_without_executor_call(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    events, records = _patch_kernel_boundaries(monkeypatch)
+    calls: list[str] = []
+    manager = _QueueAgent(
+        "manager", ["Next: cli\nExecutor tier: unknown\nTask: rejected task"]
+    )
+    executor = _QueueAgent("executor", [], calls)
+    auditor = _QueueAgent("auditor", [])
+
+    report = asyncio.run(
+        manager_runtime._run_impl(
+            task="reject unknown",
+            env=object(),
+            config=_routing_config(tmp_path, rounds=1),
+            manager_agent=manager,
+            gui_executor_agents={"cheap": executor, "strong": executor},
+            cli_executor_agents={"cheap": executor, "strong": executor},
+            gui_auditor_agent=auditor,
+            cli_auditor_agent=auditor,
+        )
+    )
+
+    assert calls == []
+    assert records[0].next_step == "invalid"
+    assert records[0].executor_routing["selection_reason"] == "invalid"
+    assert "Allowed executor tiers: cheap, strong" in records[0].harness_feedback
+    assert report["rounds"][0]["executor_routing"]["requested_tier"] == "unknown"
+    assert any(event == "executor_routing_rejected" for event, _ in events)
+
+
+def test_kernel_auditor_timeout_does_not_increment_or_clear_failures(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _events, records = _patch_kernel_boundaries(monkeypatch)
+    manager = _QueueAgent("manager", ["Next: cli\nTask: same"] * 3)
+    executor = _QueueAgent("executor", ["done"] * 3)
+    auditor = _QueueAgent(
+        "auditor",
+        [
+            _audit("incomplete"),
+            EpisodeResult(status="timeout", error="audit timeout"),
+            _audit("incomplete"),
+        ],
+    )
+
+    asyncio.run(
+        manager_runtime._run_impl(
+            task="timeout accounting",
+            env=object(),
+            config=_routing_config(tmp_path, rounds=3),
+            manager_agent=manager,
+            gui_executor_agents={"cheap": executor, "strong": executor},
+            cli_executor_agents={"cheap": executor, "strong": executor},
+            gui_auditor_agent=auditor,
+            cli_auditor_agent=auditor,
+        )
+    )
+
+    assert records[0].executor_routing["failures_after"] == 1
+    assert records[1].executor_routing["audit_signal"] == "not_counted"
+    assert records[1].executor_routing["failures_after"] == 1
+    assert records[2].executor_routing["failures_before"] == 1
+    assert records[2].executor_routing["failures_after"] == 2
+
+
+def test_kernel_rejected_format_repair_does_not_count(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _events, records = _patch_kernel_boundaries(monkeypatch)
+    manager = _QueueAgent("manager", ["Next: cli\nTask: same"])
+    executor = _QueueAgent("executor", ["done"])
+    auditor = _QueueAgent("auditor", ["missing required control header"])
+    repair = _QueueAgent("repair", ["still invalid"])
+
+    asyncio.run(
+        manager_runtime._run_impl(
+            task="repair accounting",
+            env=object(),
+            config=_routing_config(tmp_path, rounds=1),
+            manager_agent=manager,
+            gui_executor_agents={"cheap": executor, "strong": executor},
+            cli_executor_agents={"cheap": executor, "strong": executor},
+            gui_auditor_agent=auditor,
+            cli_auditor_agent=auditor,
+            auditor_format_repair_agent=repair,
+        )
+    )
+
+    assert records[0].auditor_status["format_repair_accepted"] is False
+    assert records[0].executor_routing["audit_signal"] == "not_counted"
+    assert records[0].executor_routing["failures_after"] == 0
+
+
+def test_kernel_accepted_format_repair_counts_its_parsed_status(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _events, records = _patch_kernel_boundaries(monkeypatch)
+    manager = _QueueAgent("manager", ["Next: cli\nTask: same"])
+    executor = _QueueAgent("executor", ["done"])
+    auditor = _QueueAgent("auditor", ["missing required control header"])
+    repair = _QueueAgent("repair", [_audit("incomplete")])
+
+    asyncio.run(
+        manager_runtime._run_impl(
+            task="repair accounting",
+            env=object(),
+            config=_routing_config(tmp_path, rounds=1),
+            manager_agent=manager,
+            gui_executor_agents={"cheap": executor, "strong": executor},
+            cli_executor_agents={"cheap": executor, "strong": executor},
+            gui_auditor_agent=auditor,
+            cli_auditor_agent=auditor,
+            auditor_format_repair_agent=repair,
+        )
+    )
+
+    assert records[0].auditor_status["format_repair_accepted"] is True
+    assert records[0].executor_routing["audit_signal"] == "incomplete"
+    assert records[0].executor_routing["failures_after"] == 1
+
+
+@pytest.mark.parametrize(
+    "case",
+    ("executor_cancel", "executor_error", "auditor_cancel", "auditor_error", "repair_cancel"),
+)
+def test_kernel_early_failures_persist_not_counted_routing_metadata(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, case: str
+) -> None:
+    _events, records = _patch_kernel_boundaries(monkeypatch)
+    manager = _QueueAgent("manager", ["Next: cli\nTask: same"])
+    executor_result: str | EpisodeResult = "done"
+    auditor_result: str | EpisodeResult = _audit("incomplete")
+    repair: _QueueAgent | None = None
+    if case == "executor_cancel":
+        executor_result = EpisodeResult(status="cancelled", error="cancelled")
+    elif case == "executor_error":
+        executor_result = EpisodeResult(status="error", error="executor failed")
+    elif case == "auditor_cancel":
+        auditor_result = EpisodeResult(status="cancelled", error="cancelled")
+    elif case == "auditor_error":
+        auditor_result = EpisodeResult(status="error", error="auditor failed")
+    else:
+        auditor_result = "missing required control header"
+        repair = _QueueAgent(
+            "repair", [EpisodeResult(status="cancelled", error="cancelled")]
+        )
+    executor = _QueueAgent("executor", [executor_result])
+    auditor = _QueueAgent("auditor", [auditor_result])
+
+    asyncio.run(
+        manager_runtime._run_impl(
+            task="early exit metadata",
+            env=object(),
+            config=_routing_config(tmp_path, rounds=1),
+            manager_agent=manager,
+            gui_executor_agents={"cheap": executor, "strong": executor},
+            cli_executor_agents={"cheap": executor, "strong": executor},
+            gui_auditor_agent=auditor,
+            cli_auditor_agent=auditor,
+            auditor_format_repair_agent=repair,
+        )
+    )
+
+    assert len(records) == 1
+    assert records[0].executor_routing["audit_signal"] == "not_counted"
+    assert records[0].executor_routing["failures_after"] == 0
+
+
+def test_kernel_routing_disabled_uses_legacy_singular_binding(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _events, records = _patch_kernel_boundaries(monkeypatch)
+    calls: list[str] = []
+    manager = _QueueAgent("manager", ["Next: cli\nTask: legacy task"])
+    executor = _QueueAgent("legacy", ["done"], calls)
+    auditor = _QueueAgent("auditor", [_audit("incomplete")])
+    config = HarnessConfig(
+        max_total_episodes=1,
+        workspace_path=str(tmp_path / "workspace"),
+        harness_dir=str(tmp_path / "harness"),
+        log_dir=str(tmp_path / "logs"),
+    )
+
+    asyncio.run(
+        manager_runtime._run_impl(
+            task="legacy",
+            env=object(),
+            config=config,
+            manager_agent=manager,
+            gui_executor_agent=executor,
+            cli_executor_agent=executor,
+            gui_auditor_agent=auditor,
+            cli_auditor_agent=auditor,
+        )
+    )
+
+    assert calls == ["legacy"]
+    assert records[0].executor_routing["enabled"] is False
+
+
+def test_kernel_tier_map_mismatch_fails_before_any_episode(tmp_path: Path) -> None:
+    calls: list[str] = []
+    agent = _QueueAgent("agent", [], calls)
+    with pytest.raises(ValueError, match="identical keys"):
+        asyncio.run(
+            manager_runtime._run_impl(
+                task="fail before start",
+                env=object(),
+                config=_routing_config(tmp_path, rounds=1),
+                manager_agent=agent,
+                gui_executor_agents={"cheap": agent, "strong": agent},
+                cli_executor_agents={"cheap": agent},
+                gui_auditor_agent=agent,
+                cli_auditor_agent=agent,
+            )
+        )
+    assert calls == []
+
+
+@pytest.mark.parametrize(
+    "case",
+    (
+        "policy_without_maps",
+        "maps_without_policy",
+        "missing_policy_tier",
+        "empty_key",
+        "padded_key",
+    ),
+)
+def test_kernel_invalid_routing_setup_fails_before_any_episode(
+    tmp_path: Path, case: str
+) -> None:
+    calls: list[str] = []
+    agent = _QueueAgent("agent", [], calls)
+    config = (
+        _routing_config(tmp_path, rounds=1)
+        if case != "maps_without_policy"
+        else HarnessConfig(log_dir=str(tmp_path / "logs"))
+    )
+    kwargs: dict[str, object] = {}
+    if case == "maps_without_policy":
+        kwargs = {
+            "gui_executor_agents": {"cheap": agent, "strong": agent},
+            "cli_executor_agents": {"cheap": agent, "strong": agent},
+        }
+    elif case == "missing_policy_tier":
+        kwargs = {
+            "gui_executor_agents": {"cheap": agent},
+            "cli_executor_agents": {"cheap": agent},
+        }
+    elif case == "empty_key":
+        kwargs = {
+            "gui_executor_agents": {"": agent, "cheap": agent, "strong": agent},
+            "cli_executor_agents": {"": agent, "cheap": agent, "strong": agent},
+        }
+    elif case == "padded_key":
+        kwargs = {
+            "gui_executor_agents": {
+                "cheap": agent,
+                "strong": agent,
+                " premium ": agent,
+            },
+            "cli_executor_agents": {
+                "cheap": agent,
+                "strong": agent,
+                " premium ": agent,
+            },
+        }
+
+    with pytest.raises(ValueError):
+        asyncio.run(
+            manager_runtime._run_impl(
+                task="fail before start",
+                env=object(),
+                config=config,
+                manager_agent=agent,
+                gui_auditor_agent=agent,
+                cli_auditor_agent=agent,
+                **kwargs,
+            )
+        )
+    assert calls == []
+
+
+def test_kernel_manager_runtime_failure_precedes_routing_decision_safely(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _events, records = _patch_kernel_boundaries(monkeypatch)
+    calls: list[str] = []
+    manager = _QueueAgent(
+        "manager", [EpisodeResult(status="error", error="manager failed")]
+    )
+    executor = _QueueAgent("executor", [], calls)
+    auditor = _QueueAgent("auditor", [])
+
+    asyncio.run(
+        manager_runtime._run_impl(
+            task="manager failure",
+            env=object(),
+            config=_routing_config(tmp_path, rounds=1),
+            manager_agent=manager,
+            gui_executor_agents={"cheap": executor, "strong": executor},
+            cli_executor_agents={"cheap": executor, "strong": executor},
+            gui_auditor_agent=auditor,
+            cli_auditor_agent=auditor,
+        )
+    )
+
+    assert calls == []
+    assert len(records) == 1
+    assert records[0].manager_status["status"] == "error"
+    assert records[0].executor_routing == {}
+
+
+def test_cli_main_carries_project_executor_routing_defaults(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    policy = ExecutorRoutingConfig("cheap", 2, "strong")
+    tiers = {
+        "cheap": {"model": "cheap-model"},
+        "strong": {"agent": "claude_code"},
+    }
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(
+        cli,
+        "load_run_defaults",
+        lambda: {
+            "executor_tiers": tiers,
+            "executor_routing": policy,
+            "dashboard": False,
+        },
+    )
+    monkeypatch.setattr(cli, "_run_command", lambda args: captured.update(vars(args)) or 19)
+
+    assert cli.main(["run", "--task", "inspect routing defaults"]) == 19
+    assert captured["executor_tiers"] is tiers
+    assert captured["executor_routing"] is policy
+
+
+@pytest.mark.parametrize(
+    ("route_role", "tier_spec", "overrides", "expected"),
+    (
+        (
+            "gui_executor",
+            {"agent": "claude_code"},
+            {"gui_executor_agent": "codex", "gui_executor_model": "codex-model"},
+            ("claude_code", None),
+        ),
+        (
+            "gui_executor",
+            {"agent": "codex"},
+            {"gui_executor_agent": "codex", "gui_executor_model": "codex-model"},
+            ("codex", "codex-model"),
+        ),
+        (
+            "gui_executor",
+            {"model": "tier-model"},
+            {"gui_executor_agent": "opencode"},
+            ("opencode", "tier-model"),
+        ),
+        (
+            "cli_executor",
+            {},
+            {"executor_agent": "claude_code", "executor_model": "executor-model"},
+            ("claude_code", "executor-model"),
+        ),
+        (
+            "gui_executor",
+            {},
+            {"gui_executor_agent": "opencode", "gui_executor_model": "gui-model"},
+            ("opencode", "gui-model"),
+        ),
+        (
+            "cli_executor",
+            {},
+            {"cli_executor_agent": "deepseek_harness", "cli_executor_model": "cli-model"},
+            ("deepseek_harness", "cli-model"),
+        ),
+    ),
+)
+def test_cli_executor_tier_binding_fallbacks(
+    route_role: str,
+    tier_spec: dict[str, str],
+    overrides: dict[str, object],
+    expected: tuple[str, str | None],
+) -> None:
+    args = _cli_binding_args(**overrides)
+    assert cli._resolve_executor_tier_binding(args, route_role, tier_spec) == expected
+
+
+def test_cli_executor_tier_backend_boundary_does_not_inherit_global_model() -> None:
+    args = _cli_binding_args(executor_agent="claude_code")
+    assert cli._resolve_role_model(args, "gui_executor") is None
+    assert cli._resolve_executor_tier_binding(
+        args, "gui_executor", {"agent": "opencode"}
+    ) == ("opencode", None)
+
+
+def test_cli_enabled_builds_permission_separated_tier_maps_without_singulars() -> None:
+    policy = ExecutorRoutingConfig("cheap", 2, "strong")
+    args = _cli_binding_args(
+        executor_routing=policy,
+        executor_tiers={
+            "cheap": {"model": "cheap-model"},
+            "strong": {"agent": "claude_code"},
+        },
+        gui_executor_agent="codex",
+        cli_executor_agent="opencode",
+    )
+    calls: list[tuple[str, str, str | None]] = []
+
+    def build(permission: str, backend: str, model: str | None) -> object:
+        binding = (permission, backend, model)
+        calls.append(binding)
+        return binding
+
+    built = cli._build_executor_agent_kwargs(args, build)
+
+    assert set(built) == {"gui_executor_agents", "cli_executor_agents"}
+    assert built["gui_executor_agents"] == {
+        "cheap": ("gui_executor", "codex", "cheap-model"),
+        "strong": ("gui_executor", "claude_code", None),
+    }
+    assert built["cli_executor_agents"] == {
+        "cheap": ("cli_executor", "opencode", "cheap-model"),
+        "strong": ("cli_executor", "claude_code", None),
+    }
+    assert len(calls) == 4
+
+
+@pytest.mark.parametrize("tiers", (None, {}))
+def test_cli_enabled_requires_tiers_before_building_agents(tiers: object) -> None:
+    args = _cli_binding_args(
+        executor_routing=ExecutorRoutingConfig("cheap", 2, "strong"),
+        executor_tiers=tiers,
+    )
+    calls: list[tuple[str, str, str | None]] = []
+
+    with pytest.raises(ValueError, match="requires configured executor tiers"):
+        cli._build_executor_agent_kwargs(
+            args,
+            lambda permission, backend, model: calls.append(
+                (permission, backend, model)
+            ),
+        )
+    assert calls == []
+
+
+@pytest.mark.parametrize("with_empty_config_attrs", (False, True))
+def test_cli_disabled_builds_legacy_singular_executors(
+    with_empty_config_attrs: bool,
+) -> None:
+    overrides: dict[str, object] = {
+        "gui_executor_agent": "codex",
+        "gui_executor_model": "gui-model",
+        "cli_executor_agent": "claude_code",
+        "cli_executor_model": "cli-model",
+    }
+    if with_empty_config_attrs:
+        overrides.update(executor_routing=None, executor_tiers=None)
+    args = _cli_binding_args(**overrides)
+    calls: list[tuple[str, str, str | None]] = []
+
+    def build(permission: str, backend: str, model: str | None) -> object:
+        binding = (permission, backend, model)
+        calls.append(binding)
+        return binding
+
+    built = cli._build_executor_agent_kwargs(args, build)
+
+    assert built == {
+        "gui_executor_agent": ("gui_executor", "codex", "gui-model"),
+        "cli_executor_agent": ("cli_executor", "claude_code", "cli-model"),
+    }
+    assert len(calls) == 2


### PR DESCRIPTION
## Summary

Adds cost-aware executor tier routing to LongHorizon Harness.

A Manager can choose the initial executor tier, while the harness tracks valid Auditor failures for the same subtask and automatically escalates the next execution after the configured threshold. The implementation remains backend-agnostic and preserves the existing single-executor configuration.

Closes #13.

## What changed

- Added named executor tiers under `[run.roles.executor.<tier>]` and routing policy under `[run.executor_routing]`.
- Added strict configuration and programmatic validation for tier names, defaults, escalation targets, and thresholds.
- Extended the English and Chinese Manager protocol with an optional `Executor tier:` field.
- Added a shared structural parser authority for route, tier, task identity, ASK fields, related references, state, and task contract, including adversarial nested-protocol protection.
- Added backend-agnostic GUI/CLI tier-to-adapter binding with permission isolation and field-level backend/model fallback.
- Added durable routing evidence to managed rounds, events, JSONL, and reports.
- Counted only accepted Auditor `incomplete`/`blocked` outcomes; provider failures, timeouts, cancellation, and rejected format repair are recorded as `not_counted`.
- Added sticky escalation plus reset behavior for completion, route changes, and new task identities.
- Updated English and Chinese documentation and initialization examples, including the current Resume limitation: a retry run is created and routing counters reset; this is not checkpoint continuation.

## Compatibility

- Existing `[run.roles.executor]` and single-executor runs continue to work unchanged.
- Routing is config-only; no new public CLI flags were added.
- GUI and CLI tiers build separate permission-scoped adapters.
- Unknown Manager tiers are recoverable invalid plans and never silently fall back to another agent.

## Validation

- Executor routing focused suite: 132 passed.
- Executor routing + role prompt suite: 145 passed.
- Legacy focused comparison: 14 passed, 3 unchanged Windows secure-filesystem failures, 6 skipped because `pytest-asyncio` is unavailable.
- Python compile check, CLI help, generated init template, diff, status, and process checks passed.
- Three-agent planning, implementation, and independent final review completed with no P0-P3 findings.

## Residual risk

- No paid-provider end-to-end run was performed.
- This Windows environment cannot exercise POSIX secure-filesystem behavior.
- The full Windows suite is not green because of the repository's existing POSIX/secure-filesystem, symlink-privilege, and missing async-plugin baseline failures; no new failure class was introduced.
- Before merge, Linux CI with full extras and a smoke run against two real backends is recommended.

## AI assistance

The implementation was generated with AI assistance under separate planner, executor, and reviewer roles. The repository owner authorized the scope and contribution; upstream maintainer review is requested.
