### PR TITLE
docs: document guard_exclude_paths, trim its config comment, fix max_rounds default

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,9 +339,12 @@ Task text, run IDs, and API keys are deliberately **not** configurable here; the
 | `claude_mcp_config` | commented out | Path to a `.mcp.json` for Claude Code. Overrides the installed plugin. |
 | `codex_mcp_config` | commented out | Path to a `[mcp_servers.*]` TOML for Codex. Overrides the installed plugin. |
 | `mcp_add_dirs` | `[]` | Extra directories the MCP server may read. Claude Code rejects these, because its role isolation requires task files to live inside the workspace. |
+| `guard_exclude_paths` | `[]` | Workspace paths the auditor's read-only guard skips while snapshotting: build outputs and caches that churn on their own, such as `["target", "node_modules", ".venv"]`. Agents keep full access to them. |
 | `max_rounds` | `30` | Upper bound on Manage-Execute-Audit rounds before the run stops. |
 | `dashboard` | `true` | Start the web dashboard with each run. |
 | `dashboard_port` | `0` | Dashboard port; `0` lets the OS pick a free one. |
+
+Every entry in `guard_exclude_paths` is a hole in the audit: the guard is the only witness of workspace mutations, and the agents keep reading and writing an excluded path through Bash. Exclude build outputs, never source. Paths resolve against the workspace and must stay inside it; `.git` and the harness's own control and state directories are rejected, and the run refuses to start on the first violation. The effective list is printed at run start and recorded in every audited episode's metadata as `verifier_guard_exclude_paths`. The matching CLI flag, `--guard-exclude-path`, may be repeated, and a single use of it replaces the configured list rather than adding to it.
 
 ##### `[run.timeouts]`
 

--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ Task text, run IDs, and API keys are deliberately **not** configurable here; the
 | `codex_mcp_config` | commented out | Path to a `[mcp_servers.*]` TOML for Codex. Overrides the installed plugin. |
 | `mcp_add_dirs` | `[]` | Extra directories the MCP server may read. Claude Code rejects these, because its role isolation requires task files to live inside the workspace. |
 | `guard_exclude_paths` | `[]` | Workspace paths the auditor's read-only guard skips while snapshotting: build outputs and caches that churn on their own, such as `["target", "node_modules", ".venv"]`. Agents keep full access to them. |
-| `max_rounds` | `30` | Upper bound on Manage-Execute-Audit rounds before the run stops. |
+| `max_rounds` | `25` | Upper bound on Manage-Execute-Audit rounds before the run stops. |
 | `dashboard` | `true` | Start the web dashboard with each run. |
 | `dashboard_port` | `0` | Dashboard port; `0` lets the OS pick a free one. |
 
@@ -496,7 +496,7 @@ lh-harness web --workspace-root .               # Serve the workbench for anothe
 | `--task` | Task text or `@task.md` |
 | `--agent` | `claude_code`, `codex`, `opencode`, or `deepseek_harness` (CLI-only in phase 1) |
 | `--env` | `local` |
-| `--max-rounds` | Maximum number of Manage-Execute-Audit rounds; the CLI default is 30 |
+| `--max-rounds` | Maximum number of Manage-Execute-Audit rounds; the CLI default is 25 |
 | `--dashboard` | Start live monitoring and human intervention |
 | `--no-dashboard` | Disable a Dashboard enabled by the project configuration |
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -341,7 +341,7 @@ lh-harness check-update
 | `codex_mcp_config` | 默认注释 | Codex 用的 `[mcp_servers.*]` TOML 路径，会覆盖已安装的插件。 |
 | `mcp_add_dirs` | `[]` | 额外允许 MCP server 读取的目录。Claude Code 会拒绝该项，因为其角色隔离要求任务文件必须放在工作目录内。 |
 | `guard_exclude_paths` | `[]` | Auditor 只读 guard 在快照时跳过的工作区路径，用于会自行变动的构建产物和缓存，例如 `["target", "node_modules", ".venv"]`。Agent 仍可正常访问这些路径。 |
-| `max_rounds` | `30` | Manage-Execute-Audit 循环的最大轮数，达到即停止。 |
+| `max_rounds` | `25` | Manage-Execute-Audit 循环的最大轮数，达到即停止。 |
 | `dashboard` | `true` | 每次运行时启动 Web Dashboard。 |
 | `dashboard_port` | `0` | Dashboard 端口，`0` 表示由系统分配空闲端口。 |
 
@@ -497,7 +497,7 @@ lh-harness web --workspace-root .               # 为指定目录启动工作台
 | `--task` | 任务文本或 `@task.md` |
 | `--agent` | `claude_code`、`codex`、`opencode` 或 `deepseek_harness`（第一阶段仅 CLI） |
 | `--env` | `local` |
-| `--max-rounds` | Manage-Execute-Audit 循环的最大轮数；CLI 默认为 30 |
+| `--max-rounds` | Manage-Execute-Audit 循环的最大轮数；CLI 默认为 25 |
 | `--dashboard` | 启动实时监控和人工介入功能 |
 | `--no-dashboard` | 关闭项目配置中默认启用的 Dashboard |
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -340,9 +340,12 @@ lh-harness check-update
 | `claude_mcp_config` | 默认注释 | Claude Code 用的 `.mcp.json` 路径，会覆盖已安装的插件。 |
 | `codex_mcp_config` | 默认注释 | Codex 用的 `[mcp_servers.*]` TOML 路径，会覆盖已安装的插件。 |
 | `mcp_add_dirs` | `[]` | 额外允许 MCP server 读取的目录。Claude Code 会拒绝该项，因为其角色隔离要求任务文件必须放在工作目录内。 |
+| `guard_exclude_paths` | `[]` | Auditor 只读 guard 在快照时跳过的工作区路径，用于会自行变动的构建产物和缓存，例如 `["target", "node_modules", ".venv"]`。Agent 仍可正常访问这些路径。 |
 | `max_rounds` | `30` | Manage-Execute-Audit 循环的最大轮数，达到即停止。 |
 | `dashboard` | `true` | 每次运行时启动 Web Dashboard。 |
 | `dashboard_port` | `0` | Dashboard 端口，`0` 表示由系统分配空闲端口。 |
+
+`guard_exclude_paths` 中的每一项都是审计的缺口：guard 是工作区改动的唯一见证者，而被排除的路径 Agent 仍可通过 Bash 读写。只排除构建产物，不要排除源码。路径相对工作目录解析并且必须留在工作目录内；`.git` 以及 Harness 自身的控制与状态目录会被拒绝，遇到第一个违规项时运行直接终止。最终生效的列表会在运行开始时打印，并记录在每个审计 episode 的 metadata 字段 `verifier_guard_exclude_paths` 中。对应的 CLI 参数 `--guard-exclude-path` 可重复传入；只要用了它，就会替换配置中的列表，而不是在其基础上追加。
 
 ##### `[run.timeouts]`
 

--- a/src/lh_harness/config.py
+++ b/src/lh_harness/config.py
@@ -85,12 +85,9 @@ prompt_language = "en"
 # codex_mcp_config = "/path/to/mcp.toml"
 mcp_add_dirs = []
 
-# Build/cache directories the auditor read-only guard should not snapshot,
-# e.g. ["target", "node_modules", "build", ".venv"]. Agents can still read
-# them. Exclusions must stay inside the workspace; ".git" and harness-owned
-# control/state paths are rejected at startup, and the effective list is
-# echoed at run start and recorded in each audited episode's metadata.
-# Passing --guard-exclude-path replaces this list rather than adding to it.
+# Build/cache directories the auditor guard skips while snapshotting, e.g.
+# ["target", "node_modules", ".venv"]. Agents can still read them.
+# --guard-exclude-path replaces this list rather than adding to it.
 guard_exclude_paths = []
 
 max_rounds = 25


### PR DESCRIPTION
`guard_exclude_paths` landed in #28, but neither README mentions it, so the only description of the setting is the comment in the generated config — and that comment now runs six lines, five of which restate validation rules an operator cannot act on while editing the file.

Rebased onto 0.1.7.

### Trim the config template comment

`CONFIG_TEMPLATE` keeps the part that helps at the point of edit — what the key is for, a concrete example, that agents still read excluded paths, and the replace semantics added in #56 — matching the one-to-three-line comments on the surrounding keys. The validation rules move to the README.

### Document the setting in both READMEs

A `[run]` table row plus a paragraph under the table, in `README.md` and `README.zh-CN.md`, covering what the comment no longer says:

- every exclusion is a hole in the audit, since the guard is the only witness of workspace mutations and the agents keep Bash access to the excluded path;
- exclusions resolve against the workspace and must stay inside it, and `.git` and harness-owned control/state paths are rejected at startup, with the run refusing to start on the first violation;
- the effective list is echoed at run start and recorded per audited episode as `verifier_guard_exclude_paths`;
- `--guard-exclude-path` is repeatable and replaces the configured list rather than adding to it, per `_apply_repeatable_defaults`.

### Correct the documented `max_rounds` default

Both READMEs advertise `30` in the `[run]` table and in the CLI options list, while `DEFAULT_MAX_ROUNDS`, the config template, and `lh-harness run --help` all say `25`.

---

Documentation only — no behavior change. `pytest`: 404 passed, 2 skipped.
