### PR TITLE
Add per-role effort with per-backend translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ Task text, run IDs, and API keys are deliberately **not** configurable here; the
 |---|---|---|
 | `agent` | `"codex"` | Backend for every role unless a role overrides it: `codex`, `claude_code`, `opencode`, or `deepseek_harness`. |
 | `model` | `"gpt-5.6-sol"` | Model for every role unless a role overrides it. Must be a model the chosen backend exposes. |
-| `effort` | `"med"` | Effort level for every role unless a role overrides it: `min`, `low`, `med`, `high`, `xhigh`, or `max`. See [Effort levels](#effort-levels). |
+| `effort` | `"medium"` | Effort level for every role unless a role overrides it, passed to the backend verbatim. See [Effort levels](#effort-levels). |
 | `env` | `"local"` | Execution environment. Only `local` today. |
 | `runs_root` | `"./.lh-harness/runs"` | Where run directories are created. Each run gets `<runs_root>/<run-id>/`. |
 | `workspace` | commented out | Working directory the agents operate in. Defaults to the directory `lh-harness` was started from, so a task acts on your real project; set it to isolate the run somewhere else. |
@@ -377,38 +377,30 @@ cli_auditor  → auditor  → [run].agent / [run].model / [run].effort
 
 ##### Effort levels
 
-`effort` controls how hard a role's model works — following Anthropic's umbrella term, where effort shapes the whole response, not only its thinking. One normalized scale covers every backend:
+`effort` controls how hard a role's model works. The value is passed to the backend **verbatim** — there is no cross-backend mapping — so each backend accepts exactly the levels it documents, and an unsupported value fails the run with a clear error instead of being silently substituted:
 
-```
-min · low · med · high · xhigh · max
-```
+| Backend | Dial | Accepted levels |
+|---|---|---|
+| Codex | `model_reasoning_effort` | `minimal`, `low`, `medium`, `high`, `xhigh` |
+| Claude Code | `CLAUDE_CODE_EFFORT_LEVEL` | `low`, `medium`, `high`, `xhigh`, `max` |
+| DeepSeek Harness | `reasoningEffort` | `low`, `high`, `max` |
+| OpenCode | `--variant` | the model's variant presets (OpenAI-style models ship `none`/`minimal`/`low`/`medium`/`high`/`xhigh`; custom variants come from `opencode.jsonc`) |
 
-Set it for all roles at once, per role, or per run:
+The web workbench offers each model's own discovered levels (from the model catalogue's `reasoning_efforts`). Set effort for all roles at once, per role, or per run:
 
 ```toml
 [run]
-effort = "med"
+effort = "medium"
 
 [run.roles.manager]
 effort = "high"       # a role's own effort outranks [run].effort
 ```
 
 ```bash
-lh-harness run --task "..." --effort med --auditor-effort low
+lh-harness run --task "..." --effort medium --auditor-effort low
 ```
 
-Each backend translates a level into its own dial, and a level a backend lacks maps to its nearest supported one:
-
-| You write | Codex (`model_reasoning_effort`) | Claude Code (`CLAUDE_CODE_EFFORT_LEVEL`) | OpenCode (`--variant`) | DeepSeek Harness (`reasoningEffort`) |
-|---|---|---|---|---|
-| `min` | `minimal` | `low` | `minimal` | `low` |
-| `low` | `low` | `low` | `low` | `low` |
-| `med` | `medium` | `medium` | `medium` | `high`* |
-| `high` | `high` | `high` | `high` | `high` |
-| `xhigh` | `xhigh` | `xhigh` | `xhigh` | `high`* |
-| `max` | `xhigh`* | `max` | `max` | `max` |
-
-\* The backend has no such level, so the nearest supported one is used; episode metadata records it as `effort_effective`.
+The requested level is recorded in every episode's metadata (`effort`) and shown in the run details view.
 
 Every field above also has a CLI flag (`--agent`, `--max-rounds`, `--gui-executor-model`, `--auditor-timeout`, `--effort`, `--manager-effort`, and so on) that overrides it for a single run. Run `lh-harness run --help` for the full list.
 

--- a/README.md
+++ b/README.md
@@ -386,7 +386,7 @@ cli_auditor  → auditor  → [run].agent / [run].model / [run].effort
 | DeepSeek Harness | `reasoningEffort` | `low`, `high`, `max` |
 | OpenCode | `--variant` | the model's variant presets (OpenAI-style models ship `none`/`minimal`/`low`/`medium`/`high`/`xhigh`; custom variants come from `opencode.jsonc`) |
 
-The web workbench offers each model's own discovered levels (from the model catalogue's `reasoning_efforts`). Set effort for all roles at once, per role, or per run:
+The config file and CLI accept any well-formed name and leave the judgement to the backend the value is addressed to — the same boundary the web workbench uses — so OpenCode's user-defined variant names work everywhere, and a typo on the other backends still fails fast at agent setup with the list of valid levels. The web workbench offers each model's own discovered levels (from the model catalogue's `reasoning_efforts`). Set effort for all roles at once, per role, or per run:
 
 ```toml
 [run]

--- a/README.md
+++ b/README.md
@@ -327,6 +327,7 @@ Task text, run IDs, and API keys are deliberately **not** configurable here; the
 |---|---|---|
 | `agent` | `"codex"` | Backend for every role unless a role overrides it: `codex`, `claude_code`, `opencode`, or `deepseek_harness`. |
 | `model` | `"gpt-5.6-sol"` | Model for every role unless a role overrides it. Must be a model the chosen backend exposes. |
+| `effort` | `"med"` | Effort level for every role unless a role overrides it: `min`, `low`, `med`, `high`, `xhigh`, or `max`. See [Effort levels](#effort-levels). |
 | `env` | `"local"` | Execution environment. Only `local` today. |
 | `runs_root` | `"./.lh-harness/runs"` | Where run directories are created. Each run gets `<runs_root>/<run-id>/`. |
 | `workspace` | commented out | Working directory the agents operate in. Defaults to the directory `lh-harness` was started from, so a task acts on your real project; set it to isolate the run somewhere else. |
@@ -354,13 +355,13 @@ Per-episode limits in seconds. One episode is a single role invocation, not the 
 
 ##### `[run.roles.*]`
 
-Each role can take its own `agent` and `model`, so you can pay for a strong model only where it matters: a capable Manager and Auditor with a cheaper Executor, for example. Every field is commented out by default, meaning "inherit".
+Each role can take its own `agent`, `model`, and `effort`, so you can pay for a strong model only where it matters: a capable Manager and Auditor with a cheaper Executor, for example. Every field is commented out by default, meaning "inherit".
 
 Resolution walks the chain until it finds a value:
 
 ```
-gui_executor → executor → [run].agent / [run].model
-cli_auditor  → auditor  → [run].agent / [run].model
+gui_executor → executor → [run].agent / [run].model / [run].effort
+cli_auditor  → auditor  → [run].agent / [run].model / [run].effort
 ```
 
 | Section | Falls back to | Covers |
@@ -374,7 +375,42 @@ cli_auditor  → auditor  → [run].agent / [run].model
 | `[run.roles.cli_auditor]` | `auditor` | CLI audit |
 | `[run.roles.final_response]` | `manager` | The closing reply written for you |
 
-Every field above also has a CLI flag (`--agent`, `--max-rounds`, `--gui-executor-model`, `--auditor-timeout`, and so on) that overrides it for a single run. Run `lh-harness run --help` for the full list.
+##### Effort levels
+
+`effort` controls how hard a role's model works — following Anthropic's umbrella term, where effort shapes the whole response, not only its thinking. One normalized scale covers every backend:
+
+```
+min · low · med · high · xhigh · max
+```
+
+Set it for all roles at once, per role, or per run:
+
+```toml
+[run]
+effort = "med"
+
+[run.roles.manager]
+effort = "high"       # a role's own effort outranks [run].effort
+```
+
+```bash
+lh-harness run --task "..." --effort med --auditor-effort low
+```
+
+Each backend translates a level into its own dial, and a level a backend lacks maps to its nearest supported one:
+
+| You write | Codex (`model_reasoning_effort`) | Claude Code (`CLAUDE_CODE_EFFORT_LEVEL`) | OpenCode (`--variant`) | DeepSeek Harness (`reasoningEffort`) |
+|---|---|---|---|---|
+| `min` | `minimal` | `low` | `minimal` | `low` |
+| `low` | `low` | `low` | `low` | `low` |
+| `med` | `medium` | `medium` | `medium` | `high`* |
+| `high` | `high` | `high` | `high` | `high` |
+| `xhigh` | `xhigh` | `xhigh` | `xhigh` | `high`* |
+| `max` | `xhigh`* | `max` | `max` | `max` |
+
+\* The backend has no such level, so the nearest supported one is used; episode metadata records it as `effort_effective`.
+
+Every field above also has a CLI flag (`--agent`, `--max-rounds`, `--gui-executor-model`, `--auditor-timeout`, `--effort`, `--manager-effort`, and so on) that overrides it for a single run. Run `lh-harness run --help` for the full list.
 
 If a Manager, Executor, or Auditor reaches its local episode timeout, the run keeps the partial trajectory and recorded task state, then lets the next Manager round inspect the real workspace and recover. The timeout remains an agent execution timeout; it is not treated as proof of a provider network failure. Repeated timed-out rounds still trigger the Dashboard's human-review gate.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -387,7 +387,7 @@ cli_auditor  → auditor  → [run].agent / [run].model / [run].effort
 | DeepSeek Harness | `reasoningEffort` | `low`、`high`、`max` |
 | OpenCode | `--variant` | 模型自身的 variant 预设（OpenAI 系模型自带 `none`/`minimal`/`low`/`medium`/`high`/`xhigh`；自定义预设来自 `opencode.jsonc`） |
 
-Web 工作台会展示每个模型自己被检测到的等级（来自模型目录的 `reasoning_efforts`）。可以全局设置、按角色设置，或对单次运行设置：
+配置文件和 CLI 接受任何格式合法的名称，把判断交给该值实际送达的后端——与 Web 工作台使用的是同一道校验边界——因此 OpenCode 用户自定义的 variant 名称在任何入口都可用，而其他后端上的拼写错误仍会在 agent 启动阶段快速报错并列出有效等级。Web 工作台会展示每个模型自己被检测到的等级（来自模型目录的 `reasoning_efforts`）。可以全局设置、按角色设置，或对单次运行设置：
 
 ```toml
 [run]

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -328,7 +328,7 @@ lh-harness check-update
 |---|---|---|
 | `agent` | `"codex"` | 所有角色使用的后端（角色可单独覆盖）：`codex`、`claude_code`、`opencode` 或 `deepseek_harness`。 |
 | `model` | `"gpt-5.6-sol"` | 所有角色使用的模型（角色可单独覆盖）。必须是所选后端支持的模型。 |
-| `effort` | `"med"` | 所有角色的 effort 等级（角色可单独覆盖）：`min`、`low`、`med`、`high`、`xhigh` 或 `max`。见 [Effort 等级](#effort-等级)。 |
+| `effort` | `"medium"` | 所有角色的 effort 等级（角色可单独覆盖），原样传给后端。见 [Effort 等级](#effort-等级)。 |
 | `env` | `"local"` | 执行环境，目前只有 `local`。 |
 | `runs_root` | `"./.lh-harness/runs"` | 运行目录的根路径，每次运行生成 `<runs_root>/<run-id>/`。 |
 | `workspace` | 默认注释 | Agent 实际操作的工作目录。默认就是启动 `lh-harness` 的那个目录，任务直接作用于你的真实项目；需要隔离到别处时才设置。 |
@@ -378,38 +378,30 @@ cli_auditor  → auditor  → [run].agent / [run].model / [run].effort
 
 ##### Effort 等级
 
-`effort` 控制角色模型的思考与执行投入——沿用 Anthropic 的总控概念：effort 影响整个响应，而不仅是 thinking。所有后端共用一套归一化等级：
+`effort` 控制角色模型的思考与执行投入。取值**原样传给后端**——不做跨后端映射——每个后端只接受自己文档中列出的等级，不支持的值会直接报错，而不是被悄悄替换：
 
-```
-min · low · med · high · xhigh · max
-```
+| 后端 | 原生参数 | 可用等级 |
+|---|---|---|
+| Codex | `model_reasoning_effort` | `minimal`、`low`、`medium`、`high`、`xhigh` |
+| Claude Code | `CLAUDE_CODE_EFFORT_LEVEL` | `low`、`medium`、`high`、`xhigh`、`max` |
+| DeepSeek Harness | `reasoningEffort` | `low`、`high`、`max` |
+| OpenCode | `--variant` | 模型自身的 variant 预设（OpenAI 系模型自带 `none`/`minimal`/`low`/`medium`/`high`/`xhigh`；自定义预设来自 `opencode.jsonc`） |
 
-可以全局设置、按角色设置，或对单次运行设置：
+Web 工作台会展示每个模型自己被检测到的等级（来自模型目录的 `reasoning_efforts`）。可以全局设置、按角色设置，或对单次运行设置：
 
 ```toml
 [run]
-effort = "med"
+effort = "medium"
 
 [run.roles.manager]
 effort = "high"       # 角色自己的 effort 优先于 [run].effort
 ```
 
 ```bash
-lh-harness run --task "..." --effort med --auditor-effort low
+lh-harness run --task "..." --effort medium --auditor-effort low
 ```
 
-每个后端会把等级翻译成自己的原生参数；后端缺少的等级会映射到最接近的支持等级：
-
-| 你写的 | Codex（`model_reasoning_effort`） | Claude Code（`CLAUDE_CODE_EFFORT_LEVEL`） | OpenCode（`--variant`） | DeepSeek Harness（`reasoningEffort`） |
-|---|---|---|---|---|
-| `min` | `minimal` | `low` | `minimal` | `low` |
-| `low` | `low` | `low` | `low` | `low` |
-| `med` | `medium` | `medium` | `medium` | `high`* |
-| `high` | `high` | `high` | `high` | `high` |
-| `xhigh` | `xhigh` | `xhigh` | `xhigh` | `high`* |
-| `max` | `xhigh`* | `max` | `max` | `max` |
-
-\* 后端没有该等级，使用最接近的支持等级；episode metadata 中记录为 `effort_effective`。
+请求的等级会记录在每个 episode 的 metadata（`effort`）中，并显示在任务详情页。
 
 上述每个字段都有对应的 CLI 参数（`--agent`、`--max-rounds`、`--gui-executor-model`、`--auditor-timeout`、`--effort`、`--manager-effort` 等）可以对单次运行覆盖。完整列表见 `lh-harness run --help`。
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -328,6 +328,7 @@ lh-harness check-update
 |---|---|---|
 | `agent` | `"codex"` | 所有角色使用的后端（角色可单独覆盖）：`codex`、`claude_code`、`opencode` 或 `deepseek_harness`。 |
 | `model` | `"gpt-5.6-sol"` | 所有角色使用的模型（角色可单独覆盖）。必须是所选后端支持的模型。 |
+| `effort` | `"med"` | 所有角色的 effort 等级（角色可单独覆盖）：`min`、`low`、`med`、`high`、`xhigh` 或 `max`。见 [Effort 等级](#effort-等级)。 |
 | `env` | `"local"` | 执行环境，目前只有 `local`。 |
 | `runs_root` | `"./.lh-harness/runs"` | 运行目录的根路径，每次运行生成 `<runs_root>/<run-id>/`。 |
 | `workspace` | 默认注释 | Agent 实际操作的工作目录。默认就是启动 `lh-harness` 的那个目录，任务直接作用于你的真实项目；需要隔离到别处时才设置。 |
@@ -355,13 +356,13 @@ lh-harness check-update
 
 ##### `[run.roles.*]`
 
-每个角色都可以单独指定 `agent` 与 `model`，因此可以只在关键位置使用强模型：例如 Manager 与 Auditor 用强模型、Executor 用更便宜的。所有字段默认都是注释状态，表示「继承」。
+每个角色都可以单独指定 `agent`、`model` 与 `effort`，因此可以只在关键位置使用强模型：例如 Manager 与 Auditor 用强模型、Executor 用更便宜的。所有字段默认都是注释状态，表示「继承」。
 
 取值时沿以下链路回退，直到找到值为止：
 
 ```
-gui_executor → executor → [run].agent / [run].model
-cli_auditor  → auditor  → [run].agent / [run].model
+gui_executor → executor → [run].agent / [run].model / [run].effort
+cli_auditor  → auditor  → [run].agent / [run].model / [run].effort
 ```
 
 | 配置段 | 回退到 | 作用范围 |
@@ -375,7 +376,42 @@ cli_auditor  → auditor  → [run].agent / [run].model
 | `[run.roles.cli_auditor]` | `auditor` | CLI 验收 |
 | `[run.roles.final_response]` | `manager` | 写给你的最终回复 |
 
-上述每个字段都有对应的 CLI 参数（`--agent`、`--max-rounds`、`--gui-executor-model`、`--auditor-timeout` 等）可以对单次运行覆盖。完整列表见 `lh-harness run --help`。
+##### Effort 等级
+
+`effort` 控制角色模型的思考与执行投入——沿用 Anthropic 的总控概念：effort 影响整个响应，而不仅是 thinking。所有后端共用一套归一化等级：
+
+```
+min · low · med · high · xhigh · max
+```
+
+可以全局设置、按角色设置，或对单次运行设置：
+
+```toml
+[run]
+effort = "med"
+
+[run.roles.manager]
+effort = "high"       # 角色自己的 effort 优先于 [run].effort
+```
+
+```bash
+lh-harness run --task "..." --effort med --auditor-effort low
+```
+
+每个后端会把等级翻译成自己的原生参数；后端缺少的等级会映射到最接近的支持等级：
+
+| 你写的 | Codex（`model_reasoning_effort`） | Claude Code（`CLAUDE_CODE_EFFORT_LEVEL`） | OpenCode（`--variant`） | DeepSeek Harness（`reasoningEffort`） |
+|---|---|---|---|---|
+| `min` | `minimal` | `low` | `minimal` | `low` |
+| `low` | `low` | `low` | `low` | `low` |
+| `med` | `medium` | `medium` | `medium` | `high`* |
+| `high` | `high` | `high` | `high` | `high` |
+| `xhigh` | `xhigh` | `xhigh` | `xhigh` | `high`* |
+| `max` | `xhigh`* | `max` | `max` | `max` |
+
+\* 后端没有该等级，使用最接近的支持等级；episode metadata 中记录为 `effort_effective`。
+
+上述每个字段都有对应的 CLI 参数（`--agent`、`--max-rounds`、`--gui-executor-model`、`--auditor-timeout`、`--effort`、`--manager-effort` 等）可以对单次运行覆盖。完整列表见 `lh-harness run --help`。
 
 当 Manager、Executor 或 Auditor 达到本地 episode 超时时限时，Harness 会保留已有轨迹和任务状态，并让下一轮 Manager 检查真实 workspace 后继续恢复。本地 episode 超时会显示为“Agent 执行超时”，不会再被误判为 provider 网络故障；连续超时仍会触发 Dashboard 的人工复核门禁。
 

--- a/frontend/core/src/types.ts
+++ b/frontend/core/src/types.ts
@@ -77,7 +77,7 @@ export interface RunSummary {
   log_dir: string;
   agent?: string;
   model?: string | null;
-  role_configs?: Record<'manager' | 'executor' | 'auditor', { agent: string; model: string }>;
+  role_configs?: Record<'manager' | 'executor' | 'auditor', { agent: string; model: string; effort?: string }>;
   workspace?: string;
   max_rounds?: number;
   prompt_language?: 'en' | 'zh';
@@ -101,7 +101,7 @@ export interface Snapshot {
     final_response?: string;
     agent?: string;
     model?: string | null;
-    role_configs?: Record<'manager' | 'executor' | 'auditor', { agent: string; model: string }>;
+    role_configs?: Record<'manager' | 'executor' | 'auditor', { agent: string; model: string; effort?: string }>;
     workspace?: string;
     max_rounds?: number;
     prompt_language?: 'en' | 'zh';

--- a/frontend/web/src/App.tsx
+++ b/frontend/web/src/App.tsx
@@ -225,6 +225,7 @@ const MODEL_PRESETS: Record<string, { id: string; label: string }[]> = {
 
 type PublicRole = 'manager' | 'executor' | 'auditor';
 type RoleSelection = RoleRuntimeConfig & { custom: boolean };
+const EFFORT_LEVEL_FALLBACK = ['min', 'low', 'med', 'high', 'xhigh', 'max'];
 const PUBLIC_ROLES: Array<{ id: PublicRole; label: string; description: string }> = [
   { id: 'manager', label: 'Manager', description: '规划、路由与完成判定' },
   { id: 'executor', label: 'Executor', description: '执行 GUI / CLI 子任务' },
@@ -1731,8 +1732,9 @@ function RoleRuntimePicker({ role, selection, meta, onChange }: { role: typeof P
   return <section className="role-runtime-card">
     <div className="role-runtime-title"><span className="role-runtime-mark">{role.label[0]}</span><div><strong>{role.label}</strong><small>{roleDescription}</small></div></div>
     <div className="role-runtime-grid">
-      <label className="drawer-field"><span>Harness</span><select value={selection.agent} onChange={(event) => onChange({ agent: event.target.value, model: '', custom: false })}>{agentChoices.map((choice) => <option value={choice.id} key={choice.id} disabled={choice.available === false}>{choice.label}{choice.available === false ? text(' · 未安装', ' · Not installed') : ''}</option>)}</select></label>
+      <label className="drawer-field"><span>Harness</span><select value={selection.agent} onChange={(event) => onChange({ agent: event.target.value, model: '', effort: selection.effort, custom: false })}>{agentChoices.map((choice) => <option value={choice.id} key={choice.id} disabled={choice.available === false}>{choice.label}{choice.available === false ? text(' · 未安装', ' · Not installed') : ''}</option>)}</select></label>
       <label className="drawer-field"><span>Model</span><select value={selectValue} onChange={(event) => { const value = event.target.value; onChange(value === '__custom__' ? { ...selection, model: '', custom: true } : { ...selection, model: value, custom: false }); }}><option value="">{text(`Provider 默认（${providerDefault}）`, `Provider default (${providerDefault})`)}</option>{choices.map((choice) => <option value={choice.id} key={choice.id}>{choice.label}</option>)}<option value="__custom__">{text('自定义模型…', 'Custom model…')}</option></select></label>
+      <label className="drawer-field"><span>{text('思考强度', 'Effort')}</span><select value={selection.effort || ''} onChange={(event) => onChange({ ...selection, effort: event.target.value || undefined })}><option value="">{text('默认', 'Default')}</option>{(meta?.defaults?.effort_levels?.length ? meta.defaults.effort_levels : EFFORT_LEVEL_FALLBACK).map((level) => <option value={level} key={level}>{level}</option>)}</select></label>
     </div>
     {selection.custom && <input className="role-runtime-custom" autoFocus value={selection.model || ''} onChange={(event) => onChange({ ...selection, model: event.target.value })} placeholder={text('输入 provider 暴露的模型名', 'Enter a model name exposed by the provider')} />}
     <small className={`drawer-field-note ${discovery?.account_scoped ? 'model-detected' : ''}`}>{selection.custom ? text('自定义模型不在检测目录时仍允许尝试；若不存在、无权限或凭据错误，任务会立即失败并显示 provider 原因。', 'You may try a custom model that was not detected. If it is unavailable, unauthorized, or the credentials are invalid, the task will fail immediately with the provider reason.') : [backendScopeNote, discoveryNote].filter(Boolean).join(' ')}</small>
@@ -1743,9 +1745,9 @@ function DetailsDrawer({ creating, runId, snapshot, meta, selectedRound, setSele
   const { language, text } = useUiLanguage();
   const [task, setTask] = useState('');
   const [roleSelections, setRoleSelections] = useState<Record<PublicRole, RoleSelection>>({
-    manager: { agent: 'codex', model: '', custom: false },
-    executor: { agent: 'codex', model: '', custom: false },
-    auditor: { agent: 'codex', model: '', custom: false },
+    manager: { agent: 'codex', model: '', effort: undefined, custom: false },
+    executor: { agent: 'codex', model: '', effort: undefined, custom: false },
+    auditor: { agent: 'codex', model: '', effort: undefined, custom: false },
   });
   const rolesInitialised = useRef(false);
   const [modelRefreshBusy, setModelRefreshBusy] = useState(false);
@@ -1760,7 +1762,7 @@ function DetailsDrawer({ creating, runId, snapshot, meta, selectedRound, setSele
     setRoleSelections(Object.fromEntries(PUBLIC_ROLES.map(({ id }) => {
       const configured = meta.defaults?.roles?.[id];
       const roleAgent = configured?.agent || fallbackAgent;
-      return [id, { agent: roleAgent, model: configured?.model || '', custom: false }];
+      return [id, { agent: roleAgent, model: configured?.model || '', effort: configured?.effort || undefined, custom: false }];
     })) as Record<PublicRole, RoleSelection>);
     rolesInitialised.current = true;
   }, [meta]);
@@ -1778,6 +1780,7 @@ function DetailsDrawer({ creating, runId, snapshot, meta, selectedRound, setSele
   const resolvedRoles = Object.fromEntries(PUBLIC_ROLES.map(({ id }) => [id, {
     agent: roleSelections[id].agent,
     model: roleSelections[id].model?.trim() || defaultModel(meta, roleSelections[id].agent),
+    ...(roleSelections[id].effort ? { effort: roleSelections[id].effort } : {}),
   }])) as Record<PublicRole, RoleRuntimeConfig>;
   return <div className="drawer-backdrop" onClick={onClose}><aside className={`details-drawer ${creating ? 'create-drawer' : ''}`} role="dialog" aria-modal="true" aria-label={creating ? text('创建新任务', 'Create new task') : text('会话详情', 'Task details')} onClick={(event) => event.stopPropagation()}>
     <div className="drawer-header"><div><div className="drawer-eyebrow">{creating ? text('新任务', 'NEW TASK') : text('会话详情', 'TASK DETAILS')}</div><h2>{creating ? text('创建 LongHorizon 任务', 'Create a LongHorizon task') : text('详情', 'Details')}</h2></div><button className="drawer-close" onClick={onClose} aria-label={text('关闭', 'Close')}><X size={18} /></button></div>
@@ -1792,6 +1795,7 @@ function DetailsDrawer({ creating, runId, snapshot, meta, selectedRound, setSele
       <label className="drawer-field"><span>Workspace <small>{text('可选', 'optional')}</small></span><input value={workspace} onChange={(event) => setWorkspace(event.target.value)} placeholder={text('使用 Web 服务的工作区根目录', 'Use the Web server workspace root')} /></label>
       <div className="drawer-actions"><button onClick={onClose}>{text('取消', 'Cancel')}</button><button className="primary-action" disabled={!task.trim() || controlBusy || PUBLIC_ROLES.some(({ id }) => !roleSelections[id].agent || roleSelections[id].custom && !roleSelections[id].model?.trim())} onClick={() => void onCreate(task.trim(), resolvedRoles, workspace.trim(), maxRounds, promptLanguage)}>{controlBusy ? text('正在启动…', 'Starting…') : text('开始任务', 'Start task')}</button></div>
     </> : <>
+      {snapshot.run.role_configs && <div className="role-binding-strip" aria-label={text('角色运行配置', 'Role runtime configuration')}>{PUBLIC_ROLES.map(({ id, label }) => { const spec = snapshot.run.role_configs?.[id]; return spec ? <span className="role-binding-chip" key={id} title={`${label}: ${spec.agent} · ${spec.model}${spec.effort ? ` · effort ${spec.effort}` : ''}`}><strong>{label}</strong><span>{spec.model}</span>{spec.effort && <em>{spec.effort}</em>}</span> : null; })}</div>}
       <div className="details-tabs" role="tablist" aria-label={text('详情类别', 'Detail categories')}><button id="details-tab-artifacts" role="tab" aria-controls="details-panel-artifacts" aria-selected={tab === 'artifacts'} tabIndex={tab === 'artifacts' ? 0 : -1} className={tab === 'artifacts' ? 'active' : ''} onClick={() => setTab('artifacts')}>{text('运行记录', 'Run records')}</button><button id="details-tab-trajectory" role="tab" aria-controls="details-panel-trajectory" aria-selected={tab === 'trajectory'} tabIndex={tab === 'trajectory' ? 0 : -1} className={tab === 'trajectory' ? 'active' : ''} onClick={() => setTab('trajectory')}>{text('执行轨迹', 'Trajectory')}</button><button id="details-tab-events" role="tab" aria-controls="details-panel-events" aria-selected={tab === 'events'} tabIndex={tab === 'events' ? 0 : -1} className={tab === 'events' ? 'active' : ''} onClick={() => setTab('events')}>{text('事件', 'Events')}</button></div>
       <div className="drawer-rounds"><span>{text('轮次', 'Rounds')}</span>{hiddenRounds > 0 && <button className="drawer-round-more" onClick={() => setRoundLimit((limit) => Math.min(snapshot.rounds.length, limit + MAX_TRAJECTORY_ROUNDS))}>{text(`+${hiddenRounds} 更早`, `+${hiddenRounds} earlier`)}</button>}{roundChoices.map((round) => <button className={round.round_index === selectedRound ? 'active' : ''} key={round.round_index} onClick={() => setSelectedRound(round.round_index)}>R{round.round_index}</button>)}</div>
       {tab === 'artifacts' && <div id="details-panel-artifacts" className="drawer-content" role="tabpanel" aria-labelledby="details-tab-artifacts"><p className="drawer-artifact-note">{text(`这里是本轮三角色的运行记录。真实交付物保存在任务 Workspace${snapshot.run.workspace ? `：${snapshot.run.workspace}` : ''} 或目标应用中，Auditor 会在同一真实环境里独立检查。`, `These are the three roles' records for this round. Actual deliverables are saved in the task workspace${snapshot.run.workspace ? `: ${snapshot.run.workspace}` : ''} or the target application, where the Auditor independently checks them.`)}</p><div className="artifact-list-drawer">{artifactList?.artifacts.map((name) => <button className={name === artifactName ? 'active' : ''} title={name} key={name} onClick={() => void openArtifact(selectedRound || 0, name)}>{name}</button>)}{selectedRound === null && <span className="drawer-muted">{text('暂无轮次结果。', 'No round results yet.')}</span>}{selectedRound !== null && artifactError && <div className="drawer-error-state"><span className="drawer-error">{text('记录加载失败：', 'Failed to load records: ')}{compactText(artifactError, 240)}</span>{retryArtifacts && <button type="button" onClick={retryArtifacts}>{text('重试', 'Retry')}</button>}</div>}{selectedRound !== null && !artifactError && !artifactList && <span className="drawer-muted">{text('正在加载运行记录…', 'Loading run records…')}</span>}{artifactList && !artifactList.artifacts.length && <span className="drawer-muted">{text('本轮暂无运行记录。', 'No run records for this round.')}</span>}</div>{artifactName && isImageArtifact(artifactName) ? <div className="drawer-image-preview"><ImageGallery images={[artifactRawUrl(runId, selectedRound || 0, artifactName)]} label={artifactName} /></div> : <pre className="drawer-pre">{artifactText || text('请选择一条运行记录。', 'Select a run record.')}</pre>}</div>}

--- a/frontend/web/src/App.tsx
+++ b/frontend/web/src/App.tsx
@@ -216,7 +216,7 @@ interface ActivityStep {
   imageWarning?: string;
 }
 
-const MODEL_PRESETS: Record<string, { id: string; label: string }[]> = {
+const MODEL_PRESETS: Record<string, { id: string; label: string; reasoning_efforts?: string[] }[]> = {
   codex: [{ id: 'gpt-5.6-sol', label: 'GPT-5.6 Sol · default' }],
   claude_code: [{ id: 'claude-opus-5', label: 'Claude Opus 5 · default' }],
   deepseek_harness: [{ id: 'deepseek-v4-flash', label: 'DeepSeek V4 Flash · default' }],
@@ -225,7 +225,12 @@ const MODEL_PRESETS: Record<string, { id: string; label: string }[]> = {
 
 type PublicRole = 'manager' | 'executor' | 'auditor';
 type RoleSelection = RoleRuntimeConfig & { custom: boolean };
-const EFFORT_LEVEL_FALLBACK = ['min', 'low', 'med', 'high', 'xhigh', 'max'];
+const EFFORT_LEVEL_FALLBACK: Record<string, string[]> = {
+  codex: ['minimal', 'low', 'medium', 'high', 'xhigh'],
+  claude_code: ['low', 'medium', 'high', 'xhigh', 'max'],
+  deepseek_harness: ['low', 'high', 'max'],
+  opencode: ['none', 'minimal', 'low', 'medium', 'high', 'xhigh'],
+};
 const PUBLIC_ROLES: Array<{ id: PublicRole; label: string; description: string }> = [
   { id: 'manager', label: 'Manager', description: '规划、路由与完成判定' },
   { id: 'executor', label: 'Executor', description: '执行 GUI / CLI 子任务' },
@@ -238,14 +243,14 @@ const PUBLIC_ROLES: Array<{ id: PublicRole; label: string; description: string }
 const MAX_TRAJECTORY_ROUNDS = 8;
 const MAX_TRAJECTORY_STEPS = 600;
 
-function normalizedModelChoices(value: unknown): { id: string; label: string; availability?: string }[] {
+function normalizedModelChoices(value: unknown): { id: string; label: string; availability?: string; reasoning_efforts?: string[] }[] {
   if (!Array.isArray(value)) return [];
   return value.flatMap((item) => {
     if (typeof item === 'string' && item.trim()) return [{ id: item.trim(), label: item.trim() }];
     if (!item || typeof item !== 'object') return [];
     const record = item as Record<string, unknown>;
     const id = typeof record.id === 'string' ? record.id.trim() : '';
-    return id ? [{ id, label: typeof record.label === 'string' && record.label.trim() ? record.label.trim() : id, availability: typeof record.availability === 'string' ? record.availability : undefined }] : [];
+    return id ? [{ id, label: typeof record.label === 'string' && record.label.trim() ? record.label.trim() : id, availability: typeof record.availability === 'string' ? record.availability : undefined, reasoning_efforts: Array.isArray(record.reasoning_efforts) ? record.reasoning_efforts.filter((level): level is string => typeof level === 'string') : undefined }] : [];
   });
 }
 
@@ -1709,6 +1714,14 @@ function RoleRuntimePicker({ role, selection, meta, onChange }: { role: typeof P
   );
   const choices = discovered.length ? discovered : MODEL_PRESETS[selection.agent] || [];
   const providerDefault = defaultModel(meta, selection.agent) || 'provider default';
+  // The effort options are the model's own discovered levels when the
+  // catalogue has them, otherwise the backend's documented set - values pass
+  // to the backend verbatim, so only levels it accepts are offered.
+  const chosenModelId = selection.model || defaultModel(meta, selection.agent);
+  const modelEfforts = choices.find((choice) => choice.id === chosenModelId)?.reasoning_efforts;
+  const effortLevels: string[] = modelEfforts?.length
+    ? modelEfforts
+    : meta?.defaults?.effort_levels?.[selection.agent] || EFFORT_LEVEL_FALLBACK[selection.agent] || [];
   const selectValue = selection.custom
     ? '__custom__'
     : selection.model && choices.some((choice) => choice.id === selection.model)
@@ -1732,9 +1745,9 @@ function RoleRuntimePicker({ role, selection, meta, onChange }: { role: typeof P
   return <section className="role-runtime-card">
     <div className="role-runtime-title"><span className="role-runtime-mark">{role.label[0]}</span><div><strong>{role.label}</strong><small>{roleDescription}</small></div></div>
     <div className="role-runtime-grid">
-      <label className="drawer-field"><span>Harness</span><select value={selection.agent} onChange={(event) => onChange({ agent: event.target.value, model: '', effort: selection.effort, custom: false })}>{agentChoices.map((choice) => <option value={choice.id} key={choice.id} disabled={choice.available === false}>{choice.label}{choice.available === false ? text(' · 未安装', ' · Not installed') : ''}</option>)}</select></label>
+      <label className="drawer-field"><span>Harness</span><select value={selection.agent} onChange={(event) => onChange({ agent: event.target.value, model: '', effort: undefined, custom: false })}>{agentChoices.map((choice) => <option value={choice.id} key={choice.id} disabled={choice.available === false}>{choice.label}{choice.available === false ? text(' · 未安装', ' · Not installed') : ''}</option>)}</select></label>
       <label className="drawer-field"><span>Model</span><select value={selectValue} onChange={(event) => { const value = event.target.value; onChange(value === '__custom__' ? { ...selection, model: '', custom: true } : { ...selection, model: value, custom: false }); }}><option value="">{text(`Provider 默认（${providerDefault}）`, `Provider default (${providerDefault})`)}</option>{choices.map((choice) => <option value={choice.id} key={choice.id}>{choice.label}</option>)}<option value="__custom__">{text('自定义模型…', 'Custom model…')}</option></select></label>
-      <label className="drawer-field"><span>{text('思考强度', 'Effort')}</span><select value={selection.effort || ''} onChange={(event) => onChange({ ...selection, effort: event.target.value || undefined })}><option value="">{text('默认', 'Default')}</option>{(meta?.defaults?.effort_levels?.length ? meta.defaults.effort_levels : EFFORT_LEVEL_FALLBACK).map((level) => <option value={level} key={level}>{level}</option>)}</select></label>
+      <label className="drawer-field"><span>{text('思考强度', 'Effort')}</span><select value={selection.effort && effortLevels.includes(selection.effort) ? selection.effort : ''} onChange={(event) => onChange({ ...selection, effort: event.target.value || undefined })}><option value="">{text('默认', 'Default')}</option>{effortLevels.map((level) => <option value={level} key={level}>{level}</option>)}</select></label>
     </div>
     {selection.custom && <input className="role-runtime-custom" autoFocus value={selection.model || ''} onChange={(event) => onChange({ ...selection, model: event.target.value })} placeholder={text('输入 provider 暴露的模型名', 'Enter a model name exposed by the provider')} />}
     <small className={`drawer-field-note ${discovery?.account_scoped ? 'model-detected' : ''}`}>{selection.custom ? text('自定义模型不在检测目录时仍允许尝试；若不存在、无权限或凭据错误，任务会立即失败并显示 provider 原因。', 'You may try a custom model that was not detected. If it is unavailable, unauthorized, or the credentials are invalid, the task will fail immediately with the provider reason.') : [backendScopeNote, discoveryNote].filter(Boolean).join(' ')}</small>

--- a/frontend/web/src/api.ts
+++ b/frontend/web/src/api.ts
@@ -112,13 +112,13 @@ export interface WebMeta {
   /** Server-discovered agent/model catalogue. Older servers may omit these. */
   agents?: Array<{ id: string; label?: string; available?: boolean; default_model?: string; models?: ModelChoice[]; discovery?: ModelDiscovery }>;
   models?: Record<string, ModelChoice[]>;
-  defaults?: { agent?: string; model?: string; roles?: Record<string, RoleRuntimeConfig> };
+  defaults?: { agent?: string; model?: string; effort_levels?: string[]; roles?: Record<string, RoleRuntimeConfig> };
   model_discovery?: Record<string, ModelDiscovery>;
 }
 
 export interface ModelChoice { id: string; label?: string; availability?: string; is_default?: boolean; reasoning_efforts?: string[] }
 export interface ModelDiscovery { status?: string; source?: string; account_scoped?: boolean; refreshed_at?: string | number | null; warning?: string }
-export interface RoleRuntimeConfig { agent: string; model?: string }
+export interface RoleRuntimeConfig { agent: string; model?: string; effort?: string }
 
 export async function getJson<T>(path: string): Promise<T> {
   const response = await fetch(path, { headers: authHeaders() });

--- a/frontend/web/src/api.ts
+++ b/frontend/web/src/api.ts
@@ -112,7 +112,7 @@ export interface WebMeta {
   /** Server-discovered agent/model catalogue. Older servers may omit these. */
   agents?: Array<{ id: string; label?: string; available?: boolean; default_model?: string; models?: ModelChoice[]; discovery?: ModelDiscovery }>;
   models?: Record<string, ModelChoice[]>;
-  defaults?: { agent?: string; model?: string; effort_levels?: string[]; roles?: Record<string, RoleRuntimeConfig> };
+  defaults?: { agent?: string; model?: string; effort_levels?: Record<string, string[]>; roles?: Record<string, RoleRuntimeConfig> };
   model_discovery?: Record<string, ModelDiscovery>;
 }
 

--- a/frontend/web/src/style.css
+++ b/frontend/web/src/style.css
@@ -483,7 +483,12 @@ body { -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; 
 .role-runtime-title strong { color: #35383b; font-size: 11px; }
 .role-runtime-title small { color: #929497; font-size: 9px; }
 .role-runtime-mark { display: grid; place-items: center; width: 22px; height: 22px; border-radius: 6px; color: #2f6f5b; background: #e8f3ee; font-size: 10px; font-weight: 700; }
-.role-runtime-grid { display: grid; grid-template-columns: minmax(0, .8fr) minmax(0, 1.2fr); gap: 8px; }
+.role-runtime-grid { display: grid; grid-template-columns: minmax(0, .95fr) minmax(0, 1.15fr) minmax(0, .5fr); gap: 8px; }
+.role-binding-strip { display: flex; flex-wrap: wrap; gap: 6px; margin-bottom: 10px; }
+.role-binding-chip { display: inline-flex; align-items: center; gap: 6px; max-width: 100%; padding: 4px 9px; border: 1px solid #e2e3e4; border-radius: 999px; background: #fafafa; font-size: 11px; color: #62666a; }
+.role-binding-chip strong { color: #26292c; font-weight: 600; }
+.role-binding-chip span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 220px; }
+.role-binding-chip em { font-style: normal; padding: 1px 7px; border-radius: 999px; background: #e8f0ec; color: #39735f; font-weight: 600; }
 .role-runtime-grid .drawer-field { margin: 0; }
 .role-runtime-custom { width: 100%; box-sizing: border-box; }
 .drawer-field-note.model-detected { color: #39735f; }

--- a/src/lh_harness/adapters/claude_code.py
+++ b/src/lh_harness/adapters/claude_code.py
@@ -16,6 +16,7 @@ from .claude_permissions import (
 from ..environment.base import Environment
 from ..provider_errors import GUARD_REJECTION_MESSAGE
 from ..types import (
+    BACKEND_EFFORT_LEVELS,
     DEFAULT_CLAUDE_MODEL,
     DEFAULT_TMP_DIR,
     DEFAULT_WORKSPACE_PATH,
@@ -24,18 +25,9 @@ from ..types import (
 )
 from .cli_agent import CommandAgentAdapter
 
-# Claude Code reads its effort level from CLAUDE_CODE_EFFORT_LEVEL (the env
-# var also outranks a session's /effort choice, which is exactly the isolation
-# a harness role needs).  It documents low|medium|high|xhigh|max; the scale's
-# "med" spells out to "medium" there, and "min" lands on Claude's floor.
-_CLAUDE_EFFORT_LEVELS = {
-    "min": "low",
-    "low": "low",
-    "med": "medium",
-    "high": "high",
-    "xhigh": "xhigh",
-    "max": "max",
-}
+# Claude Code reads its effort level from CLAUDE_CODE_EFFORT_LEVEL; the env
+# var also outranks a session's /effort choice, which is exactly the
+# isolation a harness role needs.
 
 
 class ClaudeCodeAdapter(CommandAgentAdapter):
@@ -54,13 +46,12 @@ class ClaudeCodeAdapter(CommandAgentAdapter):
         guard_exclude_paths: tuple[str, ...] = (),
         effort: str | None = None,
     ) -> None:
-        if effort is not None and effort not in _CLAUDE_EFFORT_LEVELS:
+        if effort is not None and effort not in BACKEND_EFFORT_LEVELS["claude_code"]:
             raise ValueError(
                 "Claude Code effort must be one of "
-                f"{', '.join(_CLAUDE_EFFORT_LEVELS)}"
+                f"{', '.join(BACKEND_EFFORT_LEVELS['claude_code'])}"
             )
         self.effort = effort
-        self.effort_effective = _CLAUDE_EFFORT_LEVELS[effort] if effort else None
         policy = policy_for_role(role)
         env_parts: list[str] = []
         if api_key:
@@ -79,8 +70,8 @@ class ClaudeCodeAdapter(CommandAgentAdapter):
                 f"LH_HARNESS_CLAUDE_ROLE={shlex.quote(role)}",
             ]
         )
-        if self.effort_effective:
-            env_parts.append(f"CLAUDE_CODE_EFFORT_LEVEL={self.effort_effective}")
+        if effort:
+            env_parts.append(f"CLAUDE_CODE_EFFORT_LEVEL={effort}")
 
         # MCP support remains opt-in. --strict-mcp-config keeps unrelated
         # user/project MCP servers out of every role.

--- a/src/lh_harness/adapters/claude_code.py
+++ b/src/lh_harness/adapters/claude_code.py
@@ -24,6 +24,19 @@ from ..types import (
 )
 from .cli_agent import CommandAgentAdapter
 
+# Claude Code reads its effort level from CLAUDE_CODE_EFFORT_LEVEL (the env
+# var also outranks a session's /effort choice, which is exactly the isolation
+# a harness role needs).  It documents low|medium|high|xhigh|max; the scale's
+# "med" spells out to "medium" there, and "min" lands on Claude's floor.
+_CLAUDE_EFFORT_LEVELS = {
+    "min": "low",
+    "low": "low",
+    "med": "medium",
+    "high": "high",
+    "xhigh": "xhigh",
+    "max": "max",
+}
+
 
 class ClaudeCodeAdapter(CommandAgentAdapter):
     def __init__(
@@ -39,7 +52,15 @@ class ClaudeCodeAdapter(CommandAgentAdapter):
         role: ClaudeRole = "cli_executor",
         hidden_paths: tuple[str, ...] = (),
         guard_exclude_paths: tuple[str, ...] = (),
+        effort: str | None = None,
     ) -> None:
+        if effort is not None and effort not in _CLAUDE_EFFORT_LEVELS:
+            raise ValueError(
+                "Claude Code effort must be one of "
+                f"{', '.join(_CLAUDE_EFFORT_LEVELS)}"
+            )
+        self.effort = effort
+        self.effort_effective = _CLAUDE_EFFORT_LEVELS[effort] if effort else None
         policy = policy_for_role(role)
         env_parts: list[str] = []
         if api_key:
@@ -58,6 +79,8 @@ class ClaudeCodeAdapter(CommandAgentAdapter):
                 f"LH_HARNESS_CLAUDE_ROLE={shlex.quote(role)}",
             ]
         )
+        if self.effort_effective:
+            env_parts.append(f"CLAUDE_CODE_EFFORT_LEVEL={self.effort_effective}")
 
         # MCP support remains opt-in. --strict-mcp-config keeps unrelated
         # user/project MCP servers out of every role.

--- a/src/lh_harness/adapters/cli_agent.py
+++ b/src/lh_harness/adapters/cli_agent.py
@@ -43,12 +43,10 @@ class CommandAgentAdapter:
         self.workspace_path = workspace_path.rstrip("/")
         self.visible_output_parser = visible_output_parser
         self.hidden_paths = tuple(hidden_paths)
-        # Subclasses that translate the normalized effort scale set these
-        # around super().__init__; run_episode records them so both the
-        # requested depth and the backend-level substitution stay auditable in
+        # Subclasses with an effort dial set this around super().__init__;
+        # run_episode records it so the requested depth stays auditable in
         # every episode's artifacts.
         self.effort = getattr(self, "effort", None)
-        self.effort_effective = getattr(self, "effort_effective", None)
 
     async def run_episode(
         self,
@@ -121,14 +119,7 @@ class CommandAgentAdapter:
                 ),
                 "stderr_chars": len(result.stderr),
                 "stderr_tail": redact_secrets(result.stderr[-2000:]),
-                **(
-                    {
-                        "effort": self.effort,
-                        "effort_effective": self.effort_effective or self.effort,
-                    }
-                    if self.effort
-                    else {}
-                ),
+                **({"effort": self.effort} if self.effort else {}),
             },
         )
 

--- a/src/lh_harness/adapters/cli_agent.py
+++ b/src/lh_harness/adapters/cli_agent.py
@@ -43,6 +43,12 @@ class CommandAgentAdapter:
         self.workspace_path = workspace_path.rstrip("/")
         self.visible_output_parser = visible_output_parser
         self.hidden_paths = tuple(hidden_paths)
+        # Subclasses that translate the normalized effort scale set these
+        # around super().__init__; run_episode records them so both the
+        # requested depth and the backend-level substitution stay auditable in
+        # every episode's artifacts.
+        self.effort = getattr(self, "effort", None)
+        self.effort_effective = getattr(self, "effort_effective", None)
 
     async def run_episode(
         self,
@@ -115,6 +121,14 @@ class CommandAgentAdapter:
                 ),
                 "stderr_chars": len(result.stderr),
                 "stderr_tail": redact_secrets(result.stderr[-2000:]),
+                **(
+                    {
+                        "effort": self.effort,
+                        "effort_effective": self.effort_effective or self.effort,
+                    }
+                    if self.effort
+                    else {}
+                ),
             },
         )
 

--- a/src/lh_harness/adapters/codex.py
+++ b/src/lh_harness/adapters/codex.py
@@ -5,7 +5,12 @@ import json
 import os
 import shlex
 
-from ..types import DEFAULT_CODEX_MODEL, DEFAULT_TMP_DIR, DEFAULT_WORKSPACE_PATH
+from ..types import (
+    DEFAULT_CODEX_MODEL,
+    DEFAULT_TMP_DIR,
+    DEFAULT_WORKSPACE_PATH,
+    EFFORT_CHOICES,
+)
 from ..agent_logs import visible_output as extract_codex_visible_output
 from ..utils.agent_cli import resolve_codex_binary
 from .cli_agent import CommandAgentAdapter
@@ -19,6 +24,18 @@ except ModuleNotFoundError:
 # target any OpenAI-compatible endpoint without editing ~/.codex/config.toml.
 _PROVIDER_ID = "lh_harness"
 _DEFAULT_BASE_URL = "https://api.openai.com/v1"
+
+# Codex documents minimal|low|medium|high|xhigh for model_reasoning_effort:
+# the scale's "min" spells out to "minimal" there, and "max" exists only on
+# the Claude side, so it lands on Codex's top level.
+_CODEX_EFFORTS = {
+    "min": "minimal",
+    "low": "low",
+    "med": "medium",
+    "high": "high",
+    "xhigh": "xhigh",
+    "max": "xhigh",
+}
 
 
 class CodexAdapter(CommandAgentAdapter):
@@ -34,7 +51,14 @@ class CodexAdapter(CommandAgentAdapter):
         add_dirs: list[str] | None = None,
         sandbox_mode: str | None = None,
         hidden_paths: tuple[str, ...] = (),
+        effort: str | None = None,
     ) -> None:
+        if effort is not None and effort not in EFFORT_CHOICES:
+            raise ValueError(
+                f"Codex effort must be one of {', '.join(EFFORT_CHOICES)}"
+            )
+        self.effort = effort
+        self.effort_effective = _CODEX_EFFORTS[effort] if effort else None
         env_parts: list[str] = []
         if api_key:
             quoted_key = shlex.quote(api_key)
@@ -80,6 +104,15 @@ class CodexAdapter(CommandAgentAdapter):
 
         if model:
             command_parts.extend(["--model", shlex.quote(model)])
+        if self.effort_effective:
+            command_parts.extend(
+                [
+                    "-c",
+                    shlex.quote(
+                        f"model_reasoning_effort={json.dumps(self.effort_effective)}"
+                    ),
+                ]
+            )
         # `-` makes Codex read the prompt from stdin, keeping long prompts off
         # the command line and out of the process table.
         command_parts.append("-")

--- a/src/lh_harness/adapters/codex.py
+++ b/src/lh_harness/adapters/codex.py
@@ -6,10 +6,10 @@ import os
 import shlex
 
 from ..types import (
+    BACKEND_EFFORT_LEVELS,
     DEFAULT_CODEX_MODEL,
     DEFAULT_TMP_DIR,
     DEFAULT_WORKSPACE_PATH,
-    EFFORT_CHOICES,
 )
 from ..agent_logs import visible_output as extract_codex_visible_output
 from ..utils.agent_cli import resolve_codex_binary
@@ -24,18 +24,6 @@ except ModuleNotFoundError:
 # target any OpenAI-compatible endpoint without editing ~/.codex/config.toml.
 _PROVIDER_ID = "lh_harness"
 _DEFAULT_BASE_URL = "https://api.openai.com/v1"
-
-# Codex documents minimal|low|medium|high|xhigh for model_reasoning_effort:
-# the scale's "min" spells out to "minimal" there, and "max" exists only on
-# the Claude side, so it lands on Codex's top level.
-_CODEX_EFFORTS = {
-    "min": "minimal",
-    "low": "low",
-    "med": "medium",
-    "high": "high",
-    "xhigh": "xhigh",
-    "max": "xhigh",
-}
 
 
 class CodexAdapter(CommandAgentAdapter):
@@ -53,12 +41,12 @@ class CodexAdapter(CommandAgentAdapter):
         hidden_paths: tuple[str, ...] = (),
         effort: str | None = None,
     ) -> None:
-        if effort is not None and effort not in EFFORT_CHOICES:
+        if effort is not None and effort not in BACKEND_EFFORT_LEVELS["codex"]:
             raise ValueError(
-                f"Codex effort must be one of {', '.join(EFFORT_CHOICES)}"
+                "Codex effort must be one of "
+                f"{', '.join(BACKEND_EFFORT_LEVELS['codex'])}"
             )
         self.effort = effort
-        self.effort_effective = _CODEX_EFFORTS[effort] if effort else None
         env_parts: list[str] = []
         if api_key:
             quoted_key = shlex.quote(api_key)
@@ -104,14 +92,9 @@ class CodexAdapter(CommandAgentAdapter):
 
         if model:
             command_parts.extend(["--model", shlex.quote(model)])
-        if self.effort_effective:
+        if effort:
             command_parts.extend(
-                [
-                    "-c",
-                    shlex.quote(
-                        f"model_reasoning_effort={json.dumps(self.effort_effective)}"
-                    ),
-                ]
+                ["-c", shlex.quote(f"model_reasoning_effort={json.dumps(effort)}")]
             )
         # `-` makes Codex read the prompt from stdin, keeping long prompts off
         # the command line and out of the process table.

--- a/src/lh_harness/adapters/deepseek_harness.py
+++ b/src/lh_harness/adapters/deepseek_harness.py
@@ -6,22 +6,9 @@ import sys
 from collections.abc import Callable, Sequence
 
 from ..agent_logs import visible_output as extract_visible_output
-from ..types import DEFAULT_DEEPSEEK_HARNESS_MODEL
+from ..types import BACKEND_EFFORT_LEVELS, DEFAULT_DEEPSEEK_HARNESS_MODEL
 from ..utils.agent_cli import resolve_dsh_binary
 from .cli_agent import CommandAgentAdapter
-
-# The dsh llm-deepseek plugin takes `reasoningEffort: low|high|max`; DeepSeek's
-# own API docs map medium (our "med") and xhigh onto high for V4 Flash/Pro, and the scale
-# has no minimum tier below low, so "min" lands there too.  The runner writes
-# the effective value into the profile patch next to the model override.
-_DSH_EFFORTS = {
-    "min": "low",
-    "low": "low",
-    "med": "high",
-    "high": "high",
-    "xhigh": "high",
-    "max": "max",
-}
 
 _READ_ONLY_ROLES = {
     "manager",
@@ -59,13 +46,12 @@ class DeepSeekHarnessAdapter(CommandAgentAdapter):
         visible_output_parser: Callable[[str], str] | None = None,
         effort: str | None = None,
     ) -> None:
-        if effort is not None and effort not in _DSH_EFFORTS:
+        if effort is not None and effort not in BACKEND_EFFORT_LEVELS["deepseek_harness"]:
             raise ValueError(
                 "DeepSeek Harness effort must be one of "
-                f"{', '.join(_DSH_EFFORTS)}"
+                f"{', '.join(BACKEND_EFFORT_LEVELS['deepseek_harness'])}"
             )
         self.effort = effort
-        self.effort_effective = _DSH_EFFORTS[effort] if effort else None
         normalized_model = model.strip()
         if not normalized_model:
             raise ValueError("DeepSeek Harness model must not be empty")
@@ -104,8 +90,10 @@ class DeepSeekHarnessAdapter(CommandAgentAdapter):
             "--model",
             shlex.quote(normalized_model),
         ]
-        if self.effort_effective:
-            command.extend(["--reasoning-effort", shlex.quote(self.effort_effective)])
+        if effort:
+            # The dsh llm-deepseek plugin takes `reasoningEffort` verbatim; the
+            # runner writes it into the profile patch next to the model override.
+            command.extend(["--reasoning-effort", shlex.quote(effort)])
         super().__init__(
             command_template=" ".join(command),
             workspace_path=workspace_path,

--- a/src/lh_harness/adapters/deepseek_harness.py
+++ b/src/lh_harness/adapters/deepseek_harness.py
@@ -10,6 +10,19 @@ from ..types import DEFAULT_DEEPSEEK_HARNESS_MODEL
 from ..utils.agent_cli import resolve_dsh_binary
 from .cli_agent import CommandAgentAdapter
 
+# The dsh llm-deepseek plugin takes `reasoningEffort: low|high|max`; DeepSeek's
+# own API docs map medium (our "med") and xhigh onto high for V4 Flash/Pro, and the scale
+# has no minimum tier below low, so "min" lands there too.  The runner writes
+# the effective value into the profile patch next to the model override.
+_DSH_EFFORTS = {
+    "min": "low",
+    "low": "low",
+    "med": "high",
+    "high": "high",
+    "xhigh": "high",
+    "max": "max",
+}
+
 _READ_ONLY_ROLES = {
     "manager",
     "final_response",
@@ -44,7 +57,15 @@ class DeepSeekHarnessAdapter(CommandAgentAdapter):
         add_dirs: Sequence[str] = (),
         hidden_paths: Sequence[str] = (),
         visible_output_parser: Callable[[str], str] | None = None,
+        effort: str | None = None,
     ) -> None:
+        if effort is not None and effort not in _DSH_EFFORTS:
+            raise ValueError(
+                "DeepSeek Harness effort must be one of "
+                f"{', '.join(_DSH_EFFORTS)}"
+            )
+        self.effort = effort
+        self.effort_effective = _DSH_EFFORTS[effort] if effort else None
         normalized_model = model.strip()
         if not normalized_model:
             raise ValueError("DeepSeek Harness model must not be empty")
@@ -83,6 +104,8 @@ class DeepSeekHarnessAdapter(CommandAgentAdapter):
             "--model",
             shlex.quote(normalized_model),
         ]
+        if self.effort_effective:
+            command.extend(["--reasoning-effort", shlex.quote(self.effort_effective)])
         super().__init__(
             command_template=" ".join(command),
             workspace_path=workspace_path,

--- a/src/lh_harness/adapters/deepseek_runner.py
+++ b/src/lh_harness/adapters/deepseek_runner.py
@@ -32,17 +32,25 @@ def _model_patch_path(prompt_path: Path) -> Path:
     return prompt_path.with_name(f"{prompt_path.name}.dsh-model-patch.yml")
 
 
-def run(binary: str, prompt_path: Path, model: str) -> int:
+def run(binary: str, prompt_path: Path, model: str, reasoning_effort: str | None = None) -> int:
     try:
         prompt = prompt_path.read_text(encoding="utf-8")
         patch_path = _model_patch_path(prompt_path)
-        patch_path.write_text(
+        patch = (
             "- id: agent-default-model\n"
             "  config:\n"
             "    provider: deepseek-official\n"
-            f"    model: {json.dumps(model, ensure_ascii=False)}\n",
-            encoding="utf-8",
+            f"    model: {json.dumps(model, ensure_ascii=False)}\n"
         )
+        if reasoning_effort:
+            # dsh patch layers merge per plugin id, so this override keeps the
+            # profile's other llm-deepseek settings (thinking stays enabled).
+            patch += (
+                "- id: llm-deepseek\n"
+                "  config:\n"
+                f"    reasoningEffort: {json.dumps(reasoning_effort)}\n"
+            )
+        patch_path.write_text(patch, encoding="utf-8")
     except (OSError, UnicodeError) as exc:
         message = f"could not prepare DeepSeek Harness prompt: {exc}"
         sys.stderr.write(message + "\n")
@@ -85,12 +93,13 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--binary", required=True)
     parser.add_argument("--prompt", required=True)
     parser.add_argument("--model", required=True)
+    parser.add_argument("--reasoning-effort", default=None)
     return parser
 
 
 def main(argv: Sequence[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
-    return run(args.binary, Path(args.prompt), args.model)
+    return run(args.binary, Path(args.prompt), args.model, args.reasoning_effort)
 
 
 if __name__ == "__main__":

--- a/src/lh_harness/adapters/opencode.py
+++ b/src/lh_harness/adapters/opencode.py
@@ -20,13 +20,6 @@ from .cli_agent import CommandAgentAdapter
 
 _CONFIG_FILENAME_RE = re.compile(r"[^A-Za-z0-9_.-]+")
 
-# OpenCode's --variant selects a named per-model preset. OpenAI-style models
-# ship default variants named after the reasoning-effort levels themselves
-# (minimal|low|medium|high|xhigh), so the scale's "min" and "med" spell out
-# to "minimal" and "medium"; every other name passes through as-is - other providers ship a
-# subset (e.g. high/max) and take custom variants from opencode.jsonc.
-_VARIANT_FOR_EFFORT = {"min": "minimal", "med": "medium"}
-
 
 class OpenCodeAdapter(CommandAgentAdapter):
     """Run OpenCode headlessly through LongHorizon Harness.
@@ -60,7 +53,6 @@ class OpenCodeAdapter(CommandAgentAdapter):
         normalized_effort = (effort or "").strip()
         if len(normalized_effort) > 64:
             raise ValueError("OpenCode reasoning effort is too long")
-        variant = _VARIANT_FOR_EFFORT.get(normalized_effort, normalized_effort)
 
         opencode_binary = resolve_opencode_binary() or "opencode"
         env_parts: list[str] = []
@@ -86,8 +78,12 @@ class OpenCodeAdapter(CommandAgentAdapter):
             "--model",
             shlex.quote(normalized_model),
         ]
-        if variant:
-            command_parts.extend(["--variant", shlex.quote(variant)])
+        # --variant selects a named per-model preset, so the effort value passes
+        # through verbatim: OpenAI-style models ship default variants named after
+        # the reasoning-effort levels themselves, other providers ship a subset
+        # (e.g. high/max) and take custom variants from opencode.jsonc.
+        if normalized_effort:
+            command_parts.extend(["--variant", shlex.quote(normalized_effort)])
         # `opencode run` reads the prompt from stdin when no positional message
         # is given, keeping long prompts off the command line.
         command_parts.append("< {prompt_path}")
@@ -102,7 +98,6 @@ class OpenCodeAdapter(CommandAgentAdapter):
         )
         self.model = normalized_model
         self.effort = normalized_effort or None
-        self.effort_effective = variant or None
         self.role = role
 
     async def run_episode(
@@ -122,7 +117,7 @@ class OpenCodeAdapter(CommandAgentAdapter):
             {
                 "opencode_role": self.role,
                 "opencode_model": self.model,
-                "opencode_variant": self.effort_effective or "",
+                "opencode_variant": self.effort or "",
                 "opencode_approval_mode": "yolo",
             }
         )

--- a/src/lh_harness/adapters/opencode.py
+++ b/src/lh_harness/adapters/opencode.py
@@ -20,6 +20,13 @@ from .cli_agent import CommandAgentAdapter
 
 _CONFIG_FILENAME_RE = re.compile(r"[^A-Za-z0-9_.-]+")
 
+# OpenCode's --variant selects a named per-model preset. OpenAI-style models
+# ship default variants named after the reasoning-effort levels themselves
+# (minimal|low|medium|high|xhigh), so the scale's "min" and "med" spell out
+# to "minimal" and "medium"; every other name passes through as-is - other providers ship a
+# subset (e.g. high/max) and take custom variants from opencode.jsonc.
+_VARIANT_FOR_EFFORT = {"min": "minimal", "med": "medium"}
+
 
 class OpenCodeAdapter(CommandAgentAdapter):
     """Run OpenCode headlessly through LongHorizon Harness.
@@ -53,6 +60,7 @@ class OpenCodeAdapter(CommandAgentAdapter):
         normalized_effort = (effort or "").strip()
         if len(normalized_effort) > 64:
             raise ValueError("OpenCode reasoning effort is too long")
+        variant = _VARIANT_FOR_EFFORT.get(normalized_effort, normalized_effort)
 
         opencode_binary = resolve_opencode_binary() or "opencode"
         env_parts: list[str] = []
@@ -78,8 +86,8 @@ class OpenCodeAdapter(CommandAgentAdapter):
             "--model",
             shlex.quote(normalized_model),
         ]
-        if normalized_effort:
-            command_parts.extend(["--variant", shlex.quote(normalized_effort)])
+        if variant:
+            command_parts.extend(["--variant", shlex.quote(variant)])
         # `opencode run` reads the prompt from stdin when no positional message
         # is given, keeping long prompts off the command line.
         command_parts.append("< {prompt_path}")
@@ -93,7 +101,8 @@ class OpenCodeAdapter(CommandAgentAdapter):
             hidden_paths=hidden_paths,
         )
         self.model = normalized_model
-        self.effort = normalized_effort
+        self.effort = normalized_effort or None
+        self.effort_effective = variant or None
         self.role = role
 
     async def run_episode(
@@ -113,7 +122,7 @@ class OpenCodeAdapter(CommandAgentAdapter):
             {
                 "opencode_role": self.role,
                 "opencode_model": self.model,
-                "opencode_variant": self.effort,
+                "opencode_variant": self.effort_effective or "",
                 "opencode_approval_mode": "yolo",
             }
         )

--- a/src/lh_harness/cli.py
+++ b/src/lh_harness/cli.py
@@ -32,7 +32,6 @@ from .types import (
     DEFAULT_MAX_ROUNDS,
     DEFAULT_WORKSPACE_PATH,
     MAX_ROUNDS,
-    EFFORT_CHOICES,
     EpisodeBudget,
     HarnessConfig,
 )
@@ -422,13 +421,13 @@ def main(argv: list[str] | None = None) -> int:
     run_parser.add_argument(
         "--effort",
         default=run_default("effort"),
-        choices=EFFORT_CHOICES,
         help=(
             "Effort for every role, passed to each backend verbatim "
             "(Codex model_reasoning_effort, Claude Code CLAUDE_CODE_EFFORT_LEVEL, "
             "OpenCode --variant, DeepSeek Harness reasoningEffort). Each backend "
-            "accepts its own documented subset and rejects the rest; defaults to "
-            "the backend's own default."
+            "validates the value itself: codex/claude_code/deepseek_harness "
+            "accept only their documented levels, opencode accepts any variant "
+            "name the model defines; defaults to the backend's own default."
         ),
     )
     for role, _, scope in _ROLE_OPTIONS:
@@ -446,7 +445,6 @@ def main(argv: list[str] | None = None) -> int:
         run_parser.add_argument(
             _flag(role, "effort"),
             default=run_default(f"{role}_effort"),
-            choices=EFFORT_CHOICES,
             help=f"Effort for {scope}; defaults to {_fallback_hint(role, 'effort')}.",
         )
     # Only the local backend is implemented; kept as a flag so existing

--- a/src/lh_harness/cli.py
+++ b/src/lh_harness/cli.py
@@ -424,11 +424,11 @@ def main(argv: list[str] | None = None) -> int:
         default=run_default("effort"),
         choices=EFFORT_CHOICES,
         help=(
-            "Effort for every role, translated per backend "
+            "Effort for every role, passed to each backend verbatim "
             "(Codex model_reasoning_effort, Claude Code CLAUDE_CODE_EFFORT_LEVEL, "
-            "OpenCode --variant, DeepSeek Harness reasoningEffort); a level a "
-            "backend lacks maps to its nearest supported one. Defaults to each "
-            "backend's own default."
+            "OpenCode --variant, DeepSeek Harness reasoningEffort). Each backend "
+            "accepts its own documented subset and rejects the rest; defaults to "
+            "the backend's own default."
         ),
     )
     for role, _, scope in _ROLE_OPTIONS:

--- a/src/lh_harness/cli.py
+++ b/src/lh_harness/cli.py
@@ -32,6 +32,7 @@ from .types import (
     DEFAULT_MAX_ROUNDS,
     DEFAULT_WORKSPACE_PATH,
     MAX_ROUNDS,
+    EFFORT_CHOICES,
     EpisodeBudget,
     HarnessConfig,
 )
@@ -418,6 +419,18 @@ def main(argv: list[str] | None = None) -> int:
         default=run_default("model"),
         help="Model for every role. Defaults to the chosen agent's own default.",
     )
+    run_parser.add_argument(
+        "--effort",
+        default=run_default("effort"),
+        choices=EFFORT_CHOICES,
+        help=(
+            "Effort for every role, translated per backend "
+            "(Codex model_reasoning_effort, Claude Code CLAUDE_CODE_EFFORT_LEVEL, "
+            "OpenCode --variant, DeepSeek Harness reasoningEffort); a level a "
+            "backend lacks maps to its nearest supported one. Defaults to each "
+            "backend's own default."
+        ),
+    )
     for role, _, scope in _ROLE_OPTIONS:
         run_parser.add_argument(
             _flag(role, "agent"),
@@ -429,6 +442,12 @@ def main(argv: list[str] | None = None) -> int:
             _flag(role, "model"),
             default=run_default(f"{role}_model"),
             help=f"Model for {scope}; defaults to {_fallback_hint(role, 'model')}.",
+        )
+        run_parser.add_argument(
+            _flag(role, "effort"),
+            default=run_default(f"{role}_effort"),
+            choices=EFFORT_CHOICES,
+            help=f"Effort for {scope}; defaults to {_fallback_hint(role, 'effort')}.",
         )
     # Only the local backend is implemented; kept as a flag so existing
     # `--env local` invocations keep working and future backends can slot in.
@@ -1684,8 +1703,9 @@ def _run_command(args: argparse.Namespace) -> int:
         # same model must never share a differently privileged adapter.
         name = _resolve_role_option(args, role, "agent")
         model = _resolve_role_model(args, role)
+        effort = _resolve_role_effort(args, role)
         effective_permission_role = permission_role or role
-        key = (effective_permission_role, name, model)
+        key = (effective_permission_role, name, model, effort)
         if key not in agent_cache:
             agent_cache[key] = _build_agent(
                 name,
@@ -1699,6 +1719,7 @@ def _run_command(args: argparse.Namespace) -> int:
                 mcp_add_dirs=args.mcp_add_dir,
                 hidden_paths=hidden_paths,
                 guard_exclude_paths=guard_exclude_paths,
+                effort=effort,
             )
         return agent_cache[key]
 
@@ -1953,6 +1974,22 @@ def _resolve_role_model(args: argparse.Namespace, role: str) -> str | None:
     return getattr(args, "model", None)
 
 
+def _resolve_role_effort(args: argparse.Namespace, role: str) -> str | None:
+    """Resolve effort down the role fallback chain.
+
+    The scale is normalized across backends, so unlike models it may safely
+    cross an explicit agent boundary and end at the global flag.
+    """
+
+    current: str | None = role
+    while current:
+        value = getattr(args, f"{current}_effort", None)
+        if value:
+            return value
+        current = _ROLE_PARENTS[current]
+    return getattr(args, "effort", None)
+
+
 def _public_role_configs_from_args(
     args: argparse.Namespace,
 ) -> dict[str, dict[str, str | None]] | None:
@@ -2089,6 +2126,7 @@ def _build_agent(
     mcp_add_dirs: list[str] | None = None,
     hidden_paths: tuple[str, ...] = (),
     guard_exclude_paths: tuple[str, ...] = (),
+    effort: str | None = None,
 ):
     if name == "codex":
         from .adapters.codex import CodexAdapter
@@ -2101,6 +2139,7 @@ def _build_agent(
             mcp_config=mcp_config,
             add_dirs=mcp_add_dirs,
             hidden_paths=hidden_paths,
+            effort=effort,
         )
         if model is not None:
             kwargs["model"] = model
@@ -2120,6 +2159,7 @@ def _build_agent(
             # The Codex adapter has no auditor snapshot guard, so the
             # exclusions are a Claude-Code-only concern for now.
             guard_exclude_paths=guard_exclude_paths,
+            effort=effort,
         )
         if model is not None:
             kwargs["model"] = model
@@ -2135,6 +2175,7 @@ def _build_agent(
             add_dirs=mcp_add_dirs,
             role=role,
             hidden_paths=hidden_paths,
+            effort=effort,
         )
         if model is not None:
             kwargs["model"] = model
@@ -2149,6 +2190,7 @@ def _build_agent(
             prompt_dir=prompt_dir,
             role=role,
             hidden_paths=hidden_paths,
+            effort=effort,
         )
         if model is not None:
             kwargs["model"] = model

--- a/src/lh_harness/config.py
+++ b/src/lh_harness/config.py
@@ -4,7 +4,7 @@ import importlib
 from pathlib import Path
 from typing import Any
 
-from .types import EFFORT_CHOICES, MAX_ROUNDS
+from .types import MAX_ROUNDS
 
 try:
     tomllib = importlib.import_module("tomllib")
@@ -198,7 +198,7 @@ def _flatten_run_table(run: dict[str, Any]) -> dict[str, Any]:
     if "agent" in run:
         defaults["agent"] = _choice(run["agent"], "run.agent", _AGENT_CHOICES)
     if "effort" in run:
-        defaults["effort"] = _choice(run["effort"], "run.effort", set(EFFORT_CHOICES))
+        defaults["effort"] = _effort(run["effort"], "run.effort")
     if "env" in run:
         defaults["env"] = _choice(run["env"], "run.env", {"local"})
     if "prompt_language" in run:
@@ -245,8 +245,8 @@ def _flatten_run_table(run: dict[str, Any]) -> dict[str, Any]:
                 values["model"], f"run.roles.{role}.model"
             )
         if "effort" in values:
-            defaults[f"{role}_effort"] = _choice(
-                values["effort"], f"run.roles.{role}.effort", set(EFFORT_CHOICES)
+            defaults[f"{role}_effort"] = _effort(
+                values["effort"], f"run.roles.{role}.effort"
             )
 
     timeouts = run.get("timeouts", {})
@@ -270,6 +270,16 @@ def _choice(value: Any, name: str, choices: set[str]) -> str:
     result = _string(value, name)
     if result not in choices:
         raise ProjectConfigError(f"{name} must be one of: {_names(choices)}")
+    return result
+
+
+def _effort(value: Any, name: str) -> str:
+    # Effort names are backend-defined (OpenCode variants may even be
+    # user-defined), so only the shape is checked here; the role's own
+    # backend validates the value when the agent is built.
+    result = _string(value, name)
+    if len(result) > 64 or "\x00" in result:
+        raise ProjectConfigError(f"{name} must be a printable name of at most 64 characters")
     return result
 
 

--- a/src/lh_harness/config.py
+++ b/src/lh_harness/config.py
@@ -63,7 +63,7 @@ CONFIG_TEMPLATE = """# LongHorizon-Harness project defaults.
 [run]
 agent = "codex"
 model = "gpt-5.6-sol"
-effort = "med"
+effort = "medium"
 
 env = "local"
 runs_root = "./.lh-harness/runs"
@@ -108,43 +108,43 @@ auditor = 300
 [run.roles.manager]
 # agent = "codex"
 # model = "gpt-5.6-sol"
-# effort = "med"
+# effort = "medium"
 
 [run.roles.executor]
 # agent = "codex"
 # model = "gpt-5.6-sol"
-# effort = "med"
+# effort = "medium"
 
 [run.roles.auditor]
 # agent = "codex"
 # model = "gpt-5.6-sol"
-# effort = "med"
+# effort = "medium"
 
 # Writes the closing reply to you; falls back to the manager's agent/model.
 [run.roles.final_response]
 # agent = "codex"
 # model = "gpt-5.6-sol"
-# effort = "med"
+# effort = "medium"
 
 [run.roles.gui_executor]
 # agent = "codex"
 # model = "gpt-5.6-sol"
-# effort = "med"
+# effort = "medium"
 
 [run.roles.gui_auditor]
 # agent = "codex"
 # model = "gpt-5.6-sol"
-# effort = "med"
+# effort = "medium"
 
 [run.roles.cli_executor]
 # agent = "codex"
 # model = "gpt-5.6-sol"
-# effort = "med"
+# effort = "medium"
 
 [run.roles.cli_auditor]
 # agent = "codex"
 # model = "gpt-5.6-sol"
-# effort = "med"
+# effort = "medium"
 """
 
 

--- a/src/lh_harness/config.py
+++ b/src/lh_harness/config.py
@@ -4,7 +4,7 @@ import importlib
 from pathlib import Path
 from typing import Any
 
-from .types import MAX_ROUNDS
+from .types import EFFORT_CHOICES, MAX_ROUNDS
 
 try:
     tomllib = importlib.import_module("tomllib")
@@ -39,6 +39,7 @@ _RUN_KEYS = {
     "codex_mcp_config",
     "mcp_add_dirs",
     "guard_exclude_paths",
+    "effort",
     "max_rounds",
     "dashboard",
     "dashboard_port",
@@ -62,6 +63,7 @@ CONFIG_TEMPLATE = """# LongHorizon-Harness project defaults.
 [run]
 agent = "codex"
 model = "gpt-5.6-sol"
+effort = "med"
 
 env = "local"
 runs_root = "./.lh-harness/runs"
@@ -73,6 +75,7 @@ runs_root = "./.lh-harness/runs"
 # base_url = "https://api.example.com/v1"
 
 prompt_language = "en"
+
 # Each agent reads its own format; installed plugins are loaded automatically.
 # claude_mcp_config = "/path/to/mcp.json"
 # codex_mcp_config = "/path/to/mcp.toml"
@@ -98,38 +101,50 @@ gui_executor = 1800
 cli_executor = 1800
 auditor = 300
 
+# The public roles first; the gui_*/cli_* variants below inherit from
+# executor/auditor unless overridden. A role's own effort outranks the
+# global [run] effort above.
+
 [run.roles.manager]
 # agent = "codex"
 # model = "gpt-5.6-sol"
+# effort = "med"
 
 [run.roles.executor]
 # agent = "codex"
 # model = "gpt-5.6-sol"
-
-[run.roles.gui_executor]
-# agent = "codex"
-# model = "gpt-5.6-sol"
-
-[run.roles.cli_executor]
-# agent = "codex"
-# model = "gpt-5.6-sol"
+# effort = "med"
 
 [run.roles.auditor]
 # agent = "codex"
 # model = "gpt-5.6-sol"
-
-[run.roles.gui_auditor]
-# agent = "codex"
-# model = "gpt-5.6-sol"
-
-[run.roles.cli_auditor]
-# agent = "codex"
-# model = "gpt-5.6-sol"
+# effort = "med"
 
 # Writes the closing reply to you; falls back to the manager's agent/model.
 [run.roles.final_response]
 # agent = "codex"
 # model = "gpt-5.6-sol"
+# effort = "med"
+
+[run.roles.gui_executor]
+# agent = "codex"
+# model = "gpt-5.6-sol"
+# effort = "med"
+
+[run.roles.gui_auditor]
+# agent = "codex"
+# model = "gpt-5.6-sol"
+# effort = "med"
+
+[run.roles.cli_executor]
+# agent = "codex"
+# model = "gpt-5.6-sol"
+# effort = "med"
+
+[run.roles.cli_auditor]
+# agent = "codex"
+# model = "gpt-5.6-sol"
+# effort = "med"
 """
 
 
@@ -182,6 +197,8 @@ def _flatten_run_table(run: dict[str, Any]) -> dict[str, Any]:
 
     if "agent" in run:
         defaults["agent"] = _choice(run["agent"], "run.agent", _AGENT_CHOICES)
+    if "effort" in run:
+        defaults["effort"] = _choice(run["effort"], "run.effort", set(EFFORT_CHOICES))
     if "env" in run:
         defaults["env"] = _choice(run["env"], "run.env", {"local"})
     if "prompt_language" in run:
@@ -214,7 +231,7 @@ def _flatten_run_table(run: dict[str, Any]) -> dict[str, Any]:
     for role, values in roles.items():
         if not isinstance(values, dict):
             raise ProjectConfigError(f"[run.roles.{role}] must be a TOML table")
-        unknown_role_keys = set(values) - {"agent", "model"}
+        unknown_role_keys = set(values) - {"agent", "model", "effort"}
         if unknown_role_keys:
             raise ProjectConfigError(
                 f"unknown [run.roles.{role}] key(s): {_names(unknown_role_keys)}"
@@ -226,6 +243,10 @@ def _flatten_run_table(run: dict[str, Any]) -> dict[str, Any]:
         if "model" in values:
             defaults[f"{role}_model"] = _string(
                 values["model"], f"run.roles.{role}.model"
+            )
+        if "effort" in values:
+            defaults[f"{role}_effort"] = _choice(
+                values["effort"], f"run.roles.{role}.effort", set(EFFORT_CHOICES)
             )
 
     timeouts = run.get("timeouts", {})

--- a/src/lh_harness/supervisor/service.py
+++ b/src/lh_harness/supervisor/service.py
@@ -43,7 +43,7 @@ from ..types import (
     DEFAULT_OPENCODE_MODEL,
     DEFAULT_MAX_ROUNDS,
     MAX_ROUNDS,
-    EFFORT_CHOICES,
+    BACKEND_EFFORT_LEVELS,
 )
 from ..utils.run_boundary import safe_run_control, safe_run_dir, safe_run_logs, safe_run_role, safe_run_rounds
 
@@ -125,9 +125,18 @@ def _normalise_role_configs(
         result[role] = {"agent": role_agent, "model": role_model}
         raw_effort = raw.get("effort")
         if raw_effort is not None and raw_effort != "":
-            if not isinstance(raw_effort, str) or raw_effort not in EFFORT_CHOICES:
+            if not isinstance(raw_effort, str):
+                raise ValueError(f"roles.{role}.effort must be a string")
+            if role_agent == "opencode":
+                # OpenCode's effort is a per-model variant name; custom
+                # variants come from opencode.jsonc, so only shape is checked.
+                if len(raw_effort) > 64 or "\x00" in raw_effort:
+                    raise ValueError(f"roles.{role}.effort is not a valid OpenCode variant name")
+            elif raw_effort not in BACKEND_EFFORT_LEVELS[role_agent]:
                 raise ValueError(
-                    f"roles.{role}.effort must be one of: " + ", ".join(EFFORT_CHOICES)
+                    f"roles.{role}.effort must be one of: "
+                    + ", ".join(BACKEND_EFFORT_LEVELS[role_agent])
+                    + f" for {role_agent}"
                 )
             result[role]["effort"] = raw_effort
     return result

--- a/src/lh_harness/supervisor/service.py
+++ b/src/lh_harness/supervisor/service.py
@@ -43,6 +43,7 @@ from ..types import (
     DEFAULT_OPENCODE_MODEL,
     DEFAULT_MAX_ROUNDS,
     MAX_ROUNDS,
+    EFFORT_CHOICES,
 )
 from ..utils.run_boundary import safe_run_control, safe_run_dir, safe_run_logs, safe_run_role, safe_run_rounds
 
@@ -104,7 +105,7 @@ def _normalise_role_configs(
             raw = {}
         if not isinstance(raw, dict):
             raise ValueError(f"roles.{role} must be an object")
-        extra = set(raw) - {"agent", "model"}
+        extra = set(raw) - {"agent", "model", "effort"}
         if extra:
             raise ValueError(f"unknown roles.{role} field: {sorted(extra)[0]}")
         role_agent = str(raw.get("agent") or agent).strip()
@@ -122,6 +123,13 @@ def _normalise_role_configs(
         if not role_model or len(role_model) > 256 or "\x00" in role_model:
             raise ValueError(f"roles.{role}.model must be a non-empty string of at most 256 characters")
         result[role] = {"agent": role_agent, "model": role_model}
+        raw_effort = raw.get("effort")
+        if raw_effort is not None and raw_effort != "":
+            if not isinstance(raw_effort, str) or raw_effort not in EFFORT_CHOICES:
+                raise ValueError(
+                    f"roles.{role}.effort must be one of: " + ", ".join(EFFORT_CHOICES)
+                )
+            result[role]["effort"] = raw_effort
     return result
 
 
@@ -1238,6 +1246,8 @@ class RunSupervisor:
                     f"--{role}-model={spec['model']}",
                 ]
             )
+            if spec.get("effort"):
+                command.append(f"--{role}-effort={spec['effort']}")
         return command
 
     def create_run(

--- a/src/lh_harness/types.py
+++ b/src/lh_harness/types.py
@@ -33,6 +33,17 @@ DEFAULT_CODEX_MODEL = "gpt-5.6-sol"
 DEFAULT_DEEPSEEK_HARNESS_MODEL = "deepseek-v4-flash"
 DEFAULT_OPENCODE_MODEL = "opencode/deepseek-v4-flash-free"
 
+# Normalized effort scale shared by every backend, covering the union of the
+# levels the supported CLIs document.  "Effort" follows Anthropic's umbrella
+# term (distinct from the separate thinking control); on backends whose only
+# dial is reasoning-specific it drives that dial.  Each adapter translates a
+# level into its own vocabulary (Codex `model_reasoning_effort`, Claude Code
+# CLAUDE_CODE_EFFORT_LEVEL, OpenCode `--variant`, DeepSeek Harness
+# `reasoningEffort`), mapping a level its backend lacks to the nearest
+# supported one; the episode metadata records both the requested and the
+# effective value so the substitution stays visible.
+EFFORT_CHOICES: tuple[str, ...] = ("min", "low", "med", "high", "xhigh", "max")
+
 # A run is intentionally bounded at every ingress point.  Without a shared
 # ceiling, a malformed Web/CLI request can reserve an effectively unbounded
 # amount of work and disk/event pressure.  Keep this in the protocol-adjacent

--- a/src/lh_harness/types.py
+++ b/src/lh_harness/types.py
@@ -33,16 +33,21 @@ DEFAULT_CODEX_MODEL = "gpt-5.6-sol"
 DEFAULT_DEEPSEEK_HARNESS_MODEL = "deepseek-v4-flash"
 DEFAULT_OPENCODE_MODEL = "opencode/deepseek-v4-flash-free"
 
-# Normalized effort scale shared by every backend, covering the union of the
-# levels the supported CLIs document.  "Effort" follows Anthropic's umbrella
-# term (distinct from the separate thinking control); on backends whose only
-# dial is reasoning-specific it drives that dial.  Each adapter translates a
-# level into its own vocabulary (Codex `model_reasoning_effort`, Claude Code
-# CLAUDE_CODE_EFFORT_LEVEL, OpenCode `--variant`, DeepSeek Harness
-# `reasoningEffort`), mapping a level its backend lacks to the nearest
-# supported one; the episode metadata records both the requested and the
-# effective value so the substitution stays visible.
-EFFORT_CHOICES: tuple[str, ...] = ("min", "low", "med", "high", "xhigh", "max")
+# Effort levels pass through to each backend verbatim - no cross-backend
+# mapping.  BACKEND_EFFORT_LEVELS lists the levels each CLI documents for its
+# own dial (Codex `model_reasoning_effort`, Claude Code
+# CLAUDE_CODE_EFFORT_LEVELS, OpenCode `--variant` presets, DeepSeek Harness
+# `reasoningEffort`); a value outside a backend's set is a configuration
+# error, not a candidate for silent substitution.  EFFORT_CHOICES is the
+# union, used only as a typo guard at the config/CLI boundary where the
+# backend is not yet known.
+BACKEND_EFFORT_LEVELS: dict[str, tuple[str, ...]] = {
+    "codex": ("minimal", "low", "medium", "high", "xhigh"),
+    "claude_code": ("low", "medium", "high", "xhigh", "max"),
+    "deepseek_harness": ("low", "high", "max"),
+    "opencode": ("none", "minimal", "low", "medium", "high", "xhigh"),
+}
+EFFORT_CHOICES: tuple[str, ...] = ("none", "minimal", "low", "medium", "high", "xhigh", "max")
 
 # A run is intentionally bounded at every ingress point.  Without a shared
 # ceiling, a malformed Web/CLI request can reserve an effectively unbounded

--- a/src/lh_harness/types.py
+++ b/src/lh_harness/types.py
@@ -36,18 +36,19 @@ DEFAULT_OPENCODE_MODEL = "opencode/deepseek-v4-flash-free"
 # Effort levels pass through to each backend verbatim - no cross-backend
 # mapping.  BACKEND_EFFORT_LEVELS lists the levels each CLI documents for its
 # own dial (Codex `model_reasoning_effort`, Claude Code
-# CLAUDE_CODE_EFFORT_LEVELS, OpenCode `--variant` presets, DeepSeek Harness
-# `reasoningEffort`); a value outside a backend's set is a configuration
-# error, not a candidate for silent substitution.  EFFORT_CHOICES is the
-# union, used only as a typo guard at the config/CLI boundary where the
-# backend is not yet known.
+# CLAUDE_CODE_EFFORT_LEVELS, DeepSeek Harness `reasoningEffort`); a value
+# outside a backend's set is a configuration error, not a candidate for
+# silent substitution.  OpenCode's `--variant` takes per-model preset names
+# that may be user-defined in opencode.jsonc, so its values are not
+# enumerable: its entry is only the common OpenAI-style preset names the web
+# picker offers as a fallback - every layer accepts any well-formed name for
+# it and OpenCode resolves the variant itself.
 BACKEND_EFFORT_LEVELS: dict[str, tuple[str, ...]] = {
     "codex": ("minimal", "low", "medium", "high", "xhigh"),
     "claude_code": ("low", "medium", "high", "xhigh", "max"),
     "deepseek_harness": ("low", "high", "max"),
     "opencode": ("none", "minimal", "low", "medium", "high", "xhigh"),
 }
-EFFORT_CHOICES: tuple[str, ...] = ("none", "minimal", "low", "medium", "high", "xhigh", "max")
 
 # A run is intentionally bounded at every ingress point.  Without a shared
 # ceiling, a malformed Web/CLI request can reserve an effectively unbounded

--- a/src/lh_harness/webapi/server.py
+++ b/src/lh_harness/webapi/server.py
@@ -25,7 +25,7 @@ from ..model_catalog import discover_model_catalog
 from ..supervisor.service import IdempotencyConflict, RunSupervisor
 from ..supervisor.lifecycle import TERMINAL_STATUSES, canonical_lifecycle_status
 from ..supervisor.control_bus import CommandConflict, RevisionConflict
-from ..types import DEFAULT_CODEX_MODEL, DEFAULT_MAX_ROUNDS, EFFORT_CHOICES, MAX_ROUNDS
+from ..types import BACKEND_EFFORT_LEVELS, DEFAULT_CODEX_MODEL, DEFAULT_MAX_ROUNDS, MAX_ROUNDS
 from ..utils.agent_cli import resolve_codex_binary, resolve_dsh_binary, resolve_opencode_binary
 from ..utils.run_boundary import safe_run_control, safe_run_dir, safe_run_logs, safe_run_role, safe_run_rounds
 from .events import EventTailer
@@ -701,7 +701,7 @@ def create_app(
             defaults={
                 "agent": "codex",
                 "model": DEFAULT_CODEX_MODEL,
-                "effort_levels": list(EFFORT_CHOICES),
+                "effort_levels": {agent: list(levels) for agent, levels in BACKEND_EFFORT_LEVELS.items()},
                 "roles": {
                     role: {"agent": "codex", "model": DEFAULT_CODEX_MODEL}
                     for role in ("manager", "executor", "auditor")

--- a/src/lh_harness/webapi/server.py
+++ b/src/lh_harness/webapi/server.py
@@ -25,7 +25,7 @@ from ..model_catalog import discover_model_catalog
 from ..supervisor.service import IdempotencyConflict, RunSupervisor
 from ..supervisor.lifecycle import TERMINAL_STATUSES, canonical_lifecycle_status
 from ..supervisor.control_bus import CommandConflict, RevisionConflict
-from ..types import DEFAULT_CODEX_MODEL, DEFAULT_MAX_ROUNDS, MAX_ROUNDS
+from ..types import DEFAULT_CODEX_MODEL, DEFAULT_MAX_ROUNDS, EFFORT_CHOICES, MAX_ROUNDS
 from ..utils.agent_cli import resolve_codex_binary, resolve_dsh_binary, resolve_opencode_binary
 from ..utils.run_boundary import safe_run_control, safe_run_dir, safe_run_logs, safe_run_role, safe_run_rounds
 from .events import EventTailer
@@ -701,6 +701,7 @@ def create_app(
             defaults={
                 "agent": "codex",
                 "model": DEFAULT_CODEX_MODEL,
+                "effort_levels": list(EFFORT_CHOICES),
                 "roles": {
                     role: {"agent": "codex", "model": DEFAULT_CODEX_MODEL}
                     for role in ("manager", "executor", "auditor")

--- a/src/lh_harness/webapi/snapshot.py
+++ b/src/lh_harness/webapi/snapshot.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from ..dashboard.state import DashboardState
+from ..types import EFFORT_CHOICES
 from ..supervisor.lifecycle import canonical_lifecycle_status
 from .events import EventTailer
 
@@ -104,6 +105,9 @@ def _safe_role_configs(value: object) -> dict[str, dict[str, str]]:
         if not isinstance(model, str) or not model.strip() or len(model.strip()) > 256 or "\x00" in model:
             continue
         result[role] = {"agent": agent, "model": model.strip()}
+        effort = raw.get("effort")
+        if isinstance(effort, str) and effort in EFFORT_CHOICES:
+            result[role]["effort"] = effort
     return result if len(result) == 3 else {}
 
 

--- a/src/lh_harness/webapi/snapshot.py
+++ b/src/lh_harness/webapi/snapshot.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from typing import Any
 
 from ..dashboard.state import DashboardState
-from ..types import EFFORT_CHOICES
 from ..supervisor.lifecycle import canonical_lifecycle_status
 from .events import EventTailer
 
@@ -106,8 +105,8 @@ def _safe_role_configs(value: object) -> dict[str, dict[str, str]]:
             continue
         result[role] = {"agent": agent, "model": model.strip()}
         effort = raw.get("effort")
-        if isinstance(effort, str) and effort in EFFORT_CHOICES:
-            result[role]["effort"] = effort
+        if isinstance(effort, str) and 0 < len(effort) <= 64 and "\x00" not in effort:
+            result[role]["effort"] = effort.strip()
     return result if len(result) == 3 else {}
 
 

--- a/tests/test_effort.py
+++ b/tests/test_effort.py
@@ -385,3 +385,19 @@ def test_supervisor_rejects_bad_role_effort() -> None:
         _normalise_role_configs(
             {"executor": {"effort": "ultra"}}, agent="codex", model=None
         )
+
+
+def test_snapshot_provenance_keeps_valid_role_effort() -> None:
+    from lh_harness.webapi.snapshot import _safe_role_configs
+
+    cleaned = _safe_role_configs(
+        {
+            "manager": {"agent": "codex", "model": "m", "effort": "high"},
+            "executor": {"agent": "codex", "model": "m", "effort": "bogus"},
+            "auditor": {"agent": "codex", "model": "m"},
+        }
+    )
+
+    assert cleaned["manager"]["effort"] == "high"
+    assert "effort" not in cleaned["executor"]
+    assert "effort" not in cleaned["auditor"]

--- a/tests/test_effort.py
+++ b/tests/test_effort.py
@@ -23,7 +23,7 @@ from lh_harness.adapters.opencode import OpenCodeAdapter
 from lh_harness.cli import _ROLE_PARENTS, _build_agent, _resolve_role_effort
 from lh_harness.config import ProjectConfigError, _flatten_run_table
 from lh_harness.environment.local import LocalEnvironment
-from lh_harness.types import BACKEND_EFFORT_LEVELS, EFFORT_CHOICES, EpisodeBudget
+from lh_harness.types import BACKEND_EFFORT_LEVELS, EpisodeBudget
 
 
 # --- config ----------------------------------------------------------------
@@ -47,17 +47,22 @@ def test_config_accepts_per_role_effort() -> None:
     assert defaults["auditor_effort"] == "low"
 
 
-@pytest.mark.parametrize("bad", ["ultra", "", 3, True, ["high"]])
-def test_config_rejects_unknown_effort_values(bad: object) -> None:
+def test_config_accepts_custom_opencode_variant_names() -> None:
+    # Effort names are backend-defined (OpenCode variants may be user-defined
+    # in opencode.jsonc), so the config layer checks only the shape; the
+    # role's own backend rejects names it does not support when the agent is
+    # built, exactly like the web supervisor boundary.
+    assert _flatten_run_table({"effort": "deep"}) == {"effort": "deep"}
+    defaults = _flatten_run_table({"roles": {"executor": {"effort": "my-variant"}}})
+    assert defaults["executor_effort"] == "my-variant"
+
+
+@pytest.mark.parametrize("bad", ["", 3, True, ["high"], "x" * 65, "nul\x00led"])
+def test_config_rejects_malformed_effort_values(bad: object) -> None:
     with pytest.raises(ProjectConfigError, match=r"\beffort\b"):
         _flatten_run_table({"effort": bad})
     with pytest.raises(ProjectConfigError, match=r"\beffort\b"):
         _flatten_run_table({"roles": {"executor": {"effort": bad}}})
-
-
-def test_union_choices_cover_every_backend_level() -> None:
-    for backend, levels in BACKEND_EFFORT_LEVELS.items():
-        assert set(levels) <= set(EFFORT_CHOICES), backend
 
 
 # --- CLI fallback chain ----------------------------------------------------

--- a/tests/test_effort.py
+++ b/tests/test_effort.py
@@ -1,0 +1,387 @@
+"""Per-role effort: config keys, CLI fallback chain, adapter dials.
+
+The harness exposes one normalized scale — min/low/med/high/xhigh/max,
+covering the union of the levels the backends document — and each adapter
+translates a level into its own documented dial and vocabulary, mapping a
+level its backend lacks to the nearest supported one.  Episode metadata
+records both the requested and the effective value so substitutions stay
+visible.
+"""
+
+import argparse
+import asyncio
+import json
+import stat
+from pathlib import Path
+
+import pytest
+
+from lh_harness.adapters import opencode as opencode_adapter_module
+from lh_harness.adapters.claude_code import ClaudeCodeAdapter
+from lh_harness.adapters.codex import CodexAdapter
+from lh_harness.adapters.deepseek_harness import DeepSeekHarnessAdapter
+from lh_harness.adapters.deepseek_runner import run as deepseek_runner_run
+from lh_harness.adapters.opencode import OpenCodeAdapter
+from lh_harness.cli import _ROLE_PARENTS, _build_agent, _resolve_role_effort
+from lh_harness.config import ProjectConfigError, _flatten_run_table
+from lh_harness.environment.local import LocalEnvironment
+from lh_harness.types import EpisodeBudget, EFFORT_CHOICES
+
+
+# --- config ----------------------------------------------------------------
+
+
+def test_config_accepts_global_effort() -> None:
+    assert _flatten_run_table({"effort": "xhigh"}) == {"effort": "xhigh"}
+
+
+def test_config_accepts_per_role_effort() -> None:
+    defaults = _flatten_run_table(
+        {
+            "roles": {
+                "manager": {"effort": "max"},
+                "auditor": {"effort": "low"},
+            }
+        }
+    )
+
+    assert defaults["manager_effort"] == "max"
+    assert defaults["auditor_effort"] == "low"
+
+
+@pytest.mark.parametrize("bad", ["ultra", "", 3, True, ["high"]])
+def test_config_rejects_unknown_effort_values(bad: object) -> None:
+    with pytest.raises(ProjectConfigError, match=r"\beffort\b"):
+        _flatten_run_table({"effort": bad})
+    with pytest.raises(ProjectConfigError, match=r"\beffort\b"):
+        _flatten_run_table({"roles": {"executor": {"effort": bad}}})
+
+
+# --- CLI fallback chain ----------------------------------------------------
+
+
+def _args(**overrides: str) -> argparse.Namespace:
+    ns = argparse.Namespace(effort=None)
+    for role in _ROLE_PARENTS:
+        setattr(ns, f"{role}_effort", None)
+    for key, value in overrides.items():
+        setattr(ns, key, value)
+    return ns
+
+
+def test_role_specific_effort_wins() -> None:
+    args = _args(effort="low", gui_executor_effort="high")
+
+    assert _resolve_role_effort(args, "gui_executor") == "high"
+
+
+def test_effort_inherits_down_the_role_chain() -> None:
+    args = _args(executor_effort="med")
+
+    assert _resolve_role_effort(args, "cli_executor") == "med"
+    assert _resolve_role_effort(args, "manager") is None
+
+
+def test_effort_falls_back_to_the_global_flag() -> None:
+    args = _args(effort="min")
+
+    assert _resolve_role_effort(args, "auditor") == "min"
+
+
+def test_effort_defaults_to_backend_default() -> None:
+    assert _resolve_role_effort(_args(), "manager") is None
+
+
+# --- Codex: -c model_reasoning_effort (minimal|low|medium|high|xhigh) ------
+
+
+def test_codex_passes_native_levels_through(tmp_path: Path) -> None:
+    adapter = CodexAdapter(
+        workspace_path=str(tmp_path),
+        prompt_dir=str(tmp_path / "prompts"),
+        effort="xhigh",
+    )
+
+    assert 'model_reasoning_effort="xhigh"' in adapter.command_template
+    assert adapter.effort == "xhigh"
+    assert adapter.effort_effective == "xhigh"
+
+
+def test_codex_maps_max_to_its_top_level(tmp_path: Path) -> None:
+    """Codex documents no "max"; the request lands on xhigh, visibly."""
+
+    adapter = CodexAdapter(
+        workspace_path=str(tmp_path),
+        prompt_dir=str(tmp_path / "prompts"),
+        effort="max",
+    )
+
+    assert 'model_reasoning_effort="xhigh"' in adapter.command_template
+    assert adapter.effort == "max"
+    assert adapter.effort_effective == "xhigh"
+
+
+def test_codex_omits_the_override_without_effort(tmp_path: Path) -> None:
+    adapter = CodexAdapter(
+        workspace_path=str(tmp_path),
+        prompt_dir=str(tmp_path / "prompts"),
+    )
+
+    assert "model_reasoning_effort" not in adapter.command_template
+
+
+def test_codex_rejects_unknown_effort(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="effort"):
+        CodexAdapter(
+            workspace_path=str(tmp_path),
+            prompt_dir=str(tmp_path / "prompts"),
+            effort="ultra",
+        )
+
+
+# --- Claude Code: CLAUDE_CODE_EFFORT_LEVEL (low|medium|high|xhigh|max) -----
+
+
+@pytest.mark.parametrize(
+    ("effort", "level"),
+    [
+        ("min", "low"),  # Claude documents no "min"; floor is low
+        ("low", "low"),
+        ("med", "medium"),
+        ("high", "high"),
+        ("xhigh", "xhigh"),
+        ("max", "max"),
+    ],
+)
+def test_claude_sets_the_effort_level_env(tmp_path: Path, effort: str, level: str) -> None:
+    adapter = ClaudeCodeAdapter(
+        workspace_path=str(tmp_path),
+        prompt_dir=str(tmp_path / "prompts"),
+        effort=effort,
+    )
+
+    assert f"CLAUDE_CODE_EFFORT_LEVEL={level}" in adapter.command_template
+    assert adapter.effort == effort
+    assert adapter.effort_effective == level
+
+
+def test_claude_omits_the_env_without_effort(tmp_path: Path) -> None:
+    adapter = ClaudeCodeAdapter(
+        workspace_path=str(tmp_path),
+        prompt_dir=str(tmp_path / "prompts"),
+    )
+
+    assert "CLAUDE_CODE_EFFORT_LEVEL" not in adapter.command_template
+
+
+def test_claude_rejects_unknown_effort(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="effort"):
+        ClaudeCodeAdapter(
+            workspace_path=str(tmp_path),
+            prompt_dir=str(tmp_path / "prompts"),
+            effort="ultra",
+        )
+
+
+# --- DeepSeek Harness: reasoningEffort patch (low|high|max) ----------------
+
+
+@pytest.mark.parametrize(
+    ("effort", "dsh_level"),
+    [
+        ("min", "low"),
+        ("low", "low"),
+        ("med", "high"),  # DeepSeek's own docs map medium onto high
+        ("high", "high"),
+        ("xhigh", "high"),  # ... and xhigh onto high
+        ("max", "max"),
+    ],
+)
+def test_deepseek_maps_effort_onto_dsh_levels(
+    tmp_path: Path, effort: str, dsh_level: str
+) -> None:
+    adapter = DeepSeekHarnessAdapter(
+        workspace_path=str(tmp_path),
+        prompt_dir=str(tmp_path / "prompts"),
+        effort=effort,
+    )
+
+    assert f"--reasoning-effort {dsh_level}" in adapter.command_template
+    assert adapter.effort == effort
+    assert adapter.effort_effective == dsh_level
+
+
+def test_deepseek_omits_the_flag_without_effort(tmp_path: Path) -> None:
+    adapter = DeepSeekHarnessAdapter(
+        workspace_path=str(tmp_path),
+        prompt_dir=str(tmp_path / "prompts"),
+    )
+
+    assert "--reasoning-effort" not in adapter.command_template
+
+
+def test_deepseek_rejects_unknown_effort(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="effort"):
+        DeepSeekHarnessAdapter(
+            workspace_path=str(tmp_path),
+            prompt_dir=str(tmp_path / "prompts"),
+            effort="ultra",
+        )
+
+
+def test_deepseek_runner_writes_the_effort_patch(tmp_path: Path) -> None:
+    """The profile patch carries the llm-deepseek reasoningEffort override."""
+
+    prompt = tmp_path / "prompt.md"
+    prompt.write_text("hi", encoding="utf-8")
+    binary = tmp_path / "dsh"
+    binary.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    binary.chmod(binary.stat().st_mode | stat.S_IXUSR)
+
+    assert deepseek_runner_run(str(binary), prompt, "deepseek-v4-flash", "max") == 0
+
+    patch = prompt.with_name(f"{prompt.name}.dsh-model-patch.yml").read_text(encoding="utf-8")
+    assert "- id: agent-default-model" in patch
+    assert "- id: llm-deepseek" in patch
+    assert 'reasoningEffort: "max"' in patch
+
+
+def test_deepseek_runner_patch_has_no_effort_entry_by_default(tmp_path: Path) -> None:
+    prompt = tmp_path / "prompt.md"
+    prompt.write_text("hi", encoding="utf-8")
+    binary = tmp_path / "dsh"
+    binary.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    binary.chmod(binary.stat().st_mode | stat.S_IXUSR)
+
+    assert deepseek_runner_run(str(binary), prompt, "deepseek-v4-flash") == 0
+
+    patch = prompt.with_name(f"{prompt.name}.dsh-model-patch.yml").read_text(encoding="utf-8")
+    assert "llm-deepseek" not in patch
+    assert "reasoningEffort" not in patch
+
+
+# --- OpenCode: --variant <preset name> -------------------------------------
+
+
+def test_build_agent_wires_effort_into_opencode_variant(tmp_path: Path) -> None:
+    """The wiring spot where the parameter is renamed (`effort`) must not drift."""
+
+    adapter = _build_agent(
+        "opencode",
+        role="cli_executor",
+        model=None,
+        api_key=None,
+        base_url=None,
+        workspace_path=str(tmp_path),
+        prompt_dir=str(tmp_path / "prompts"),
+        effort="med",
+    )
+
+    assert isinstance(adapter, OpenCodeAdapter)
+    assert "--variant medium" in adapter.command_template
+    assert adapter.effort == "med"
+    assert adapter.effort_effective == "medium"
+
+
+def test_opencode_spells_min_out_to_the_minimal_variant(tmp_path: Path) -> None:
+    """OpenAI-style models ship a "minimal" variant; the scale's "min" maps to it."""
+
+    adapter = OpenCodeAdapter(
+        workspace_path=str(tmp_path),
+        prompt_dir=str(tmp_path / "prompts"),
+        effort="min",
+        role="cli_executor",
+    )
+
+    assert "--variant minimal" in adapter.command_template
+    assert adapter.effort == "min"
+    assert adapter.effort_effective == "minimal"
+
+
+# --- episode metadata ------------------------------------------------------
+
+
+def test_requested_and_effective_effort_land_in_episode_metadata(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    events = "\n".join(
+        json.dumps(event)
+        for event in (
+            {"type": "step_start"},
+            {"type": "text", "text": "done"},
+            {"type": "step_finish"},
+        )
+    )
+    binary = tmp_path / "bin" / "opencode"
+    binary.parent.mkdir(parents=True)
+    binary.write_text(f"#!/bin/sh\ncat >/dev/null\ncat <<'EOF'\n{events}\nEOF\n", encoding="utf-8")
+    binary.chmod(binary.stat().st_mode | stat.S_IXUSR)
+    monkeypatch.setattr(
+        opencode_adapter_module, "resolve_opencode_binary", lambda: str(binary)
+    )
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    adapter = OpenCodeAdapter(
+        workspace_path=str(workspace),
+        prompt_dir=str(tmp_path / "prompts"),
+        effort="med",
+        role="cli_executor",
+    )
+    result = asyncio.run(
+        adapter.run_episode(
+            "complete the task",
+            LocalEnvironment(tmp_dir=str(tmp_path / "tmp")),
+            EpisodeBudget(max_duration_seconds=10),
+        )
+    )
+
+    assert result.metadata["effort"] == "med"
+    assert result.metadata["effort_effective"] == "medium"
+    assert result.metadata["opencode_variant"] == "medium"
+
+
+def test_every_choice_has_a_translation_in_every_backend() -> None:
+    from lh_harness.adapters.claude_code import _CLAUDE_EFFORT_LEVELS
+    from lh_harness.adapters.deepseek_harness import _DSH_EFFORTS
+
+    assert set(_CLAUDE_EFFORT_LEVELS) == set(EFFORT_CHOICES)
+    assert set(_DSH_EFFORTS) == set(EFFORT_CHOICES)
+
+
+# --- web supervisor boundary -----------------------------------------------
+
+
+def test_supervisor_accepts_and_forwards_role_effort(tmp_path: Path) -> None:
+    from lh_harness.supervisor.service import RunSupervisor, _normalise_role_configs
+
+    resolved = _normalise_role_configs(
+        {"auditor": {"agent": "codex", "model": "gpt-test", "effort": "low"}},
+        agent="codex",
+        model="gpt-test",
+    )
+    assert resolved["auditor"]["effort"] == "low"
+    assert "effort" not in resolved["manager"]
+
+    supervisor = RunSupervisor(tmp_path / "runs", workspace_root=tmp_path / "ws")
+    command = supervisor._worker_command(
+        run_id="r1",
+        task="t",
+        agent="codex",
+        model=None,
+        role_configs=resolved,
+        workspace=str(tmp_path / "ws"),
+        max_rounds=5,
+        prompt_language="en",
+    )
+    assert "--auditor-effort=low" in command
+    assert not any("--manager-effort" in item for item in command)
+
+
+def test_supervisor_rejects_bad_role_effort() -> None:
+    from lh_harness.supervisor.service import _normalise_role_configs
+
+    with pytest.raises(ValueError, match="effort must be one of"):
+        _normalise_role_configs(
+            {"executor": {"effort": "ultra"}}, agent="codex", model=None
+        )

--- a/tests/test_effort.py
+++ b/tests/test_effort.py
@@ -1,11 +1,9 @@
-"""Per-role effort: config keys, CLI fallback chain, adapter dials.
+"""Per-role effort: config keys, CLI fallback chain, verbatim backend dials.
 
-The harness exposes one normalized scale — min/low/med/high/xhigh/max,
-covering the union of the levels the backends document — and each adapter
-translates a level into its own documented dial and vocabulary, mapping a
-level its backend lacks to the nearest supported one.  Episode metadata
-records both the requested and the effective value so substitutions stay
-visible.
+Effort values pass through to each backend verbatim — no cross-backend
+mapping.  Each backend accepts exactly the levels it documents and rejects
+the rest, so an operator can never believe a run used a depth the backend
+silently substituted.
 """
 
 import argparse
@@ -25,7 +23,7 @@ from lh_harness.adapters.opencode import OpenCodeAdapter
 from lh_harness.cli import _ROLE_PARENTS, _build_agent, _resolve_role_effort
 from lh_harness.config import ProjectConfigError, _flatten_run_table
 from lh_harness.environment.local import LocalEnvironment
-from lh_harness.types import EpisodeBudget, EFFORT_CHOICES
+from lh_harness.types import BACKEND_EFFORT_LEVELS, EFFORT_CHOICES, EpisodeBudget
 
 
 # --- config ----------------------------------------------------------------
@@ -57,6 +55,11 @@ def test_config_rejects_unknown_effort_values(bad: object) -> None:
         _flatten_run_table({"roles": {"executor": {"effort": bad}}})
 
 
+def test_union_choices_cover_every_backend_level() -> None:
+    for backend, levels in BACKEND_EFFORT_LEVELS.items():
+        assert set(levels) <= set(EFFORT_CHOICES), backend
+
+
 # --- CLI fallback chain ----------------------------------------------------
 
 
@@ -76,49 +79,45 @@ def test_role_specific_effort_wins() -> None:
 
 
 def test_effort_inherits_down_the_role_chain() -> None:
-    args = _args(executor_effort="med")
+    args = _args(executor_effort="medium")
 
-    assert _resolve_role_effort(args, "cli_executor") == "med"
+    assert _resolve_role_effort(args, "cli_executor") == "medium"
     assert _resolve_role_effort(args, "manager") is None
 
 
 def test_effort_falls_back_to_the_global_flag() -> None:
-    args = _args(effort="min")
+    args = _args(effort="minimal")
 
-    assert _resolve_role_effort(args, "auditor") == "min"
+    assert _resolve_role_effort(args, "auditor") == "minimal"
 
 
 def test_effort_defaults_to_backend_default() -> None:
     assert _resolve_role_effort(_args(), "manager") is None
 
 
-# --- Codex: -c model_reasoning_effort (minimal|low|medium|high|xhigh) ------
+# --- Codex: -c model_reasoning_effort --------------------------------------
 
 
-def test_codex_passes_native_levels_through(tmp_path: Path) -> None:
+@pytest.mark.parametrize("level", BACKEND_EFFORT_LEVELS["codex"])
+def test_codex_passes_its_levels_verbatim(tmp_path: Path, level: str) -> None:
     adapter = CodexAdapter(
         workspace_path=str(tmp_path),
         prompt_dir=str(tmp_path / "prompts"),
-        effort="xhigh",
+        effort=level,
     )
 
-    assert 'model_reasoning_effort="xhigh"' in adapter.command_template
-    assert adapter.effort == "xhigh"
-    assert adapter.effort_effective == "xhigh"
+    assert f'model_reasoning_effort="{level}"' in adapter.command_template
+    assert adapter.effort == level
 
 
-def test_codex_maps_max_to_its_top_level(tmp_path: Path) -> None:
-    """Codex documents no "max"; the request lands on xhigh, visibly."""
-
-    adapter = CodexAdapter(
-        workspace_path=str(tmp_path),
-        prompt_dir=str(tmp_path / "prompts"),
-        effort="max",
-    )
-
-    assert 'model_reasoning_effort="xhigh"' in adapter.command_template
-    assert adapter.effort == "max"
-    assert adapter.effort_effective == "xhigh"
+@pytest.mark.parametrize("level", ["max", "none", "ultra"])
+def test_codex_rejects_levels_it_does_not_document(tmp_path: Path, level: str) -> None:
+    with pytest.raises(ValueError, match="effort must be one of"):
+        CodexAdapter(
+            workspace_path=str(tmp_path),
+            prompt_dir=str(tmp_path / "prompts"),
+            effort=level,
+        )
 
 
 def test_codex_omits_the_override_without_effort(tmp_path: Path) -> None:
@@ -130,39 +129,29 @@ def test_codex_omits_the_override_without_effort(tmp_path: Path) -> None:
     assert "model_reasoning_effort" not in adapter.command_template
 
 
-def test_codex_rejects_unknown_effort(tmp_path: Path) -> None:
-    with pytest.raises(ValueError, match="effort"):
-        CodexAdapter(
-            workspace_path=str(tmp_path),
-            prompt_dir=str(tmp_path / "prompts"),
-            effort="ultra",
-        )
+# --- Claude Code: CLAUDE_CODE_EFFORT_LEVEL ----------------------------------
 
 
-# --- Claude Code: CLAUDE_CODE_EFFORT_LEVEL (low|medium|high|xhigh|max) -----
-
-
-@pytest.mark.parametrize(
-    ("effort", "level"),
-    [
-        ("min", "low"),  # Claude documents no "min"; floor is low
-        ("low", "low"),
-        ("med", "medium"),
-        ("high", "high"),
-        ("xhigh", "xhigh"),
-        ("max", "max"),
-    ],
-)
-def test_claude_sets_the_effort_level_env(tmp_path: Path, effort: str, level: str) -> None:
+@pytest.mark.parametrize("level", BACKEND_EFFORT_LEVELS["claude_code"])
+def test_claude_passes_its_levels_verbatim(tmp_path: Path, level: str) -> None:
     adapter = ClaudeCodeAdapter(
         workspace_path=str(tmp_path),
         prompt_dir=str(tmp_path / "prompts"),
-        effort=effort,
+        effort=level,
     )
 
     assert f"CLAUDE_CODE_EFFORT_LEVEL={level}" in adapter.command_template
-    assert adapter.effort == effort
-    assert adapter.effort_effective == level
+    assert adapter.effort == level
+
+
+@pytest.mark.parametrize("level", ["minimal", "none", "ultra"])
+def test_claude_rejects_levels_it_does_not_document(tmp_path: Path, level: str) -> None:
+    with pytest.raises(ValueError, match="effort must be one of"):
+        ClaudeCodeAdapter(
+            workspace_path=str(tmp_path),
+            prompt_dir=str(tmp_path / "prompts"),
+            effort=level,
+        )
 
 
 def test_claude_omits_the_env_without_effort(tmp_path: Path) -> None:
@@ -174,41 +163,29 @@ def test_claude_omits_the_env_without_effort(tmp_path: Path) -> None:
     assert "CLAUDE_CODE_EFFORT_LEVEL" not in adapter.command_template
 
 
-def test_claude_rejects_unknown_effort(tmp_path: Path) -> None:
-    with pytest.raises(ValueError, match="effort"):
-        ClaudeCodeAdapter(
-            workspace_path=str(tmp_path),
-            prompt_dir=str(tmp_path / "prompts"),
-            effort="ultra",
-        )
+# --- DeepSeek Harness: reasoningEffort profile patch ------------------------
 
 
-# --- DeepSeek Harness: reasoningEffort patch (low|high|max) ----------------
-
-
-@pytest.mark.parametrize(
-    ("effort", "dsh_level"),
-    [
-        ("min", "low"),
-        ("low", "low"),
-        ("med", "high"),  # DeepSeek's own docs map medium onto high
-        ("high", "high"),
-        ("xhigh", "high"),  # ... and xhigh onto high
-        ("max", "max"),
-    ],
-)
-def test_deepseek_maps_effort_onto_dsh_levels(
-    tmp_path: Path, effort: str, dsh_level: str
-) -> None:
+@pytest.mark.parametrize("level", BACKEND_EFFORT_LEVELS["deepseek_harness"])
+def test_deepseek_passes_its_levels_verbatim(tmp_path: Path, level: str) -> None:
     adapter = DeepSeekHarnessAdapter(
         workspace_path=str(tmp_path),
         prompt_dir=str(tmp_path / "prompts"),
-        effort=effort,
+        effort=level,
     )
 
-    assert f"--reasoning-effort {dsh_level}" in adapter.command_template
-    assert adapter.effort == effort
-    assert adapter.effort_effective == dsh_level
+    assert f"--reasoning-effort {level}" in adapter.command_template
+    assert adapter.effort == level
+
+
+@pytest.mark.parametrize("level", ["minimal", "medium", "xhigh", "ultra"])
+def test_deepseek_rejects_levels_it_does_not_document(tmp_path: Path, level: str) -> None:
+    with pytest.raises(ValueError, match="effort must be one of"):
+        DeepSeekHarnessAdapter(
+            workspace_path=str(tmp_path),
+            prompt_dir=str(tmp_path / "prompts"),
+            effort=level,
+        )
 
 
 def test_deepseek_omits_the_flag_without_effort(tmp_path: Path) -> None:
@@ -218,15 +195,6 @@ def test_deepseek_omits_the_flag_without_effort(tmp_path: Path) -> None:
     )
 
     assert "--reasoning-effort" not in adapter.command_template
-
-
-def test_deepseek_rejects_unknown_effort(tmp_path: Path) -> None:
-    with pytest.raises(ValueError, match="effort"):
-        DeepSeekHarnessAdapter(
-            workspace_path=str(tmp_path),
-            prompt_dir=str(tmp_path / "prompts"),
-            effort="ultra",
-        )
 
 
 def test_deepseek_runner_writes_the_effort_patch(tmp_path: Path) -> None:
@@ -260,7 +228,7 @@ def test_deepseek_runner_patch_has_no_effort_entry_by_default(tmp_path: Path) ->
     assert "reasoningEffort" not in patch
 
 
-# --- OpenCode: --variant <preset name> -------------------------------------
+# --- OpenCode: --variant <preset name> --------------------------------------
 
 
 def test_build_agent_wires_effort_into_opencode_variant(tmp_path: Path) -> None:
@@ -274,34 +242,29 @@ def test_build_agent_wires_effort_into_opencode_variant(tmp_path: Path) -> None:
         base_url=None,
         workspace_path=str(tmp_path),
         prompt_dir=str(tmp_path / "prompts"),
-        effort="med",
+        effort="medium",
     )
 
     assert isinstance(adapter, OpenCodeAdapter)
     assert "--variant medium" in adapter.command_template
-    assert adapter.effort == "med"
-    assert adapter.effort_effective == "medium"
+    assert adapter.effort == "medium"
 
 
-def test_opencode_spells_min_out_to_the_minimal_variant(tmp_path: Path) -> None:
-    """OpenAI-style models ship a "minimal" variant; the scale's "min" maps to it."""
-
+def test_opencode_passes_custom_variant_names_verbatim(tmp_path: Path) -> None:
     adapter = OpenCodeAdapter(
         workspace_path=str(tmp_path),
         prompt_dir=str(tmp_path / "prompts"),
-        effort="min",
+        effort="my-custom-variant",
         role="cli_executor",
     )
 
-    assert "--variant minimal" in adapter.command_template
-    assert adapter.effort == "min"
-    assert adapter.effort_effective == "minimal"
+    assert "--variant my-custom-variant" in adapter.command_template
 
 
-# --- episode metadata ------------------------------------------------------
+# --- episode metadata -------------------------------------------------------
 
 
-def test_requested_and_effective_effort_land_in_episode_metadata(
+def test_requested_effort_lands_in_episode_metadata(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     events = "\n".join(
@@ -325,7 +288,7 @@ def test_requested_and_effective_effort_land_in_episode_metadata(
     adapter = OpenCodeAdapter(
         workspace_path=str(workspace),
         prompt_dir=str(tmp_path / "prompts"),
-        effort="med",
+        effort="medium",
         role="cli_executor",
     )
     result = asyncio.run(
@@ -336,20 +299,11 @@ def test_requested_and_effective_effort_land_in_episode_metadata(
         )
     )
 
-    assert result.metadata["effort"] == "med"
-    assert result.metadata["effort_effective"] == "medium"
+    assert result.metadata["effort"] == "medium"
     assert result.metadata["opencode_variant"] == "medium"
 
 
-def test_every_choice_has_a_translation_in_every_backend() -> None:
-    from lh_harness.adapters.claude_code import _CLAUDE_EFFORT_LEVELS
-    from lh_harness.adapters.deepseek_harness import _DSH_EFFORTS
-
-    assert set(_CLAUDE_EFFORT_LEVELS) == set(EFFORT_CHOICES)
-    assert set(_DSH_EFFORTS) == set(EFFORT_CHOICES)
-
-
-# --- web supervisor boundary -----------------------------------------------
+# --- web supervisor boundary ------------------------------------------------
 
 
 def test_supervisor_accepts_and_forwards_role_effort(tmp_path: Path) -> None:
@@ -378,26 +332,37 @@ def test_supervisor_accepts_and_forwards_role_effort(tmp_path: Path) -> None:
     assert not any("--manager-effort" in item for item in command)
 
 
-def test_supervisor_rejects_bad_role_effort() -> None:
+def test_supervisor_validates_effort_against_the_role_backend() -> None:
     from lh_harness.supervisor.service import _normalise_role_configs
 
+    # "max" is a Claude level, not a Codex one - no silent substitution.
     with pytest.raises(ValueError, match="effort must be one of"):
         _normalise_role_configs(
-            {"executor": {"effort": "ultra"}}, agent="codex", model=None
+            {"executor": {"agent": "codex", "effort": "max"}}, agent="codex", model=None
         )
+    # ... but it is valid verbatim on a Claude role.
+    resolved = _normalise_role_configs(
+        {"executor": {"agent": "claude_code", "effort": "max"}}, agent="codex", model=None
+    )
+    assert resolved["executor"]["effort"] == "max"
+    # OpenCode variants are per-model names; only their shape is checked.
+    resolved = _normalise_role_configs(
+        {"executor": {"agent": "opencode", "effort": "my-variant"}}, agent="codex", model=None
+    )
+    assert resolved["executor"]["effort"] == "my-variant"
 
 
-def test_snapshot_provenance_keeps_valid_role_effort() -> None:
+def test_snapshot_provenance_keeps_role_effort() -> None:
     from lh_harness.webapi.snapshot import _safe_role_configs
 
     cleaned = _safe_role_configs(
         {
             "manager": {"agent": "codex", "model": "m", "effort": "high"},
-            "executor": {"agent": "codex", "model": "m", "effort": "bogus"},
-            "auditor": {"agent": "codex", "model": "m"},
+            "executor": {"agent": "opencode", "model": "m", "effort": "my-variant"},
+            "auditor": {"agent": "codex", "model": "m", "effort": "x" * 65},
         }
     )
 
     assert cleaned["manager"]["effort"] == "high"
-    assert "effort" not in cleaned["executor"]
+    assert cleaned["executor"]["effort"] == "my-variant"
     assert "effort" not in cleaned["auditor"]


### PR DESCRIPTION
Closes #38.

The harness discovered models' supported reasoning efforts (`model_catalog`) but offered no way to set one. This PR adds an `effort` setting whose value is **the model's own depth-of-thought level, passed to the backend verbatim** — no cross-backend mapping or substitution.

## Usage

Globally, per role, or per run, resolving down the same fallback chain as `--<role>-agent` / `--<role>-model`:

```toml
[run]
effort = "medium"

[run.roles.manager]
effort = "high"       # a role's own effort outranks [run].effort
```

```bash
lh-harness run --task "..." --effort medium --auditor-effort low
```

The generated config ships `effort = "medium"` in `[run]` and a commented `# effort = "medium"` in every role section.

## Per-backend dials

Each backend accepts exactly the levels it documents and rejects anything else with a clear error naming the valid set:

| Backend | Dial | Accepted levels |
|---|---|---|
| Codex | `-c model_reasoning_effort=` | `minimal`, `low`, `medium`, `high`, `xhigh` |
| Claude Code | `CLAUDE_CODE_EFFORT_LEVEL` env (outranks a session's `/effort`) | `low`, `medium`, `high`, `xhigh`, `max` |
| DeepSeek Harness | `reasoningEffort` in the dsh profile patch the runner already writes | `low`, `high`, `max` |
| OpenCode | `--variant` | the model's variant presets; custom names from `opencode.jsonc` pass through |

`BACKEND_EFFORT_LEVELS` in `types.py` is the single source of those sets. Every entry point behaves the same way: the CLI, the config file, and the Web API all accept any well-formed name and the value is judged once, at the role → backend boundary, by the backend it is addressed to. That keeps OpenCode's user-defined variant names usable from every entry point while a typo on the other backends still fails fast with the list of valid levels. The requested level is recorded in every episode's metadata (`effort`).

## Web workbench

- **Run creation**: each role card gains an *Effort* select offering the selected model's own discovered levels (model catalogue `reasoning_efforts`), falling back to the backend's documented set.
- **Run details**: a role-binding strip shows each role's model with its effort as a badge, from the durable `owner.json` `role_configs`.

## Practical tests

Real full MEA runs to completion (task executed, audited, verified) on three backends:

- **claude_code** (`--effort low`): all 10 spawned episodes carried `CLAUDE_CODE_EFFORT_LEVEL=low` in their commands and `"effort": "low"` in metadata; an unsupported level (`--effort minimal`) fails at agent setup: `Claude Code effort must be one of low, medium, high, xhigh, max`.
- **deepseek_harness** (`@deepseek-ai/dsh` 0.1.0-rc.7, real DeepSeek API, `--effort high`): all 12 episodes carried `--reasoning-effort high`; every on-disk profile patch contains `reasoningEffort: "high"`, and `dsh --dump-config` confirms it merges into the `llm-deepseek` plugin config; `--effort medium` fails at agent setup with `DeepSeek Harness effort must be one of low, high, max`.
- **opencode** (1.18.19, real DeepSeek API, `--effort high` resolving to a custom variant `high = { reasoningEffort: "high" }` in the workspace `opencode.jsonc`): all 10 episodes carried `--variant high` and `"effort": "high"` / `"opencode_variant": "high"` in metadata. A request-capturing endpoint confirmed the variant's options land in the API request body as `"reasoning_effort"`. Note: OpenCode itself silently ignores a variant name the model does not define (no error) — upstream behavior, outside this harness.
- **opencode with a fully custom variant name** (`--effort deep`, defined only in the workspace `opencode.jsonc`): full MEA run from the CLI to completion — all 14 episodes carried `--variant deep` and `"effort": "deep"` in metadata, while `--agent claude_code --effort deep` still fails at agent setup naming the valid levels.

## Docs & tests

- README.md / README.zh-CN.md: `effort` row in the `[run]` table, updated `[run.roles.*]` fallback chain, and an "Effort levels" subsection with the per-backend table.
- Python suite on current `main` with the frontend bundle built: **281 passed, 1 skipped**; frontend core suite: 47 passed; `tsc`/vite build clean.
