### PR TITLE
修复 Windows 兼容：控制总线、shell 引号与进程组处理

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install package with test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[test]"
+      - name: Run test suite
+        # pytest-timeout guards against platform-specific hangs; the thread
+        # method is the only one available on Windows.
+        run: pytest tests -q --timeout=120 --timeout-method=thread

--- a/README.md
+++ b/README.md
@@ -520,6 +520,12 @@ Every run is stored in an isolated `runs/<run-id>/` directory. The complete task
 | 📁 **Workspace** | Files and artifacts produced during execution |
 | ✅ **Final report** | The verified outcome of the task |
 
+## Windows Notes
+
+Windows is supported (CI runs the full suite on \windows-latest\). Console
+encoding, Store-installed CLI aliases, proxy quirks and GUI-session
+requirements are collected in [docs/windows-troubleshooting.md](docs/windows-troubleshooting.md).
+
 ## Evaluation Reproduction
 
 `eval/` provides frozen reproduction suites for three benchmarks:

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -521,6 +521,12 @@ Dashboard 会展示每一轮的任务规划、执行结果、审计证据和返�
 | 📁 **工作区** | 执行过程中产生的文件和交付物 |
 | ✅ **最终报告** | 经过验证的任务结果 |
 
+## Windows 说明
+
+Windows 已支持（CI 含 \windows-latest\ 全量测试矩阵）。控制台编码、Store
+版 CLI 别名、代理与 GUI 会话等注意事项见
+[docs/windows-troubleshooting.md](docs/windows-troubleshooting.md)。
+
 ## 评测复现
 
 `eval/` 提供三个固定版本的评测复现套件：

--- a/docs/windows-troubleshooting.md
+++ b/docs/windows-troubleshooting.md
@@ -1,0 +1,59 @@
+# Windows 排障指南
+
+LongHorizon-Harness 在 Windows 上可完整运行（本仓库 CI 含 `windows-latest` 矩阵），
+但 Windows 生态有几个已知坑。按症状排查：
+
+## `lh-harness` 命令找不到
+
+`uv tool install` 装到 `%USERPROFILE%\.local\bin`，安装器会提示并自动加入 PATH，
+但**当前已打开的终端不会生效**。重开终端，或手动：
+
+```powershell
+$env:PATH = "$env:USERPROFILE\.local\bin;$env:PATH"
+```
+
+## 控制台中文乱码
+
+harness 的持久化产物（report.json / events.jsonl / 轨迹）全部是 UTF-8。v0.1.7+
+的 CLI 在 Windows 上会自动把 stdout/stderr 切到 UTF-8 并将控制台输出码页切至
+65001，正常终端不再乱码。若你仍在自解析输出：
+
+- 读取产物文件时**显式指定 UTF-8**（PowerShell 5.1 的 `Get-Content` 默认按
+  ANSI/GBK 解码，是绝大多数"文件乱码"的真相）；
+- 或运行前 `$env:PYTHONUTF8 = "1"`。
+
+## Codex CLI 装了但 doctor 判 FAIL
+
+从 Microsoft Store 安装 Codex 桌面应用后，PATH 上会留下一个 **0 字节的
+`codex.exe` 别名**——那不是 CLI。`lh-harness doctor` 会实际执行
+`codex --version` 验证，因此能识别。修复：卸载 Store 别名或安装 npm 版
+`@openai/codex`。
+
+## GUI（computer-use）任务
+
+- 必须在**已登录的桌面会话**中运行 harness，不要以管理员身份运行服务类进程；
+- Windows 上无需 macOS 式手动授权，但 UI Automation 要求真实桌面会话；
+- 纯 CLI 任务不受影响。
+
+## 访问 GitHub / PyPI 网络超时
+
+`doctor` 与 `check-update` 会访问 api.github.com。若直连不稳：
+
+- 为 git 配置代理：`git config --global http.proxy http://127.0.0.1:<port>`
+- 环境变量方式：`$env:HTTPS_PROXY = "http://127.0.0.1:<port>"`
+- 注意部分代理对 Go 程序（gh CLI）的 TLS 握手不稳定，git/curl 通常没问题。
+
+## 免费网关模型限流
+
+`opencode/*-free` 系列模型有速率限制。长任务（多轮 × 3 角色）撞限流时，
+harness 会按"可恢复超时"自动重试，但表现为 executor 单集耗时变长。
+对时限敏感的任务换用付费端点。
+
+## 测试套件
+
+```powershell
+pip install -e ".[test]"
+pytest tests -q
+```
+
+Windows 上无需额外依赖；`pytest-timeout` 建议一并安装以防个别用例挂死。

--- a/src/lh_harness/adapters/claude_code.py
+++ b/src/lh_harness/adapters/claude_code.py
@@ -23,6 +23,7 @@ from ..types import (
     EpisodeBudget,
     EpisodeResult,
 )
+from ..utils.platform_shell import env_prefix, shell_quote
 from .cli_agent import CommandAgentAdapter
 
 
@@ -44,21 +45,20 @@ class ClaudeCodeAdapter(CommandAgentAdapter):
     ) -> None:
         policy = policy_for_role(role)
         effort = normalise_reasoning_effort(reasoning_effort)
-        env_parts: list[str] = []
+        env_assignments: list[tuple[str, str]] = []
         if api_key:
-            quoted_key = shlex.quote(api_key)
-            env_parts.append(f"ANTHROPIC_API_KEY={quoted_key}")
-            env_parts.append(f"ANTHROPIC_AUTH_TOKEN={quoted_key}")
+            env_assignments.append(("ANTHROPIC_API_KEY", api_key))
+            env_assignments.append(("ANTHROPIC_AUTH_TOKEN", api_key))
         if base_url:
             raw_url = base_url.rstrip("/")
             if raw_url.endswith("/v1"):
                 raw_url = raw_url[:-3]
-            env_parts.append(f"ANTHROPIC_BASE_URL={shlex.quote(raw_url)}")
-        env_parts.extend(
+            env_assignments.append(("ANTHROPIC_BASE_URL", raw_url))
+        env_assignments.extend(
             [
-                "CLAUDE_CODE_DISABLE_AUTO_MEMORY=1",
-                "CLAUDE_CODE_SKIP_PROMPT_HISTORY=1",
-                f"LH_HARNESS_CLAUDE_ROLE={shlex.quote(role)}",
+                ("CLAUDE_CODE_DISABLE_AUTO_MEMORY", "1"),
+                ("CLAUDE_CODE_SKIP_PROMPT_HISTORY", "1"),
+                ("LH_HARNESS_CLAUDE_ROLE", role),
             ]
         )
 
@@ -82,15 +82,15 @@ class ClaudeCodeAdapter(CommandAgentAdapter):
             )
 
         if is_auditor_role(role):
-            env_parts.extend(
+            env_assignments.extend(
                 [
-                    "GIT_OPTIONAL_LOCKS=0",
-                    "GIT_PAGER=cat",
-                    "PAGER=cat",
+                    ("GIT_OPTIONAL_LOCKS", "0"),
+                    ("GIT_PAGER", "cat"),
+                    ("PAGER", "cat"),
                 ]
             )
 
-        env_prefix = (" ".join(env_parts) + " ") if env_parts else ""
+        env_prefix_text = env_prefix(env_assignments)
         command_parts = [
             "claude",
             "--print",
@@ -102,15 +102,15 @@ class ClaudeCodeAdapter(CommandAgentAdapter):
         deny_tools = [*policy.disallowed_tools, *path_deny_rules(hidden_paths)]
         if deny_tools:
             command_parts.append("--disallowedTools")
-            command_parts.extend(shlex.quote(tool) for tool in deny_tools)
+            command_parts.extend(shell_quote(tool) for tool in deny_tools)
         self.computer_mcp_configured = bool(policy.load_computer_mcp and mcp_config)
         if self.computer_mcp_configured:
-            command_parts.extend(["--mcp-config", shlex.quote(mcp_config)])
-        command_parts.extend(["--model", shlex.quote(model)])
+            command_parts.extend(["--mcp-config", shell_quote(mcp_config)])
+        command_parts.extend(["--model", shell_quote(model)])
         # Claude Code warns and continues at its default when the value is not
         # one it knows, so an unusable effort will not fail the run here.
         if effort:
-            command_parts.extend(["--effort", shlex.quote(effort)])
+            command_parts.extend(["--effort", shell_quote(effort)])
 
         self.role = role
         self.policy = policy
@@ -120,7 +120,7 @@ class ClaudeCodeAdapter(CommandAgentAdapter):
         # legitimately churn (build outputs) during an audit window.
         self.guard_exclude_paths = tuple(guard_exclude_paths)
         super().__init__(
-            command_template=f"{env_prefix}{' '.join(command_parts)} < {{prompt_path}}",
+            command_template=f"{env_prefix_text}{' '.join(command_parts)} < {{prompt_path}}",
             prompt_dir=prompt_dir,
             workspace_path=workspace_path,
             visible_output_parser=extract_claude_visible_output,

--- a/src/lh_harness/adapters/cli_agent.py
+++ b/src/lh_harness/adapters/cli_agent.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import posixpath
 import re
+import posixpath
 import shlex
 import time
 import uuid
@@ -10,6 +10,7 @@ from pathlib import PurePath
 
 from ..environment.base import Environment
 from ..environment.remote_files import write_remote_text
+from ..agent_logs import token_usage as parse_token_usage
 from ..runtime_signals import detect_runtime_signals
 from ..types import DEFAULT_TMP_DIR, DEFAULT_WORKSPACE_PATH, EpisodeBudget, EpisodeResult
 from ..utils.platform_shell import cd_command, shell_quote
@@ -96,27 +97,34 @@ class CommandAgentAdapter:
             error = f"Episode timed out after {budget.max_duration_seconds}s."
         else:
             error = redact_secrets(result.stderr[-2000:]) if result.exit_code != 0 else None
+        try:
+            token_usage = parse_token_usage(stdout_log)
+        except (OSError, ValueError):
+            token_usage = {}
+        metadata = {
+            "command": redact_secrets(command),
+            "workspace": self.workspace_path,
+            "prompt_path": prompt_path,
+            "exit_code": result.exit_code,
+            "termination_reason": result.termination_reason,
+            "actions_log_chars": len(actions_log),
+            "trajectory_format": "jsonl",
+            "assistant_visible_output": visible_output,
+            "runtime_signals": runtime_signals,
+            "actions_log_diagnostics_only": bool(
+                self.visible_output_parser is not None and not visible_output
+            ),
+            "stderr_chars": len(result.stderr),
+            "stderr_tail": redact_secrets(result.stderr[-2000:]),
+        }
+        if any(token_usage.get(key) for key in token_usage):
+            metadata["token_usage"] = token_usage
         return EpisodeResult(
             status=status,
             actions_log=actions_log,
             error=error,
             duration_ms=duration_ms,
-            metadata={
-                "command": redact_secrets(command),
-                "workspace": self.workspace_path,
-                "prompt_path": prompt_path,
-                "exit_code": result.exit_code,
-                "termination_reason": result.termination_reason,
-                "actions_log_chars": len(actions_log),
-                "trajectory_format": "jsonl",
-                "assistant_visible_output": visible_output,
-                "runtime_signals": runtime_signals,
-                "actions_log_diagnostics_only": bool(
-                    self.visible_output_parser is not None and not visible_output
-                ),
-                "stderr_chars": len(result.stderr),
-                "stderr_tail": redact_secrets(result.stderr[-2000:]),
-            },
+            metadata=metadata,
         )
 
 

--- a/src/lh_harness/adapters/cli_agent.py
+++ b/src/lh_harness/adapters/cli_agent.py
@@ -12,6 +12,7 @@ from ..environment.base import Environment
 from ..environment.remote_files import write_remote_text
 from ..runtime_signals import detect_runtime_signals
 from ..types import DEFAULT_TMP_DIR, DEFAULT_WORKSPACE_PATH, EpisodeBudget, EpisodeResult
+from ..utils.platform_shell import cd_command, shell_quote
 
 _SECRET_NAME = r"(?:API[_-]?KEY|AUTH[_-]?TOKEN|ACCESS[_-]?TOKEN|SECRET|PASSWORD|TOKEN)"
 _SECRET_VALUE = r"(?:'[^']*'|\"[^\"]*\"|\S+)"
@@ -66,11 +67,11 @@ class CommandAgentAdapter:
         # try to interpret as placeholders.
         command_body = self.command_template
         for placeholder, value in (
-            ("{prompt_path}", shlex.quote(prompt_path)),
+            ("{prompt_path}", shell_quote(prompt_path)),
             ("{timeout}", str(budget.max_duration_seconds)),
         ):
             command_body = command_body.replace(placeholder, value)
-        command = f"cd {shlex.quote(self.workspace_path)} && {command_body}"
+        command = f"{cd_command(self.workspace_path)} && {command_body}"
         # When a live path is given (local runs), the environment mirrors stdout
         # to that file line-by-line so the dashboard shows the trajectory live.
         result = await env.exec(

--- a/src/lh_harness/adapters/codex.py
+++ b/src/lh_harness/adapters/codex.py
@@ -9,6 +9,7 @@ from ..types import DEFAULT_CODEX_MODEL, DEFAULT_TMP_DIR, DEFAULT_WORKSPACE_PATH
 from ..agent_logs import visible_output as extract_codex_visible_output
 from ..agent_registry import normalise_reasoning_effort
 from ..utils.agent_cli import resolve_codex_binary
+from ..utils.platform_shell import env_prefix, shell_quote
 from .cli_agent import CommandAgentAdapter
 
 try:
@@ -38,18 +39,17 @@ class CodexAdapter(CommandAgentAdapter):
         reasoning_effort: str | None = None,
     ) -> None:
         effort = normalise_reasoning_effort(reasoning_effort)
-        env_parts: list[str] = []
+        env_assignments: list[tuple[str, str]] = []
         if api_key:
-            quoted_key = shlex.quote(api_key)
-            env_parts.append(f"OPENAI_API_KEY={quoted_key}")
-            env_parts.append(f"CODEX_API_KEY={quoted_key}")
+            env_assignments.append(("OPENAI_API_KEY", api_key))
+            env_assignments.append(("CODEX_API_KEY", api_key))
 
         # Resolve once when an adapter is built.  A LongHorizon run must use
         # the same authenticated Codex installation as the desktop client when
         # both the standalone PATH CLI and ChatGPT.app are present.
         codex_binary = resolve_codex_binary() or "codex"
         command_parts = [
-            shlex.quote(codex_binary),
+            shell_quote(codex_binary),
             "exec",
             "--json",
             "--skip-git-repo-check",
@@ -59,18 +59,18 @@ class CodexAdapter(CommandAgentAdapter):
         # isolated environment, so bypass Codex's own sandbox unless the caller
         # picked an explicit policy.
         if sandbox_mode:
-            command_parts.extend(["--sandbox", shlex.quote(sandbox_mode)])
+            command_parts.extend(["--sandbox", shell_quote(sandbox_mode)])
         else:
             command_parts.append("--dangerously-bypass-approvals-and-sandbox")
 
         for override in _config_overrides(base_url=base_url, api_key=api_key):
-            command_parts.extend(["-c", shlex.quote(override)])
+            command_parts.extend(["-c", shell_quote(override)])
 
         # Codex has no `--effort` flag; the reasoning depth is a config value.
         # Passing nothing leaves the user's own ~/.codex/config.toml in charge.
         if effort:
             command_parts.extend(
-                ["-c", shlex.quote(f"model_reasoning_effort={json.dumps(effort)}")]
+                ["-c", shell_quote(f"model_reasoning_effort={json.dumps(effort)}")]
             )
 
         # MCP support is opt-in and uses Codex's own format: a TOML file holding
@@ -79,24 +79,24 @@ class CodexAdapter(CommandAgentAdapter):
         mcp_config = mcp_config or os.getenv("LH_HARNESS_CODEX_MCP_CONFIG")
         if mcp_config:
             for override in mcp_server_overrides(mcp_config):
-                command_parts.extend(["-c", shlex.quote(override)])
+                command_parts.extend(["-c", shell_quote(override)])
 
         resolved_add_dirs = list(add_dirs or [])
         env_add_dirs = os.getenv("LH_HARNESS_CODEX_ADD_DIRS") or os.getenv("LH_HARNESS_MCP_ADD_DIRS")
         if env_add_dirs:
             resolved_add_dirs.extend(part for part in env_add_dirs.split(os.pathsep) if part)
         for add_dir in resolved_add_dirs:
-            command_parts.extend(["--add-dir", shlex.quote(add_dir)])
+            command_parts.extend(["--add-dir", shell_quote(add_dir)])
 
         if model:
-            command_parts.extend(["--model", shlex.quote(model)])
+            command_parts.extend(["--model", shell_quote(model)])
         # `-` makes Codex read the prompt from stdin, keeping long prompts off
         # the command line and out of the process table.
         command_parts.append("-")
 
-        env_prefix = (" ".join(env_parts) + " ") if env_parts else ""
+        env_prefix_text = env_prefix(env_assignments)
         super().__init__(
-            command_template=f"{env_prefix}{' '.join(command_parts)} < {{prompt_path}}",
+            command_template=f"{env_prefix_text}{' '.join(command_parts)} < {{prompt_path}}",
             prompt_dir=prompt_dir,
             workspace_path=workspace_path,
             visible_output_parser=extract_codex_visible_output,

--- a/src/lh_harness/adapters/deepseek_harness.py
+++ b/src/lh_harness/adapters/deepseek_harness.py
@@ -9,6 +9,7 @@ from ..agent_logs import visible_output as extract_visible_output
 from ..agent_registry import normalise_reasoning_effort
 from ..types import DEFAULT_DEEPSEEK_HARNESS_MODEL
 from ..utils.agent_cli import resolve_dsh_binary
+from ..utils.platform_shell import env_prefix, shell_quote
 from .cli_agent import CommandAgentAdapter
 
 _READ_ONLY_ROLES = {
@@ -68,28 +69,27 @@ class DeepSeekHarnessAdapter(CommandAgentAdapter):
         dsh_binary = resolve_dsh_binary() or "dsh"
 
         environment = [
-            f"DSH_HOME={shlex.quote(isolated_home)}",
-            f"DSH_PERMISSION_MODE={shlex.quote(permission_mode)}",
+            ("DSH_HOME", isolated_home),
+            ("DSH_PERMISSION_MODE", permission_mode),
         ]
         if api_key:
-            environment.append(f"DEEPSEEK_API_KEY={shlex.quote(api_key)}")
+            environment.append(("DEEPSEEK_API_KEY", api_key))
         if base_url:
-            environment.append(f"DEEPSEEK_BASE_URL={shlex.quote(base_url)}")
+            environment.append(("DEEPSEEK_BASE_URL", base_url))
 
         command = [
-            *environment,
             shlex.quote(sys.executable),
             "-m",
             "lh_harness.adapters.deepseek_runner",
             "--binary",
-            shlex.quote(dsh_binary),
+            shell_quote(dsh_binary),
             "--prompt",
             "{prompt_path}",
             "--model",
-            shlex.quote(normalized_model),
+            shell_quote(normalized_model),
         ]
         super().__init__(
-            command_template=" ".join(command),
+            command_template=f"{env_prefix(environment)}{' '.join(command)}",
             workspace_path=workspace_path,
             prompt_dir=prompt_dir,
             visible_output_parser=visible_output_parser or extract_visible_output,

--- a/src/lh_harness/adapters/opencode.py
+++ b/src/lh_harness/adapters/opencode.py
@@ -47,6 +47,7 @@ class OpenCodeAdapter(CommandAgentAdapter):
         reasoning_effort: str | None = None,
         role: str = "cli_executor",
         hidden_paths: tuple[str, ...] = (),
+        mcp_config: str | None = None,
     ) -> None:
         normalized_model = model.strip()
         if not normalized_model:
@@ -65,13 +66,20 @@ class OpenCodeAdapter(CommandAgentAdapter):
             # OpenCode falls back to OPENCODE_API_KEY when a provider has no
             # key of its own, so one harness credential covers every model.
             env_assignments.append(("OPENCODE_API_KEY", api_key))
-        if base_url:
+        mcp_servers = _load_mcp_servers(mcp_config) if mcp_config else None
+        if base_url or mcp_servers:
             provider_id = normalized_model.split("/", 1)[0].strip() or "opencode"
-            config_path = _write_endpoint_config(prompt_dir, provider_id, base_url)
+            config_path = _write_runtime_config(
+                prompt_dir,
+                provider_id,
+                base_url,
+                mcp_servers,
+            )
             # OpenCode merges config files instead of replacing them, and
             # OPENCODE_CONFIG sits between the global and project configs, so
-            # a per-run file carrying only the provider override keeps the
-            # user's own providers, models, and MCP servers intact.
+            # a per-run file carrying only the provider override and the
+            # computer-use MCP servers keeps the user's own providers, models,
+            # and MCP servers intact.
             env_assignments.append(("OPENCODE_CONFIG", config_path))
 
         command_parts = [
@@ -125,29 +133,58 @@ class OpenCodeAdapter(CommandAgentAdapter):
         return result
 
 
-def _write_endpoint_config(prompt_dir: str, provider_id: str, base_url: str) -> str:
-    """Write an OPENCODE_CONFIG file overriding one provider's base URL.
+def _load_mcp_servers(mcp_config: str) -> dict[str, object]:
+    """Load the `mcp` server map from a plugin-written OpenCode config file.
+
+    The computer-use plugins store one OpenCode-format JSON per agent
+    (``{"mcp": {name: {type, command, args, enabled}}}``); anything else is a
+    configuration error rather than something to silently ignore.
+    """
+
+    try:
+        with open(mcp_config, encoding="utf-8") as fh:
+            payload = json.load(fh)
+    except OSError as exc:
+        raise ValueError(f"could not read OpenCode MCP config {mcp_config!r}: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"OpenCode MCP config {mcp_config!r} is not valid JSON: {exc}") from exc
+    servers = payload.get("mcp") if isinstance(payload, dict) else None
+    if not isinstance(servers, dict) or not servers:
+        raise ValueError(f"OpenCode MCP config {mcp_config!r} holds no `mcp` servers")
+    return servers
+
+
+def _write_runtime_config(
+    prompt_dir: str,
+    provider_id: str,
+    base_url: str | None,
+    mcp_servers: dict[str, object] | None,
+) -> str:
+    """Write an OPENCODE_CONFIG file with the provider override and/or the
+    computer-use MCP servers.
 
     The harness runs OpenCode with ``cd <workspace> && ...``, so the config
     lives inside the run's own prompt directory instead of the workspace.
     """
-    normalized_url = base_url.strip().rstrip("/")
-    if not normalized_url or "\x00" in normalized_url:
-        raise ValueError("OpenCode base URL must be a non-empty endpoint")
-    normalized_dir = prompt_dir.rstrip("/") or "."
-    safe_provider = _CONFIG_FILENAME_RE.sub("_", provider_id).strip("_") or "opencode"
-    config = {
-        "provider": {
+    config: dict[str, object] = {}
+    if base_url:
+        normalized_url = base_url.strip().rstrip("/")
+        if not normalized_url or "\x00" in normalized_url:
+            raise ValueError("OpenCode base URL must be a non-empty endpoint")
+        config["provider"] = {
             provider_id: {
                 "options": {"baseURL": normalized_url},
             }
         }
-    }
-    path = posixpath.join(normalized_dir, f"opencode-endpoint-{safe_provider}.json")
+    if mcp_servers:
+        config["mcp"] = mcp_servers
+    normalized_dir = prompt_dir.rstrip("/") or "."
+    safe_provider = _CONFIG_FILENAME_RE.sub("_", provider_id).strip("_") or "opencode"
+    path = posixpath.join(normalized_dir, f"opencode-runtime-{safe_provider}.json")
     try:
         os.makedirs(normalized_dir, exist_ok=True)
         with open(path, "w", encoding="utf-8") as fh:
             json.dump(config, fh, ensure_ascii=False, indent=2)
     except OSError as exc:
-        raise ValueError(f"could not write OpenCode endpoint config: {exc}") from exc
+        raise ValueError(f"could not write OpenCode runtime config: {exc}") from exc
     return path

--- a/src/lh_harness/adapters/opencode.py
+++ b/src/lh_harness/adapters/opencode.py
@@ -17,6 +17,7 @@ from ..types import (
     EpisodeResult,
 )
 from ..utils.agent_cli import resolve_opencode_binary
+from ..utils.platform_shell import env_prefix, shell_quote
 from .cli_agent import CommandAgentAdapter
 
 _CONFIG_FILENAME_RE = re.compile(r"[^A-Za-z0-9_.-]+")
@@ -59,11 +60,11 @@ class OpenCodeAdapter(CommandAgentAdapter):
         )
 
         opencode_binary = resolve_opencode_binary() or "opencode"
-        env_parts: list[str] = []
+        env_assignments: list[tuple[str, str]] = []
         if api_key:
             # OpenCode falls back to OPENCODE_API_KEY when a provider has no
             # key of its own, so one harness credential covers every model.
-            env_parts.append(f"OPENCODE_API_KEY={shlex.quote(api_key)}")
+            env_assignments.append(("OPENCODE_API_KEY", api_key))
         if base_url:
             provider_id = normalized_model.split("/", 1)[0].strip() or "opencode"
             config_path = _write_endpoint_config(prompt_dir, provider_id, base_url)
@@ -71,26 +72,26 @@ class OpenCodeAdapter(CommandAgentAdapter):
             # OPENCODE_CONFIG sits between the global and project configs, so
             # a per-run file carrying only the provider override keeps the
             # user's own providers, models, and MCP servers intact.
-            env_parts.append(f"OPENCODE_CONFIG={shlex.quote(config_path)}")
+            env_assignments.append(("OPENCODE_CONFIG", config_path))
 
         command_parts = [
-            shlex.quote(opencode_binary),
+            shell_quote(opencode_binary),
             "run",
             "--format",
             "json",
             "--yolo",
             "--model",
-            shlex.quote(normalized_model),
+            shell_quote(normalized_model),
         ]
         if normalized_effort:
-            command_parts.extend(["--variant", shlex.quote(normalized_effort)])
+            command_parts.extend(["--variant", shell_quote(normalized_effort)])
         # `opencode run` reads the prompt from stdin when no positional message
         # is given, keeping long prompts off the command line.
         command_parts.append("< {prompt_path}")
 
-        env_prefix = (" ".join(env_parts) + " ") if env_parts else ""
+        env_prefix_text = env_prefix(env_assignments)
         super().__init__(
-            command_template=f"{env_prefix}{' '.join(command_parts)}",
+            command_template=f"{env_prefix_text}{' '.join(command_parts)}",
             prompt_dir=prompt_dir,
             workspace_path=workspace_path,
             visible_output_parser=extract_opencode_visible_output,

--- a/src/lh_harness/agent_logs.py
+++ b/src/lh_harness/agent_logs.py
@@ -718,6 +718,46 @@ def _opencode_result_step(
     return result
 
 
+def token_usage(raw: str) -> dict[str, Any]:
+    """Sum provider token usage across every record in a trajectory.
+
+    Understands the two shapes the adapters emit: Codex/Claude top-level
+    ``usage`` objects and OpenCode ``part.tokens`` maps (with ``cache.read``
+    and ``cost``).  Unknown shapes contribute nothing, so the helper is safe
+    to run over any backend's stdout.
+    """
+
+    totals: dict[str, Any] = {
+        "input_tokens": 0,
+        "cached_input_tokens": 0,
+        "output_tokens": 0,
+        "reasoning_tokens": 0,
+        "cost_usd": 0.0,
+    }
+    for record in _json_records(raw):
+        part = record.get("part") if isinstance(record.get("part"), dict) else {}
+        tokens = part.get("tokens") if isinstance(part.get("tokens"), dict) else {}
+        cache = tokens.get("cache") if isinstance(tokens.get("cache"), dict) else {}
+        usage = record.get("usage") if isinstance(record.get("usage"), dict) else {}
+        samples = {
+            "input_tokens": (tokens.get("input"), usage.get("input_tokens")),
+            "cached_input_tokens": (cache.get("read"), usage.get("cached_input_tokens")),
+            "output_tokens": (tokens.get("output"), usage.get("output_tokens")),
+            "reasoning_tokens": (tokens.get("reasoning"), usage.get("reasoning_tokens")),
+        }
+        for key, values in samples.items():
+            for value in values:
+                if isinstance(value, (int, float)) and not isinstance(value, bool):
+                    totals[key] += value
+                    break
+        cost = part.get("cost")
+        if not isinstance(cost, (int, float)) or isinstance(cost, bool):
+            cost = usage.get("cost_usd")
+        if isinstance(cost, (int, float)) and not isinstance(cost, bool):
+            totals["cost_usd"] += cost
+    return totals
+
+
 # ----------------------------------------------------------------------------
 # Untyped chat transcripts
 # ----------------------------------------------------------------------------

--- a/src/lh_harness/auditor_agent.py
+++ b/src/lh_harness/auditor_agent.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import re
 from typing import Any
 
@@ -202,9 +203,11 @@ def audit_report_from_episode_result(
             action_guidance=_text("runtime_failed_guidance", language),
         )
 
-    report_text = compact_auditor_report_text(
-        extract_auditor_report_text(_episode_visible_output(result))
-    )
+    visible_raw = _episode_visible_output(result)
+    structured = _extract_structured_audit(visible_raw)
+    report_text = compact_auditor_report_text(extract_auditor_report_text(visible_raw))
+    if structured is None:
+        structured = _extract_structured_audit(report_text)
     if not _has_valid_control_header(report_text):
         report_text = _invalid_control_header_report(report_text, language=language)
     status = infer_report_status(report_text)
@@ -212,6 +215,12 @@ def audit_report_from_episode_result(
     action_guidance = extract_action_guidance(report_text)
     integrity_status, integrity_findings = infer_integrity_findings(report_text)
     contract_audit_status = infer_contract_audit_status(report_text)
+    if structured:
+        status = structured.get("status", status)
+        integrity_status = structured.get("integrity_status", integrity_status)
+        contract_audit_status = structured.get("contract_audit_status", contract_audit_status)
+        if "integrity_findings" in structured:
+            integrity_findings = structured["integrity_findings"]
     artifact_actions = extract_deleted_artifact_actions(report_text) if integrity_status == "violation" else []
     if result.metadata.get("verifier_workspace_mutation_detected"):
         paths = _mutation_paths(result.metadata.get("verifier_workspace_mutations"))
@@ -292,17 +301,37 @@ def audit_report_from_episode_result(
 
 
 def parse_audit_report(raw: str, round_index: int, *, language: str = "en") -> AuditReport:
+    structured = _extract_structured_audit(raw)
     report_text = compact_auditor_report_text(extract_auditor_report_text(raw))
+    if structured is None:
+        structured = _extract_structured_audit(report_text)
     if not _has_valid_control_header(report_text):
         report_text = _invalid_control_header_report(report_text, language=language)
     status = infer_report_status(report_text)
     integrity_status, integrity_findings = infer_integrity_findings(report_text)
     contract_audit_status = infer_contract_audit_status(report_text)
+    if structured:
+        # The fenced JSON verdict is the machine-readable authority; each
+        # field falls back to the control-header inference independently.
+        status = structured.get("status", status)
+        integrity_status = structured.get("integrity_status", integrity_status)
+        contract_audit_status = structured.get("contract_audit_status", contract_audit_status)
+        if "integrity_findings" in structured:
+            integrity_findings = structured["integrity_findings"]
     report_text, status, contract_audit_status = _apply_acceptance_constraint_guard(
         report_text, status, contract_audit_status, language=language
     )
     if (integrity_status == "violation" or contract_audit_status != "aligned") and status == "complete":
         status = "incomplete"
+    if integrity_status == "violation":
+        declared = structured.get("deleted_artifacts") if structured else None
+        artifact_actions = (
+            _normalize_structured_deletions(declared)
+            if declared is not None
+            else extract_deleted_artifact_actions(report_text)
+        )
+    else:
+        artifact_actions = []
     return AuditReport(
         round_id=f"round_{round_index}",
         status=status,
@@ -312,7 +341,7 @@ def parse_audit_report(raw: str, round_index: int, *, language: str = "en") -> A
         integrity_status=integrity_status,
         contract_audit_status=contract_audit_status,
         integrity_findings=integrity_findings,
-        artifact_actions=extract_deleted_artifact_actions(report_text) if integrity_status == "violation" else [],
+        artifact_actions=artifact_actions,
     )
 
 
@@ -346,6 +375,70 @@ def infer_report_status(text: str) -> str:
 
 def infer_contract_audit_status(text: str) -> str:
     return _parse_contract_audit_control_header(text) or "unknown"
+
+
+_STRUCTURED_AUDIT_RE = re.compile(r"```json\s*\n(.*?)```", re.S)
+_AUDIT_STATUS_VALUES = frozenset({"complete", "incomplete", "blocked"})
+_AUDIT_INTEGRITY_VALUES = frozenset({"clean", "suspect", "violation"})
+_AUDIT_CONTRACT_VALUES = frozenset({"aligned", "unknown", "needs_revision", "invalid"})
+
+
+def _extract_structured_audit(text: str) -> dict[str, Any] | None:
+    """Return the last valid fenced ```json audit summary, or ``None``.
+
+    The auditor prompt asks for a machine-readable verdict block after the
+    prose sections.  Every field is validated independently so a partially
+    broken block still contributes its trustworthy fields, and reports from
+    older prompts (no JSON at all) keep parsing exactly as before.
+    """
+
+    if "```json" not in str(text or ""):
+        return None
+    for match in reversed(list(_STRUCTURED_AUDIT_RE.finditer(text))):
+        try:
+            payload = json.loads(match.group(1))
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(payload, dict):
+            continue
+        structured: dict[str, Any] = {}
+        if payload.get("status") in _AUDIT_STATUS_VALUES:
+            structured["status"] = payload["status"]
+        if payload.get("integrity_status") in _AUDIT_INTEGRITY_VALUES:
+            structured["integrity_status"] = payload["integrity_status"]
+        if payload.get("contract_audit_status") in _AUDIT_CONTRACT_VALUES:
+            structured["contract_audit_status"] = payload["contract_audit_status"]
+        findings = payload.get("integrity_findings")
+        if isinstance(findings, list):
+            structured["integrity_findings"] = [item for item in findings if isinstance(item, dict)]
+        deleted = payload.get("deleted_artifacts")
+        if isinstance(deleted, list):
+            structured["deleted_artifacts"] = [item for item in deleted if isinstance(item, dict)]
+        if structured:
+            return structured
+    return None
+
+
+def _normalize_structured_deletions(entries: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Shape structured `deleted_artifacts` like the regex-declared ledger."""
+
+    actions: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for item in entries:
+        path = str(item.get("path") or "").strip()
+        if not path or path in seen:
+            continue
+        seen.add(path)
+        actions.append(
+            {
+                "action": "delete",
+                "status": "delete_declared_unverified",
+                "path": path,
+                "reason": str(item.get("reason") or ""),
+                "declaration": "structured audit summary",
+            }
+        )
+    return actions
 
 
 def _apply_acceptance_constraint_guard(

--- a/src/lh_harness/cli.py
+++ b/src/lh_harness/cli.py
@@ -63,7 +63,7 @@ _AGENTS = (
     ("opencode", "opencode", DEFAULT_OPENCODE_MODEL),
 )
 _AGENT_CHOICES = tuple(name for name, _, _ in _AGENTS)
-_MCP_AGENT_CHOICES = ("claude_code", "codex")
+_MCP_AGENT_CHOICES = ("claude_code", "codex", "opencode")
 # Each agent reads MCP config in its own format, so each gets its own flag.
 _MCP_CONFIG_DESTS = {"claude_code": "claude_mcp_config", "codex": "codex_mcp_config"}
 
@@ -1748,7 +1748,8 @@ def _run_command(args: argparse.Namespace) -> int:
     def resolve_mcp_config(agent_name: str) -> str | None:
         # The agent's own --*-mcp-config wins; otherwise the installed
         # computer-use plugin with the highest priority is loaded for this agent.
-        if agent_name in {"deepseek_harness", "opencode"}:
+        # DeepSeek Harness phase 1 has no MCP integration yet.
+        if agent_name == "deepseek_harness":
             return None
         override = getattr(args, _MCP_CONFIG_DESTS[agent_name], None)
         if override:
@@ -2303,6 +2304,7 @@ def _build_agent(
             prompt_dir=prompt_dir,
             role=role,
             hidden_paths=hidden_paths,
+            mcp_config=mcp_config,
             reasoning_effort=reasoning_effort,
         )
         if model is not None:

--- a/src/lh_harness/cli.py
+++ b/src/lh_harness/cli.py
@@ -385,7 +385,33 @@ def _fallback_hint(role: str, suffix: str) -> str:
     return ", then ".join(chain)
 
 
+def _force_utf8_stdio() -> None:
+    """Make all console/pipe output UTF-8 on Windows.
+
+    The harness's durable artifacts (reports, events, trajectories) are UTF-8;
+    without this, the same Chinese text prints as mojibake through a cp936
+    pipe and redirected logs become unreadable to every other tool in the
+    chain.  The console output codepage is switched to 65001 as well so legacy
+    conhost windows decode the bytes correctly.
+    """
+
+    if os.name != "nt":
+        return
+    try:
+        import ctypes
+
+        ctypes.windll.kernel32.SetConsoleOutputCP(65001)
+    except (OSError, AttributeError, ImportError):
+        pass
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding="utf-8", errors="replace")
+        except (AttributeError, OSError, ValueError):
+            pass
+
+
 def main(argv: list[str] | None = None) -> int:
+    _force_utf8_stdio()
     raw_argv = list(sys.argv[1:] if argv is None else argv)
     run_defaults: dict[str, object] = {}
     config_error: ProjectConfigError | None = None

--- a/src/lh_harness/dashboard/state.py
+++ b/src/lh_harness/dashboard/state.py
@@ -33,6 +33,7 @@ from ..supervisor.control_bus import (
     _ensure_dir_fd_nofollow,
     _open_private_regular_at,
     _process_lock,
+    _validate_no_symlink_chain,
 )
 from ..supervisor.lifecycle import ACTIVE_STATUSES, TERMINAL_STATUSES, canonical_lifecycle_status
 from ..utils.run_boundary import safe_run_dir, safe_run_logs, safe_run_role, safe_run_rounds
@@ -491,11 +492,44 @@ class DashboardState:
         round_dir = self._safe_round_dir(round_index)
         if round_dir is None:
             return []
+        if os.name == "nt":
+            # os.open cannot open directories on Windows, and os.scandir(fd)
+            # is POSIX-only.  Validate the boundary by explicit symlink scan,
+            # then enumerate by path; each child is still re-verified through
+            # the no-follow file open below.
+            try:
+                _validate_no_symlink_chain(round_dir.parent)
+                if round_dir.is_symlink():
+                    raise OSError("round directory is a symlink")
+                artifacts: list[str] = []
+                with os.scandir(str(round_dir)) as entries:
+                    for entry_number, entry in enumerate(entries):
+                        if entry_number >= _MAX_ARTIFACT_SCAN:
+                            break
+                        name = str(entry.name)
+                        if len(name) > _MAX_ARTIFACT_NAME_CHARS:
+                            continue
+                        candidate = round_dir / name
+                        try:
+                            child_fd = _open_nofollow(candidate, strict_parent=True)
+                            try:
+                                mode = stat_module.S_ISREG(os.fstat(child_fd).st_mode)
+                            finally:
+                                os.close(child_fd)
+                        except OSError:
+                            continue
+                        if mode:
+                            artifacts.append(name)
+                        if len(artifacts) >= _MAX_ARTIFACT_COUNT:
+                            break
+                return artifacts
+            except OSError:
+                return []
         try:
             fd = _open_nofollow(round_dir, directory=True, strict_parent=True)
         except OSError:
             return []
-        artifacts: list[str] = []
+        artifacts = []
         try:
             with os.scandir(fd) as entries:
                 for entry_number, entry in enumerate(entries):
@@ -1178,13 +1212,20 @@ def _open_nofollow(path: Path, *, directory: bool = False, strict_parent: bool =
     nofollow = getattr(os, "O_NOFOLLOW", 0)
     cloexec = getattr(os, "O_CLOEXEC", 0)
     directory_flag = getattr(os, "O_DIRECTORY", 0)
-    flags = os.O_RDONLY | nofollow | cloexec | (directory_flag if directory else 0)
+    flags = os.O_RDONLY | nofollow | cloexec | getattr(os, "O_BINARY", 0) | (directory_flag if directory else 0)
     if not directory:
         # Reject a worker-created FIFO without blocking the dashboard thread
         # while opening it.  Regular files ignore O_NONBLOCK.
         flags |= getattr(os, "O_NONBLOCK", 0)
     parts = path.parts
     if not parts or parts[0] != os.sep or len(parts) == 1 or os.open not in getattr(os, "supports_dir_fd", set()):
+        if os.name == "nt":
+            # Windows: no anchored walking.  Reject symlinked ancestors and a
+            # symlinked final component explicitly before the plain open; the
+            # regular-file/nlink checks remain with the caller's fstat.
+            _validate_no_symlink_chain(path.parent)
+            if path.is_symlink():
+                raise OSError("path is a symlink")
         return os.open(path, flags)
 
     root_fd = os.open(os.sep, os.O_RDONLY | directory_flag | nofollow | cloexec)
@@ -1241,6 +1282,9 @@ def _read_file_bounded(
     try:
         metadata = os.fstat(fd)
         if not stat_module.S_ISREG(metadata.st_mode):
+            return None, False
+        if metadata.st_nlink != 1:
+            # A hard-link alias would let another boundary's file be read here.
             return None, False
         size = int(metadata.st_size)
         start = max(0, size - max_bytes) if tail else 0

--- a/src/lh_harness/dashboard/state.py
+++ b/src/lh_harness/dashboard/state.py
@@ -27,7 +27,13 @@ from pathlib import Path
 from typing import Any
 
 from ..types import DEFAULT_LOG_DIR, MAX_ROUNDS
-from ..supervisor.control_bus import ControlBus, _ensure_dir_fd_nofollow, _open_private_regular_at
+from ..supervisor.control_bus import (
+    ControlBus,
+    _anchored_parent,
+    _ensure_dir_fd_nofollow,
+    _open_private_regular_at,
+    _process_lock,
+)
 from ..supervisor.lifecycle import ACTIVE_STATUSES, TERMINAL_STATUSES, canonical_lifecycle_status
 from ..utils.run_boundary import safe_run_dir, safe_run_logs, safe_run_role, safe_run_rounds
 
@@ -894,21 +900,18 @@ class DashboardState:
             # path-based mkdir followed by open would permit a swapped
             # ``role_management`` directory to redirect this append.
             parent_fd = _ensure_dir_fd_nofollow(path.parent)
-            fd = _open_private_regular_at(parent_fd, path.name, os.O_WRONLY | os.O_APPEND)
+            fd = _open_private_regular_at(
+                _anchored_parent(parent_fd, path.parent), path.name, os.O_WRONLY | os.O_APPEND
+            )
             with os.fdopen(fd, "a", encoding="utf-8") as fh:
                 fd = None
-                try:
-                    import fcntl
-
-                    fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
-                except ImportError as exc:
-                    raise OSError("secure approval-log locking is unavailable") from exc
-                try:
-                    fh.write(line)
-                    fh.flush()
-                    os.fsync(fh.fileno())
-                finally:
-                    fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+                with _process_lock(fh):
+                    try:
+                        fh.write(line)
+                        fh.flush()
+                        os.fsync(fh.fileno())
+                    finally:
+                        pass
         except (ImportError, OSError):
             # Approval persistence is diagnostic/control state. A read-only or
             # unavailable log must not crash the manager's execution loop.
@@ -919,7 +922,7 @@ class DashboardState:
                     os.close(fd)
                 except OSError:
                     pass
-            if parent_fd is not None:
+            if parent_fd is not None and parent_fd >= 0:
                 try:
                     os.close(parent_fd)
                 except OSError:

--- a/src/lh_harness/environment/local.py
+++ b/src/lh_harness/environment/local.py
@@ -12,7 +12,7 @@ import time
 from pathlib import Path
 
 from ..types import DEFAULT_TMP_DIR, ExecResult
-from ..supervisor.control_bus import _ensure_dir_fd_nofollow, _open_private_regular_at
+from ..supervisor.control_bus import _anchored_parent, _ensure_dir_fd_nofollow, _open_private_regular_at
 from ..trajectory_artifacts import StreamingTrajectoryArtifactWriter
 from ..utils.process_group import (
     kill_process_group,
@@ -57,7 +57,7 @@ def _open_trajectory_file(path: Path):
     fd: int | None = None
     try:
         fd = _open_private_regular_at(
-            parent_fd,
+            _anchored_parent(parent_fd, path.parent),
             path.name,
             os.O_WRONLY,
             mode=0o600,
@@ -93,6 +93,14 @@ class LocalEnvironment:
     def staging_dir(self) -> Path:
         """Where callers may stage files before uploading them into this env."""
         return self._tmp_dir
+
+    async def ensure_dir(self, remote_path: str) -> None:
+        """Native directory creation (no POSIX shell required)."""
+        Path(remote_path).expanduser().mkdir(parents=True, exist_ok=True)
+
+    async def chmod(self, remote_path: str, mode: str) -> None:
+        """POSIX permission bits have no NTFS equivalent; nothing to do."""
+        return None
 
     async def exec(
         self,

--- a/src/lh_harness/environment/local.py
+++ b/src/lh_harness/environment/local.py
@@ -14,7 +14,9 @@ from pathlib import Path
 from ..types import DEFAULT_TMP_DIR, ExecResult
 from ..supervisor.control_bus import _anchored_parent, _ensure_dir_fd_nofollow, _open_private_regular_at
 from ..trajectory_artifacts import StreamingTrajectoryArtifactWriter
+from ..utils import win_job
 from ..utils.process_group import (
+    SIGKILL,
     kill_process_group,
     signal_process_group,
     track_process_group,
@@ -99,8 +101,15 @@ class LocalEnvironment:
         Path(remote_path).expanduser().mkdir(parents=True, exist_ok=True)
 
     async def chmod(self, remote_path: str, mode: str) -> None:
-        """POSIX permission bits have no NTFS equivalent; nothing to do."""
-        return None
+        """Apply POSIX permission bits; a no-op where they have no meaning."""
+        if os.name == "nt":
+            # NTFS has no POSIX permission bits; nothing to apply.
+            return
+        try:
+            os.chmod(remote_path, int(str(mode), 8))
+        except (OSError, ValueError):
+            # Best effort: the local file is already operator-readable.
+            pass
 
     async def exec(
         self,
@@ -136,6 +145,10 @@ class LocalEnvironment:
                 limit=64 * 1024 * 1024,
             )
             track_process_group(proc.pid)
+            # Windows: put the child into a kill-on-close Job Object so every
+            # later termination (and the atexit sweep) kills the whole tree by
+            # kernel handle instead of by reusable pid.
+            win_job.assign(proc.pid)
             # Always drain incrementally. Besides powering the live dashboard,
             # this leaves the bytes already received available if a timeout or
             # cancellation happens before the child exits normally.
@@ -187,13 +200,16 @@ class LocalEnvironment:
             # and an unshielded await would be cancelled before the child exits.
             await asyncio.shield(asyncio.wait_for(proc.wait(), timeout=5))
         except asyncio.TimeoutError:
-            signal_process_group(proc.pid, signal.SIGKILL)
+            signal_process_group(proc.pid, SIGKILL)
             with contextlib.suppress(asyncio.TimeoutError, asyncio.CancelledError):
                 await asyncio.shield(asyncio.wait_for(proc.wait(), timeout=5))
         except asyncio.CancelledError:
             # Cancelled again mid-wait: fall back to the blocking sweep so the
             # agent cannot outlive us.
             kill_process_group(proc.pid)
+        # Windows: the Job Object kill is the authoritative tree termination —
+        # closing the job reaps any descendants the signals above missed.
+        win_job.kill_tree(proc.pid)
 
     @staticmethod
     async def _finish_io(io_task: asyncio.Task[None] | None) -> None:

--- a/src/lh_harness/environment/remote_files.py
+++ b/src/lh_harness/environment/remote_files.py
@@ -10,8 +10,16 @@ from .base import Environment
 from ..types import DEFAULT_TMP_DIR
 
 
+def _remote_parent(path: str) -> str:
+    """Parent of a remote path, handling both POSIX and Windows separators."""
+
+    normalized = str(path).rstrip("/\\")
+    cut = max(normalized.rfind("/"), normalized.rfind("\\"))
+    return normalized[:cut] if cut > 0 else ""
+
+
 async def write_remote_text(env: Environment, remote_path: str, content: str, mode: str = "0644") -> None:
-    parent = posixpath.dirname(remote_path.rstrip("/"))
+    parent = _remote_parent(remote_path)
     if parent:
         await ensure_remote_dir(env, parent)
 
@@ -33,12 +41,20 @@ async def write_remote_text(env: Environment, remote_path: str, content: str, mo
             except FileNotFoundError:
                 pass
 
-    result = await env.exec(f"chmod {shlex.quote(mode)} {shlex.quote(remote_path)}", timeout=30)
+    native_chmod = getattr(env, "chmod", None)
+    if callable(native_chmod):
+        await native_chmod(str(remote_path), mode)
+        return
+    result = await env.exec(f"chmod {shlex.quote(mode)} {shlex.quote(str(remote_path))}", timeout=30)
     if result.exit_code != 0:
         raise RuntimeError(f"failed chmod {remote_path}: {result.stderr or result.stdout}")
 
 
 async def ensure_remote_dir(env: Environment, remote_path: str) -> None:
-    result = await env.exec(f"mkdir -p {shlex.quote(remote_path)}", timeout=30)
+    native_ensure = getattr(env, "ensure_dir", None)
+    if callable(native_ensure):
+        await native_ensure(str(remote_path))
+        return
+    result = await env.exec(f"mkdir -p {shlex.quote(str(remote_path))}", timeout=30)
     if result.exit_code != 0:
         raise RuntimeError(f"failed creating {remote_path}: {result.stderr or result.stdout}")

--- a/src/lh_harness/manager.py
+++ b/src/lh_harness/manager.py
@@ -55,6 +55,7 @@ from .types import (
     RoleNextStep,
 )
 from .supervisor.control_bus import (
+    _SECURE_DIRFD as _SECURE_EVENT_APPEND,
     _append_jsonl as _append_jsonl_nofollow,
     _atomic_bytes_write,
     _ensure_dir_nofollow,
@@ -2402,6 +2403,28 @@ def _append_event(path: Path, event: str, payload: dict[str, Any]) -> None:
     # Event ids are assigned while holding the file lock, so the same absolute
     # id survives snapshot truncation, REST replay, and a reconnect after an
     # API restart.  The legacy ``event`` field remains for old readers.
+    if not _SECURE_EVENT_APPEND:
+        # Windows fallback: plain validated append without anchored walking.
+        # The event flock below is best-effort on this platform anyway.
+        with open(str(path), "a+", encoding="utf-8") as fh:
+            fh.seek(0)
+            sequence = sum(1 for line in fh if line.strip()) + 1
+            fh.seek(0, 2)
+            run_id = path.parents[2].name if len(path.parents) > 2 else "local"
+            record = {
+                "schema_version": 1,
+                "event_id": f"{run_id}:{sequence:06d}",
+                "ts": time.time(),
+                "event": event,
+                **_json_safe(payload),
+            }
+            fh.write(json.dumps(record, ensure_ascii=False, sort_keys=True) + "\n")
+            fh.flush()
+            try:
+                os.fsync(fh.fileno())
+            except OSError:
+                pass
+        return
     parent_fd: int | None = None
     raw_fd: int | None = None
     try:

--- a/src/lh_harness/manager.py
+++ b/src/lh_harness/manager.py
@@ -952,6 +952,7 @@ async def _run_impl(
             related_report_refs=related_report_refs,
             executor_status=_episode_status(executor_result),
             auditor_status=auditor_status,
+            token_usage=_round_token_usage(executor_result, auditor_result),
         )
         rounds.append(record)
         await _record_round(env, config, role_dir, events_path, record)
@@ -1552,6 +1553,7 @@ def _final_report(
     # Final status is a harness-level decision, not the last executor agent's self
     # claim. The auditor artifact remains the natural-language audit report.
     latest_report_text = _latest_auditor_report_text(rounds)
+    token_usage = _aggregate_token_usage(rounds)
     status = (
         "complete"
         if completion_satisfied
@@ -1583,7 +1585,51 @@ def _final_report(
         "final_response": final_response,
         "rounds": [asdict(item) for item in rounds],
         "elapsed_seconds": round(elapsed_seconds, 3),
+        "token_usage": token_usage,
     }
+
+
+def _aggregate_token_usage(rounds: list[ManagedRound]) -> dict[str, Any]:
+    """Sum per-round provider token usage into one report-level total."""
+
+    totals: dict[str, Any] = {
+        "input_tokens": 0,
+        "cached_input_tokens": 0,
+        "output_tokens": 0,
+        "reasoning_tokens": 0,
+        "cost_usd": 0.0,
+    }
+    for item in rounds:
+        usage = item.token_usage if isinstance(item.token_usage, dict) else {}
+        for key in list(totals):
+            value = usage.get(key)
+            if isinstance(value, (int, float)) and not isinstance(value, bool):
+                totals[key] += value
+    if not any(totals.values()):
+        return {}
+    return totals
+
+
+def _round_token_usage(*results: Any) -> dict[str, Any]:
+    """Merge token usage recorded by this round's role episodes."""
+
+    merged: dict[str, Any] = {
+        "input_tokens": 0,
+        "cached_input_tokens": 0,
+        "output_tokens": 0,
+        "reasoning_tokens": 0,
+        "cost_usd": 0.0,
+    }
+    for result in results:
+        metadata = getattr(result, "metadata", None)
+        usage = metadata.get("token_usage") if isinstance(metadata, dict) else None
+        if not isinstance(usage, dict):
+            continue
+        for key in list(merged):
+            value = usage.get(key)
+            if isinstance(value, (int, float)) and not isinstance(value, bool):
+                merged[key] += value
+    return merged
 
 
 def _read_local_bounded(path: Path, max_bytes: int, *, tail: bool = False) -> str | None:

--- a/src/lh_harness/plugins/community_computer_use.py
+++ b/src/lh_harness/plugins/community_computer_use.py
@@ -33,6 +33,7 @@ StatusCallback = Callable[[str, str], None]
 
 AGENT_CODEX = "codex"
 AGENT_CLAUDE_CODE = "claude_code"
+AGENT_OPENCODE = "opencode"
 
 
 @dataclass(frozen=True)
@@ -79,7 +80,7 @@ OPEN_COMPUTER_USE = CommunityPlugin(
     mcp_server_name="open-computer-use",
     summary="Open-source Codex Computer Use alternative (macOS Swift, Windows UIA, Linux AT-SPI).",
     homepage="https://github.com/iFurySt/open-codex-computer-use",
-    agents=(AGENT_CODEX, AGENT_CLAUDE_CODE),
+    agents=(AGENT_CODEX, AGENT_CLAUDE_CODE, AGENT_OPENCODE),
     mcp_args=("mcp",),
     # Only the macOS runtime needs grants; the Windows/Linux `doctor` just
     # prints a session note and always exits 0, so checking it proves nothing.
@@ -99,7 +100,7 @@ CLAWDCURSOR = CommunityPlugin(
     mcp_server_name="clawdcursor",
     summary="Local MCP server that compiles the screen into a verified UI map and acts on element ids.",
     homepage="https://github.com/AmrDab/clawdcursor",
-    agents=(AGENT_CODEX, AGENT_CLAUDE_CODE),
+    agents=(AGENT_CODEX, AGENT_CLAUDE_CODE, AGENT_OPENCODE),
     mcp_args=("mcp", "--compact"),
     activation={
         # Consent is required on every OS; `grant` walks the macOS TCC dialogs.

--- a/src/lh_harness/plugins/state.py
+++ b/src/lh_harness/plugins/state.py
@@ -51,7 +51,12 @@ def state_path() -> Path:
 
 def mcp_config_path(plugin_id: str, agent: str) -> Path:
     # Each agent gets its own native format; nothing is translated at run time.
-    suffix = "toml" if agent == "codex" else "mcp.json"
+    if agent == "codex":
+        suffix = "toml"
+    elif agent == "opencode":
+        suffix = "opencode.json"
+    else:
+        suffix = "mcp.json"
     return plugin_dir(plugin_id) / agent / f"{plugin_id}.{suffix}"
 
 
@@ -70,7 +75,20 @@ def write_mcp_config(
 
         _atomic_write(target, mcp_server_block(server_name, command, args))
         return target
-    entry: dict[str, object] = {"command": command}
+    if agent == "opencode":
+        # OpenCode reads MCP servers from the `mcp` key of its config file;
+        # the harness merges this payload into OPENCODE_CONFIG at run time.
+        entry: dict[str, object] = {
+            "type": "local",
+            "command": command,
+            "enabled": True,
+        }
+        if args:
+            entry["args"] = list(args)
+        payload = {"mcp": {server_name: entry}}
+        _atomic_write(target, json.dumps(payload, indent=2, ensure_ascii=False) + "\n")
+        return target
+    entry = {"command": command}
     if args:
         entry["args"] = list(args)
     payload = {"mcpServers": {server_name: entry}}

--- a/src/lh_harness/prompt_texts.py
+++ b/src/lh_harness/prompt_texts.py
@@ -190,16 +190,18 @@ You are the read-only LongHorizon-Harness GUI auditor for the just-finished GUI/
 - Do not click, type, scroll, drag, alter windows, or modify task files. You may observe the current screen and inspect saved screenshots, visual artifacts, and read-only evidence.
 - Verify genuine GUI state, artifact provenance, and whether screenshots satisfy the subtask. For `save_screenshot`, inspect `.meta.json` for `capture_source=real_screen`.
 - You may use Read/Glob/Grep and controlled read-only Bash commands. Computer Use is observation-only: observe or capture screenshots, but never click, type, scroll, drag, or alter GUI state. Report fabricated or untrusted artifacts, but never repair, move, or delete them.
-- Output plain natural language, never JSON. The first three nonempty lines must be exactly `Status: complete|incomplete|blocked`, `Integrity: clean|suspect|violation`, and `Contract audit: aligned|unknown|needs_revision|invalid`.
+- Keep the first three nonempty lines exactly as specified: `Status: complete|incomplete|blocked`, `Integrity: clean|suspect|violation`, `Contract audit: aligned|unknown|needs_revision|invalid`.
 - Then report audit facts, evidence, gaps, next step, trustworthy/untrustworthy artifacts, `Acceptance-constraint backcheck:`, and `State update for manager:`.
+- End the report with one fenced ```json block (under 2000 characters) repeating the machine-readable verdict so the runner can parse it reliably: {"status": "complete|incomplete|blocked", "integrity_status": "clean|suspect|violation", "contract_audit_status": "aligned|unknown|needs_revision|invalid", "integrity_findings": [{"type": "...", "severity": "...", "evidence": "...", "paths": ["..."]}], "deleted_artifacts": [{"path": "...", "reason": "..."}]}. The JSON values must agree with the three control lines; omit integrity_findings/deleted_artifacts when empty.
 """,
     "zh": """\
 你是只读的 LongHorizon-Harness GUI auditor，只审计刚完成的 GUI/视觉子任务，不是 executor。
 - 不要点击、输入、滚动、拖拽、改变窗口或修改任务文件。可以观察当前屏幕及只读检查截图、视觉产物和证据。
 - 审计真实 GUI 状态、产物来源和截图是否满足子任务；`save_screenshot` 需检查 `.meta.json` 的 `capture_source=real_screen`。
 - 可以使用 Read/Glob/Grep 和受控的只读 Bash 命令。Computer Use 仅限观察或截图，绝不能点击、输入、滚动、拖拽或改变 GUI 状态。发现伪造/不可信产物时只报告，绝不能修复、移动或删除。
-- 输出自然语言，不要 JSON。前三个非空行必须严格是 `状态: complete|incomplete|blocked`、`完整性: clean|suspect|violation`、`契约审计: aligned|unknown|needs_revision|invalid`。
+- 前三个非空行必须严格是 `状态: complete|incomplete|blocked`、`完整性: clean|suspect|violation`、`契约审计: aligned|unknown|needs_revision|invalid`。
 - 随后写审计事实、证据、缺口、下一步、可信/不可信产物、`验收约束反查:` 和 `给任务管理器的状态更新:`。
+- 报告末尾追加一个 ```json 代码块（2000 字符以内），重复机器可读判定供 runner 可靠解析：{"status": "complete|incomplete|blocked", "integrity_status": "clean|suspect|violation", "contract_audit_status": "aligned|unknown|needs_revision|invalid", "integrity_findings": [{"type": "...", "severity": "...", "evidence": "...", "paths": ["..."]}], "deleted_artifacts": [{"path": "...", "reason": "..."}]}。JSON 值必须与三行控制头一致；为空时省略 integrity_findings/deleted_artifacts。
 """,
 }
 
@@ -209,15 +211,17 @@ CLI_AUDITOR_INSTRUCTIONS: dict[PromptLanguage, str] = {
 You are the read-only LongHorizon-Harness CLI auditor for the just-finished CLI/non-GUI subtask, not an executor.
 - Do not create, modify, move, or delete task files. You have Read/Glob/Grep and a small allowlist of read-only shell commands. Computer Use is observation-only: observe or capture screenshots, but never click, type, scroll, drag, or alter GUI state.
 - Verify commands, file content, code changes, tests, logs, paths, and service state against the subtask. If visual state matters, require genuine GUI actions and real-screen evidence.
-- Output plain natural language, never JSON. The first three nonempty lines must be exactly `Status: complete|incomplete|blocked`, `Integrity: clean|suspect|violation`, and `Contract audit: aligned|unknown|needs_revision|invalid`.
+- Keep the first three nonempty lines exactly as specified: `Status: complete|incomplete|blocked`, `Integrity: clean|suspect|violation`, `Contract audit: aligned|unknown|needs_revision|invalid`.
 - Then report audit facts, evidence, gaps, next step, trustworthy/untrustworthy artifacts, `Acceptance-constraint backcheck:`, and `State update for manager:`.
+- End the report with one fenced ```json block (under 2000 characters) repeating the machine-readable verdict so the runner can parse it reliably: {"status": "complete|incomplete|blocked", "integrity_status": "clean|suspect|violation", "contract_audit_status": "aligned|unknown|needs_revision|invalid", "integrity_findings": [{"type": "...", "severity": "...", "evidence": "...", "paths": ["..."]}], "deleted_artifacts": [{"path": "...", "reason": "..."}]}. The JSON values must agree with the three control lines; omit integrity_findings/deleted_artifacts when empty.
 """,
     "zh": """\
 你是只读的 LongHorizon-Harness CLI auditor，只审计刚完成的 CLI/非 GUI 子任务，不是 executor。
 - 不要创建、修改、移动或删除任务文件。你可以使用 Read/Glob/Grep 和少量受控只读 shell 命令；Computer Use 仅限观察或截图，绝不能点击、输入、滚动、拖拽或改变 GUI 状态。
 - 对照子任务审计命令、文件内容、代码修改、测试、日志、路径和服务状态。涉及视觉状态时必须要求真实 GUI 操作和真实屏幕证据。
-- 输出自然语言，不要 JSON。前三个非空行必须严格是 `状态: complete|incomplete|blocked`、`完整性: clean|suspect|violation`、`契约审计: aligned|unknown|needs_revision|invalid`。
+- 前三个非空行必须严格是 `状态: complete|incomplete|blocked`、`完整性: clean|suspect|violation`、`契约审计: aligned|unknown|needs_revision|invalid`。
 - 随后写审计事实、证据、缺口、下一步、可信/不可信产物、`验收约束反查:` 和 `给任务管理器的状态更新:`。
+- 报告末尾追加一个 ```json 代码块（2000 字符以内），重复机器可读判定供 runner 可靠解析：{"status": "complete|incomplete|blocked", "integrity_status": "clean|suspect|violation", "contract_audit_status": "aligned|unknown|needs_revision|invalid", "integrity_findings": [{"type": "...", "severity": "...", "evidence": "...", "paths": ["..."]}], "deleted_artifacts": [{"path": "...", "reason": "..."}]}。JSON 值必须与三行控制头一致；为空时省略 integrity_findings/deleted_artifacts。
 """,
 }
 

--- a/src/lh_harness/supervisor/control_bus.py
+++ b/src/lh_harness/supervisor/control_bus.py
@@ -80,7 +80,7 @@ def _process_lock(handle: Any):
             locked = True
         else:
             handle.seek(0)
-            deadline = time.time() + 30.0
+            deadline = time.time() + 5.0
             while True:
                 try:
                     msvcrt_module.locking(fileno, msvcrt_module.LK_NBLCK, 1)
@@ -146,6 +146,8 @@ def _open_nofollow(path: str | Path, *, directory: bool = False) -> int:
             raise OSError("secure control-bus path opening is unavailable")
         absolute = Path(_absolute_anchored_path(path))
         _validate_no_symlink_chain(absolute.parent)
+        if absolute.is_symlink():
+            raise OSError("control-bus path is a symlink")
         descriptor = os.open(str(absolute), os.O_RDONLY | getattr(os, "O_BINARY", 0))
         try:
             if not stat.S_ISREG(os.fstat(descriptor).st_mode):
@@ -218,6 +220,11 @@ def _ensure_dir_fd_nofollow(path: str | Path, *, mode: int = 0o700) -> int:
         or os.mkdir not in getattr(os, "supports_dir_fd", set())
     ):
         target = Path(_absolute_anchored_path(path))
+        # Reject symlinked ancestors BEFORE creating anything, so a swapped
+        # run boundary cannot be followed as a side effect of the mkdir.
+        parent = target.parent
+        if str(parent) != str(target.anchor):
+            _validate_no_symlink_chain(parent)
         target.mkdir(mode=mode, parents=True, exist_ok=True)
         _validate_no_symlink_chain(target)
         return -1
@@ -308,14 +315,16 @@ def _open_private_regular_at(
         base = Path(_absolute_anchored_path(parent_fd))
         base.mkdir(mode=0o700, parents=True, exist_ok=True)
         _validate_no_symlink_chain(base)
-        final = str(base / name)
+        final = base / name
+        if final.is_symlink():
+            raise OSError("private file is a symlink")
         for _ in range(32):
             try:
                 try:
-                    descriptor = os.open(final, flags | os.O_CREAT | os.O_EXCL | binary, mode)
+                    descriptor = os.open(str(final), flags | os.O_CREAT | os.O_EXCL | binary, mode)
                 except FileExistsError:
                     try:
-                        descriptor = os.open(final, flags | binary)
+                        descriptor = os.open(str(final), flags | binary)
                     except FileNotFoundError:
                         continue
             except OSError:
@@ -399,13 +408,20 @@ def _atomic_bytes_write(path: Path, payload: bytes, *, mode: int = 0o600) -> Non
     path = Path(path)
     if not _SECURE_DIRFD:
         parent = Path(_absolute_anchored_path(path.parent))
+        if str(parent) != Path(parent.anchor).anchor and str(parent) != str(parent.anchor):
+            _validate_no_symlink_chain(parent)
         parent.mkdir(mode=0o700, parents=True, exist_ok=True)
         _validate_no_symlink_chain(parent)
         handle_fd, temporary_text = tempfile.mkstemp(
             prefix=f".{path.name}.", suffix=".tmp", dir=str(parent)
         )
         try:
-            with os.fdopen(handle_fd, "wb") as handle:
+            try:
+                handle = os.fdopen(handle_fd, "wb")
+            except BaseException:
+                os.close(handle_fd)
+                raise
+            with handle:
                 handle.write(payload)
                 handle.flush()
                 os.fsync(handle.fileno())
@@ -479,13 +495,21 @@ def _append_jsonl(path: Path, record: dict[str, Any]) -> None:
     # final file can be opened with anchored no-follow semantics.
     if not _SECURE_DIRFD:
         parent = Path(_absolute_anchored_path(path.parent))
+        if str(parent) != Path(parent.anchor).anchor and str(parent) != str(parent.anchor):
+            _validate_no_symlink_chain(parent)
         parent.mkdir(mode=0o700, parents=True, exist_ok=True)
         _validate_no_symlink_chain(parent)
-        with open(str(path), "a", encoding="utf-8") as handle:
+        handle = open(str(path), "a", encoding="utf-8")
+        try:
+            metadata = os.fstat(handle.fileno())
+            if not stat.S_ISREG(metadata.st_mode) or metadata.st_nlink != 1:
+                raise OSError("control log is not an unaliased regular file")
             with _process_lock(handle):
                 handle.write(line)
                 handle.flush()
                 os.fsync(handle.fileno())
+        finally:
+            handle.close()
         return
     fd: int | None = None
     parent_fd: int | None = None
@@ -655,13 +679,25 @@ class ControlBus:
                 # Windows fallback: path-based lock file with an msvcrt
                 # byte-range lock.  Weaker than anchored walking, but it is a
                 # real cross-process critical section.
-                self.root.mkdir(mode=0o700, parents=True, exist_ok=True)
-                _validate_no_symlink_chain(self.root)
+                _ensure_dir_nofollow(self.root)
                 fallback_handle = open(str(self.lock_path), "a+", encoding="utf-8")
                 try:
-                    with _process_lock(fallback_handle):
-                        yield
+                    metadata = os.fstat(fallback_handle.fileno())
+                    if not stat.S_ISREG(metadata.st_mode) or metadata.st_nlink != 1:
+                        raise OSError("control lock is not an unaliased regular file")
+                except OSError as exc:
+                    fallback_handle.close()
+                    raise RuntimeError("secure control-bus locking is unavailable") from exc
+                lock_context = _process_lock(fallback_handle)
+                try:
+                    lock_context.__enter__()
+                except OSError as exc:
+                    fallback_handle.close()
+                    raise RuntimeError("secure control-bus locking is unavailable") from exc
+                try:
+                    yield
                 finally:
+                    lock_context.__exit__(None, None, None)
                     fallback_handle.close()
                 return
             lock_handle = None
@@ -895,8 +931,36 @@ class ControlBus:
         return _read_json_file(self.owner_path)
 
 
+def _iter_run_control_dirs_pathbased(root: Path) -> Iterator[Path]:
+    """Windows fallback: skip symlinked run boundaries by lstat inspection."""
+
+    try:
+        entries = list(os.scandir(root))
+    except OSError:
+        return
+    for entry in entries:
+        try:
+            if entry.is_symlink():
+                continue
+            if not entry.is_dir(follow_symlinks=False):
+                continue
+            control = Path(entry.path) / "control"
+            try:
+                control_meta = os.lstat(control)
+            except OSError:
+                continue
+            if stat.S_ISLNK(control_meta.st_mode) or not stat.S_ISDIR(control_meta.st_mode):
+                continue
+        except OSError:
+            continue
+        yield root / entry.name
+
+
 def iter_run_control_dirs(runs_root: str | Path) -> Iterator[Path]:
     root = Path(runs_root).expanduser().resolve()
+    if not _SECURE_DIRFD:
+        yield from _iter_run_control_dirs_pathbased(root)
+        return
     try:
         root_fd = _open_nofollow(root, directory=True)
     except OSError:

--- a/src/lh_harness/supervisor/control_bus.py
+++ b/src/lh_harness/supervisor/control_bus.py
@@ -29,28 +29,10 @@ _TRUSTED_SYSTEM_ALIASES = frozenset({"/var", "/tmp", "/etc"})
 # those platforms degrade to plain path operations guarded by a best-effort
 # symlink scan instead of failing closed, because the run tree is owned by the
 # same operator who started the process.
-_SECURE_DIRFD = bool(
-    getattr(os, "O_NOFOLLOW", 0)
-    and getattr(os, "O_DIRECTORY", 0)
-    and os.open in getattr(os, "supports_dir_fd", set())
-    and os.mkdir in getattr(os, "supports_dir_fd", set())
-)
-
-
-def _validate_no_symlink_chain(path: Path) -> None:
-    """Reject any symlinked component below the anchor (best-effort platforms)."""
-
-    absolute = Path(os.path.abspath(os.fspath(path)))
-    anchor_parts = len(Path(absolute.anchor).parts)
-    current = Path(*absolute.parts[:anchor_parts])
-    for component in absolute.parts[anchor_parts:]:
-        current = current / component
-        try:
-            metadata = os.lstat(current)
-        except FileNotFoundError:
-            return
-        if stat.S_ISLNK(metadata.st_mode):
-            raise OSError(f"symlinked path component rejected: {current}")
+# The canonical definitions live in utils.platform_caps; the private aliases
+# below keep every existing importer (manager, cli, tests) working unchanged.
+from ..utils.platform_caps import SECURE_DIRFD as _SECURE_DIRFD  # noqa: E402
+from ..utils.platform_caps import validate_no_symlink_chain as _validate_no_symlink_chain  # noqa: E402
 
 
 def _anchored_parent(parent_fd: int, fallback_dir: str | Path) -> int | Path:

--- a/src/lh_harness/supervisor/control_bus.py
+++ b/src/lh_harness/supervisor/control_bus.py
@@ -11,6 +11,7 @@ import errno
 import json
 import os
 import stat
+import tempfile
 import threading
 import time
 import uuid
@@ -22,6 +23,83 @@ from typing import Any, Callable, Iterator
 _MAX_CONTROL_RECORD_BYTES = 512 * 1024
 _MAX_CONTROL_LOG_BYTES = 16 * 1024 * 1024
 _TRUSTED_SYSTEM_ALIASES = frozenset({"/var", "/tmp", "/etc"})
+
+# Anchored no-follow walking needs O_NOFOLLOW/O_DIRECTORY plus dir-fd variants
+# of open/mkdir.  POSIX platforms provide them; Windows does not.  Callers on
+# those platforms degrade to plain path operations guarded by a best-effort
+# symlink scan instead of failing closed, because the run tree is owned by the
+# same operator who started the process.
+_SECURE_DIRFD = bool(
+    getattr(os, "O_NOFOLLOW", 0)
+    and getattr(os, "O_DIRECTORY", 0)
+    and os.open in getattr(os, "supports_dir_fd", set())
+    and os.mkdir in getattr(os, "supports_dir_fd", set())
+)
+
+
+def _validate_no_symlink_chain(path: Path) -> None:
+    """Reject any symlinked component below the anchor (best-effort platforms)."""
+
+    absolute = Path(os.path.abspath(os.fspath(path)))
+    anchor_parts = len(Path(absolute.anchor).parts)
+    current = Path(*absolute.parts[:anchor_parts])
+    for component in absolute.parts[anchor_parts:]:
+        current = current / component
+        try:
+            metadata = os.lstat(current)
+        except FileNotFoundError:
+            return
+        if stat.S_ISLNK(metadata.st_mode):
+            raise OSError(f"symlinked path component rejected: {current}")
+
+
+def _anchored_parent(parent_fd: int, fallback_dir: str | Path) -> int | Path:
+    """Return the anchored descriptor when available, else the directory path."""
+
+    return parent_fd if parent_fd >= 0 else Path(fallback_dir)
+
+
+@contextmanager
+def _process_lock(handle: Any):
+    """Exclusive cross-process file lock: fcntl on POSIX, msvcrt on Windows."""
+
+    fcntl_module = None
+    msvcrt_module = None
+    fileno = handle.fileno()
+    try:
+        import fcntl as fcntl_module  # type: ignore
+    except ImportError:
+        try:
+            import msvcrt as msvcrt_module  # type: ignore
+        except ImportError as exc:
+            raise RuntimeError("cross-process file locking is unavailable") from exc
+    locked = False
+    try:
+        if fcntl_module is not None:
+            fcntl_module.flock(fileno, fcntl_module.LOCK_EX)
+            locked = True
+        else:
+            handle.seek(0)
+            deadline = time.time() + 30.0
+            while True:
+                try:
+                    msvcrt_module.locking(fileno, msvcrt_module.LK_NBLCK, 1)
+                    locked = True
+                    break
+                except OSError:
+                    if time.time() >= deadline:
+                        raise
+                    time.sleep(0.05)
+        yield
+    finally:
+        try:
+            if locked and fcntl_module is not None:
+                fcntl_module.flock(fileno, fcntl_module.LOCK_UN)
+            elif locked and msvcrt_module is not None:
+                handle.seek(0)
+                msvcrt_module.locking(fileno, msvcrt_module.LK_UNLCK, 1)
+        except OSError:
+            pass
 
 
 def _absolute_anchored_path(path: str | Path) -> Path:
@@ -64,7 +142,21 @@ def _open_nofollow(path: str | Path, *, directory: bool = False) -> int:
     directory_flag = getattr(os, "O_DIRECTORY", 0)
     cloexec = getattr(os, "O_CLOEXEC", 0)
     if not nofollow or not directory_flag or os.open not in getattr(os, "supports_dir_fd", set()):
-        raise OSError("secure control-bus path opening is unavailable")
+        if directory:
+            raise OSError("secure control-bus path opening is unavailable")
+        absolute = Path(_absolute_anchored_path(path))
+        _validate_no_symlink_chain(absolute.parent)
+        descriptor = os.open(str(absolute), os.O_RDONLY | getattr(os, "O_BINARY", 0))
+        try:
+            if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+                raise OSError("control-bus path is not a regular file")
+        except BaseException:
+            try:
+                os.close(descriptor)
+            except OSError:
+                pass
+            raise
+        return descriptor
     absolute = _absolute_anchored_path(path)
     parts = absolute.parts
     if len(parts) < 2 or parts[0] != os.sep:
@@ -125,7 +217,10 @@ def _ensure_dir_fd_nofollow(path: str | Path, *, mode: int = 0o700) -> int:
         or os.open not in getattr(os, "supports_dir_fd", set())
         or os.mkdir not in getattr(os, "supports_dir_fd", set())
     ):
-        raise OSError("secure control-bus directory creation is unavailable")
+        target = Path(_absolute_anchored_path(path))
+        target.mkdir(mode=mode, parents=True, exist_ok=True)
+        _validate_no_symlink_chain(target)
+        return -1
     absolute = _absolute_anchored_path(path)
     parts = absolute.parts
     if not parts or parts[0] != os.sep:
@@ -177,6 +272,8 @@ def _ensure_dir_nofollow(path: str | Path, *, mode: int = 0o700) -> None:
     """Create/validate a directory chain without traversing symlinks."""
 
     fd = _ensure_dir_fd_nofollow(path, mode=mode)
+    if fd < 0:
+        return None
     try:
         return None
     finally:
@@ -187,13 +284,16 @@ def _ensure_dir_nofollow(path: str | Path, *, mode: int = 0o700) -> None:
 
 
 def _open_private_regular_at(
-    parent_fd: int,
+    parent_fd: int | str | Path,
     name: str,
     flags: int,
     *,
     mode: int = 0o600,
 ) -> int:
     """Open or create one private regular file relative to ``parent_fd``.
+
+    ``parent_fd`` may also be a directory path on platforms without anchored
+    dir-fd support (the caller passes ``_anchored_parent()``'s result).
 
     macOS can transiently return ``ENOENT`` when several threads concurrently
     use ``O_CREAT | O_NOFOLLOW`` on the same new pathname.  An exclusive-create
@@ -203,6 +303,32 @@ def _open_private_regular_at(
 
     if not name or name in {".", ".."} or "/" in name or "\\" in name:
         raise OSError("unsafe private file name")
+    binary = getattr(os, "O_BINARY", 0)
+    if isinstance(parent_fd, (str, Path)):
+        base = Path(_absolute_anchored_path(parent_fd))
+        base.mkdir(mode=0o700, parents=True, exist_ok=True)
+        _validate_no_symlink_chain(base)
+        final = str(base / name)
+        for _ in range(32):
+            try:
+                try:
+                    descriptor = os.open(final, flags | os.O_CREAT | os.O_EXCL | binary, mode)
+                except FileExistsError:
+                    try:
+                        descriptor = os.open(final, flags | binary)
+                    except FileNotFoundError:
+                        continue
+            except OSError:
+                continue
+            metadata = os.fstat(descriptor)
+            if not stat.S_ISREG(metadata.st_mode):
+                try:
+                    os.close(descriptor)
+                except OSError:
+                    pass
+                raise OSError("private file is not an unaliased regular file")
+            return descriptor
+        raise FileNotFoundError(name)
     nofollow = getattr(os, "O_NOFOLLOW", 0)
     if not nofollow or os.open not in getattr(os, "supports_dir_fd", set()):
         raise OSError("secure private file opening is unavailable")
@@ -271,6 +397,25 @@ def _atomic_bytes_write(path: Path, payload: bytes, *, mode: int = 0o600) -> Non
     """Atomically write bytes below an anchored, no-follow parent directory."""
 
     path = Path(path)
+    if not _SECURE_DIRFD:
+        parent = Path(_absolute_anchored_path(path.parent))
+        parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        _validate_no_symlink_chain(parent)
+        handle_fd, temporary_text = tempfile.mkstemp(
+            prefix=f".{path.name}.", suffix=".tmp", dir=str(parent)
+        )
+        try:
+            with os.fdopen(handle_fd, "wb") as handle:
+                handle.write(payload)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(temporary_text, str(path))
+        finally:
+            try:
+                os.unlink(temporary_text)
+            except OSError:
+                pass
+        return
     parent_fd = _ensure_dir_fd_nofollow(path.parent)
     fd: int | None = None
     temporary_name: str | None = None
@@ -332,6 +477,16 @@ def _append_jsonl(path: Path, record: dict[str, Any]) -> None:
     # ``Path.open('a')`` follows a final symlink.  Commands and receipts are
     # control-plane data, so fail closed unless the whole parent chain and
     # final file can be opened with anchored no-follow semantics.
+    if not _SECURE_DIRFD:
+        parent = Path(_absolute_anchored_path(path.parent))
+        parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        _validate_no_symlink_chain(parent)
+        with open(str(path), "a", encoding="utf-8") as handle:
+            with _process_lock(handle):
+                handle.write(line)
+                handle.flush()
+                os.fsync(handle.fileno())
+        return
     fd: int | None = None
     parent_fd: int | None = None
     try:
@@ -496,6 +651,19 @@ class ControlBus:
         """
 
         with self._lock:
+            if not _SECURE_DIRFD:
+                # Windows fallback: path-based lock file with an msvcrt
+                # byte-range lock.  Weaker than anchored walking, but it is a
+                # real cross-process critical section.
+                self.root.mkdir(mode=0o700, parents=True, exist_ok=True)
+                _validate_no_symlink_chain(self.root)
+                fallback_handle = open(str(self.lock_path), "a+", encoding="utf-8")
+                try:
+                    with _process_lock(fallback_handle):
+                        yield
+                finally:
+                    fallback_handle.close()
+                return
             lock_handle = None
             # Directory-boundary failures are surfaced as OSError so callers
             # can distinguish an invalid/symlinked run layout from a platform

--- a/src/lh_harness/supervisor/service.py
+++ b/src/lh_harness/supervisor/service.py
@@ -27,13 +27,16 @@ from typing import Any
 from .control_bus import (
     ControlBus,
     RevisionConflict,
+    _SECURE_DIRFD,
     _atomic_bytes_write,
     _ensure_dir_fd_nofollow,
     _ensure_dir_nofollow,
     _open_nofollow,
     _open_private_regular_at,
+    _process_lock,
     _read_json_file,
     _read_jsonl,
+    _validate_no_symlink_chain,
 )
 from .lifecycle import (
     ACTIVE_STATUSES,
@@ -641,6 +644,17 @@ class RunSupervisor:
         """Serialize launch/resume idempotency transactions across workers."""
 
         lock_path = self.runs_root / ".supervisor.lock"
+        if not _SECURE_DIRFD:
+            # Windows fallback: validated path + msvcrt byte-range lock.
+            lock_path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+            _validate_no_symlink_chain(lock_path.parent)
+            fallback_handle = open(str(lock_path), "a+", encoding="utf-8")
+            try:
+                with _process_lock(fallback_handle):
+                    yield
+            finally:
+                fallback_handle.close()
+            return
         handle = None
         flock = None
         raw_fd: int | None = None
@@ -1019,7 +1033,7 @@ class RunSupervisor:
                     "signal_replay_attempted_at": time.time(),
                 }
             )
-            if str(owner.get("signal_mode") or "pgid") == "pid":
+            if str(owner.get("signal_mode") or "pgid") == "pid" or not hasattr(os, "killpg"):
                 os.kill(pid, sig)
             else:
                 os.killpg(pgid, sig)
@@ -1725,7 +1739,10 @@ class RunSupervisor:
             # unowned worker running if the durable reservation cannot be
             # promoted to a live owner.
             try:
-                os.killpg(process.pid, signal.SIGKILL)
+                if hasattr(os, "killpg"):
+                    os.killpg(process.pid, signal.SIGKILL)
+                else:
+                    process.kill()
             except OSError:
                 pass
             raise
@@ -2135,8 +2152,11 @@ class RunSupervisor:
             if process.poll() is not None:
                 continue
             try:
-                os.killpg(process.pid, signal.SIGKILL)
-            except ProcessLookupError:
+                if hasattr(os, "killpg"):
+                    os.killpg(process.pid, signal.SIGKILL)
+                else:
+                    process.kill()
+            except (ProcessLookupError, AttributeError):
                 pass
             except PermissionError:
                 # These are still verified in-memory children; fall back to

--- a/src/lh_harness/supervisor/service.py
+++ b/src/lh_harness/supervisor/service.py
@@ -56,7 +56,28 @@ from ..types import (
     DEFAULT_MAX_ROUNDS,
     MAX_ROUNDS,
 )
+from ..utils import win_job
+from ..utils.process_group import SIGKILL
 from ..utils.run_boundary import safe_run_control, safe_run_dir, safe_run_logs, safe_run_role, safe_run_rounds
+
+
+def _signal_worker(pgid: int, pid: int, sig: int, *, mode: str = "pgid") -> None:
+    """Single dispatch point for worker stop/abort signals (test seam).
+
+    POSIX signals the process group (``killpg``) or a single pid exactly as
+    before.  Windows has neither ``killpg`` nor safe raw-pid signalling: the
+    recorded Job Object terminates the tree by kernel handle, and the
+    liveness-checked fallback refuses reused or self pids.
+    """
+
+    if os.name == "nt":
+        if not win_job.kill_tree(pid):
+            win_job.kill_pid_tree(pid, sig)
+        return
+    if mode == "pid" or not hasattr(os, "killpg"):
+        os.kill(pid, sig)
+        return
+    os.killpg(pgid, sig)
 
 
 # Keep a private handle for read-only ``ps`` probes. Tests and embedding code
@@ -162,6 +183,33 @@ def _write_all(fd: int, data: bytes) -> None:
         view = view[written:]
 
 
+def _compact_worker_log_tail(fd: int, size: int) -> None:
+    """Keep only the newest tail of an oversized worker log (fd positioned end)."""
+
+    if size <= _MAX_WORKER_LOG_BYTES:
+        return
+    keep = max(1, min(_WORKER_LOG_KEEP_BYTES, _MAX_WORKER_LOG_BYTES))
+    start = max(0, size - keep)
+    os.lseek(fd, start, os.SEEK_SET)
+    tail = bytearray()
+    remaining = keep
+    while remaining:
+        chunk = os.read(fd, remaining)
+        if not chunk:
+            break
+        tail.extend(chunk)
+        remaining -= len(chunk)
+    os.ftruncate(fd, 0)
+    os.lseek(fd, 0, os.SEEK_SET)
+    _write_all(fd, bytes(tail))
+    try:
+        os.fsync(fd)
+    except OSError:
+        # The log is diagnostic; inability to flush it must not turn a
+        # successfully opened regular file into a launch deadlock.
+        pass
+
+
 def _open_worker_log(path: Path):
     """Open a run-local worker log without following the final symlink.
 
@@ -172,15 +220,34 @@ def _open_worker_log(path: Path):
     between validation and launch.  Existing oversized logs are compacted to
     their newest tail before the worker starts.
 
-    Platforms without ``O_NOFOLLOW`` are rejected explicitly.  A best-effort
-    ``Path.is_symlink`` check would make the security guarantee depend on a
-    timing window, which is worse than refusing to launch the worker.
+    Platforms without ``O_NOFOLLOW`` (Windows) fall back to a plain open
+    guarded by a best-effort symlink scan of the whole parent chain: weaker
+    than the anchored walk, but the run tree is owned by the same operator
+    who started the supervisor, and refusing to launch the worker at all is
+    not a useful security posture on those platforms.
     """
 
     path = Path(path)
     nofollow = getattr(os, "O_NOFOLLOW", 0)
     if not nofollow:
-        raise OSError(errno.ENOTSUP, "worker log requires O_NOFOLLOW")
+        _validate_no_symlink_chain(path.parent)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        if path.is_symlink():
+            raise OSError(errno.ELOOP, "worker log is a symlink")
+        handle = open(str(path), "a+b", buffering=0)
+        try:
+            fd = handle.fileno()
+            metadata = os.fstat(fd)
+            if not stat.S_ISREG(metadata.st_mode):
+                raise OSError(errno.EINVAL, "worker log is not a regular file")
+            if metadata.st_nlink != 1:
+                raise OSError(errno.ELOOP, "worker log has multiple hard links")
+            _compact_worker_log_tail(fd, metadata.st_size)
+            os.lseek(fd, 0, os.SEEK_END)
+            return handle
+        except BaseException:
+            handle.close()
+            raise
     cloexec = getattr(os, "O_CLOEXEC", 0)
     nonblock = getattr(os, "O_NONBLOCK", 0)
     # O_NONBLOCK prevents opening an attacker-supplied FIFO from hanging the
@@ -216,27 +283,7 @@ def _open_worker_log(path: Path):
             # regular-file checks remain mandatory.
             pass
 
-        if metadata.st_size > _MAX_WORKER_LOG_BYTES:
-            keep = max(1, min(_WORKER_LOG_KEEP_BYTES, _MAX_WORKER_LOG_BYTES))
-            start = max(0, metadata.st_size - keep)
-            os.lseek(fd, start, os.SEEK_SET)
-            tail = bytearray()
-            remaining = keep
-            while remaining:
-                chunk = os.read(fd, remaining)
-                if not chunk:
-                    break
-                tail.extend(chunk)
-                remaining -= len(chunk)
-            os.ftruncate(fd, 0)
-            os.lseek(fd, 0, os.SEEK_SET)
-            _write_all(fd, bytes(tail))
-            try:
-                os.fsync(fd)
-            except OSError:
-                # The log is diagnostic; inability to flush it must not turn a
-                # successfully opened regular file into a launch deadlock.
-                pass
+        _compact_worker_log_tail(fd, metadata.st_size)
 
         os.lseek(fd, 0, os.SEEK_END)
         # ``a+b`` keeps the descriptor usable for a future in-process
@@ -276,7 +323,57 @@ def _saved_task_from_rounds(
     directory = getattr(os, "O_DIRECTORY", 0)
     cloexec = getattr(os, "O_CLOEXEC", 0)
     if not nofollow or not directory or os.open not in getattr(os, "supports_dir_fd", set()):
-        return ""
+        if os.name != "nt":
+            return ""
+        # Windows fallback: plain opens guarded by a best-effort symlink scan
+        # of every component between the runs root and the round directory.
+        try:
+            base = Path(runs_root).expanduser().resolve()
+            run_path = safe_run_dir(base, run_id)
+            if run_path is None:
+                return ""
+            logs_path = safe_run_logs(base, run_path, allow_missing=False)
+            role_path = safe_run_role(base, run_path, allow_missing=False)
+            if logs_path is None or role_path is None:
+                return ""
+            rounds_dir = base / run_id / logs_path.name / role_path.name / "rounds"
+            _validate_no_symlink_chain(rounds_dir)
+            candidates: list[tuple[int, str]] = []
+            for entry in os.scandir(rounds_dir):
+                name = str(entry.name)
+                suffix = name.removeprefix("round_")
+                if suffix == name or not suffix.isdecimal():
+                    continue
+                candidates.append((int(suffix), name))
+            for _, name in sorted(candidates):
+                try:
+                    round_dir = rounds_dir / name
+                    if round_dir.is_symlink() or not round_dir.is_dir():
+                        continue
+                    contract = round_dir / "task_contract.txt"
+                    if contract.is_symlink():
+                        continue
+                    metadata = os.stat(contract)
+                    if (
+                        not stat.S_ISREG(metadata.st_mode)
+                        or metadata.st_nlink != 1
+                        or metadata.st_size > _MAX_SAVED_TASK_BYTES
+                    ):
+                        continue
+                    raw = contract.read_bytes()[: _MAX_SAVED_TASK_BYTES + 1]
+                    if len(raw) > _MAX_SAVED_TASK_BYTES:
+                        continue
+                    text = bytes(raw).decode("utf-8", errors="replace").replace("\r\n", "\n").strip()
+                    if not text:
+                        continue
+                    if first_line:
+                        return text.splitlines()[0].strip()
+                    return text
+                except (OSError, RuntimeError, ValueError):
+                    continue
+            return ""
+        except (OSError, RuntimeError, ValueError):
+            return ""
     directory_flags = os.O_RDONLY | directory | nofollow | cloexec
     file_flags = os.O_RDONLY | nofollow | cloexec | getattr(os, "O_NONBLOCK", 0)
     opened: list[int] = []
@@ -646,13 +743,26 @@ class RunSupervisor:
         lock_path = self.runs_root / ".supervisor.lock"
         if not _SECURE_DIRFD:
             # Windows fallback: validated path + msvcrt byte-range lock.
-            lock_path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
-            _validate_no_symlink_chain(lock_path.parent)
-            fallback_handle = open(str(lock_path), "a+", encoding="utf-8")
             try:
-                with _process_lock(fallback_handle):
-                    yield
+                _validate_no_symlink_chain(lock_path)
+                lock_path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+                _validate_no_symlink_chain(lock_path)
+                fallback_handle = open(str(lock_path), "a+", encoding="utf-8")
+                metadata = os.fstat(fallback_handle.fileno())
+                if not stat.S_ISREG(metadata.st_mode) or metadata.st_nlink != 1:
+                    raise OSError("supervisor lock is not an unaliased regular file")
+            except OSError as exc:
+                raise RuntimeError("secure supervisor locking is unavailable") from exc
+            lock_context = _process_lock(fallback_handle)
+            try:
+                lock_context.__enter__()
+            except OSError as exc:
+                fallback_handle.close()
+                raise RuntimeError("secure supervisor locking is unavailable") from exc
+            try:
+                yield
             finally:
+                lock_context.__exit__(None, None, None)
                 fallback_handle.close()
             return
         handle = None
@@ -833,8 +943,16 @@ class RunSupervisor:
         if pid <= 0:
             return False
         try:
-            os.kill(pid, 0)
+            if os.name == "nt":
+                # os.kill(pid, 0) terminates on Windows — probe via a real
+                # liveness check instead.
+                alive = win_job.pid_alive(pid)
+            else:
+                os.kill(pid, 0)
+                alive = True
         except OSError:
+            alive = False
+        if not alive:
             return False
         # An embedded supervisor controls its hosting process directly.  The
         # PID cannot be reused while that same process is executing this code;
@@ -1022,7 +1140,7 @@ class RunSupervisor:
             # Identity mismatch is intentionally fail-closed: never signal a
             # reused PID merely because the old owner record said it was alive.
             return reconcile_unavailable("worker is no longer running or its identity changed")
-        sig = signal.SIGKILL if action == "abort" else signal.SIGTERM
+        sig = SIGKILL if action == "abort" else signal.SIGTERM
         # Record an attempt for diagnostics under the same lock used by status
         # merges. Do not use it as a once-only gate: a crash after the signal
         # and before the receipt needs one safe retry.
@@ -1034,9 +1152,9 @@ class RunSupervisor:
                 }
             )
             if str(owner.get("signal_mode") or "pgid") == "pid" or not hasattr(os, "killpg"):
-                os.kill(pid, sig)
+                _signal_worker(pgid, pid, sig, mode="pid")
             else:
-                os.killpg(pgid, sig)
+                _signal_worker(pgid, pid, sig, mode="pgid")
         except ProcessLookupError:
             return reconcile_unavailable("worker is no longer running")
         except PermissionError:
@@ -1974,7 +2092,7 @@ class RunSupervisor:
                         None,
                     )
                     receipt = bus.receipt_for(active_command_id)
-                    active_signal = signal.SIGKILL.name if active_kind == "abort" else signal.SIGTERM.name
+                    active_signal = SIGKILL.name if active_kind == "abort" else signal.SIGTERM.name
                     return {
                         "command_id": active_command_id,
                         "status": str((receipt or {}).get("status") or "accepted"),
@@ -2058,10 +2176,10 @@ class RunSupervisor:
                 bus.receipt(command, "accepted", message="queued cooperative embedded cancellation")
                 return {"command_id": command["command_id"], "status": "accepted", "signal": sig.name}
             try:
-                if str(owner.get("signal_mode") or "pgid") == "pid":
-                    os.kill(owner_pid, sig)
+                if str(owner.get("signal_mode") or "pgid") == "pid" or not hasattr(os, "killpg"):
+                    _signal_worker(pgid, owner_pid, sig, mode="pid")
                 else:
-                    os.killpg(pgid, sig)
+                    _signal_worker(pgid, owner_pid, sig, mode="pgid")
             except ProcessLookupError:
                 # The signal raced with process exit.  Do not leave a durable
                 # ``stopping`` state behind: reconcile from the final report,
@@ -2119,7 +2237,7 @@ class RunSupervisor:
         return self._signal(run_id, signal.SIGTERM, kind="stop")
 
     def abort(self, run_id: str) -> dict[str, Any]:
-        return self._signal(run_id, signal.SIGKILL, kind="abort")
+        return self._signal(run_id, SIGKILL, kind="abort")
 
     def shutdown(self, *, grace_seconds: float = 5.0) -> None:
         """Stop workers launched by this supervisor before its API exits.

--- a/src/lh_harness/types.py
+++ b/src/lh_harness/types.py
@@ -102,6 +102,7 @@ class ManagedRound:
     manager_status: dict[str, Any] = field(default_factory=dict)
     executor_status: dict[str, Any] = field(default_factory=dict)
     auditor_status: dict[str, Any] = field(default_factory=dict)
+    token_usage: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass

--- a/src/lh_harness/utils/platform_caps.py
+++ b/src/lh_harness/utils/platform_caps.py
@@ -1,0 +1,44 @@
+"""Single home for platform capability detection.
+
+``supervisor/control_bus.py`` previously owned the anchored-walk capability
+flag and the best-effort symlink scan; the dashboard and adapters grew their
+own ``os.name`` checks.  Centralising them here keeps the fallback semantics
+from drifting between modules.  POSIX behaviour is never changed by anything
+in this module — every guard degrades only where the capability is absent.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+
+IS_WINDOWS = os.name == "nt"
+
+# Anchored no-follow walking needs O_NOFOLLOW/O_DIRECTORY plus dir-fd variants
+# of open/mkdir.  POSIX platforms provide them; Windows does not.  Callers on
+# those platforms degrade to plain path operations guarded by a best-effort
+# symlink scan instead of failing closed, because the run tree is owned by the
+# same operator who started the process.
+SECURE_DIRFD = bool(
+    getattr(os, "O_NOFOLLOW", 0)
+    and getattr(os, "O_DIRECTORY", 0)
+    and os.open in getattr(os, "supports_dir_fd", set())
+    and os.mkdir in getattr(os, "supports_dir_fd", set())
+)
+
+
+def validate_no_symlink_chain(path: Path) -> None:
+    """Reject any symlinked component below the anchor (best-effort platforms)."""
+
+    absolute = Path(os.path.abspath(os.fspath(path)))
+    anchor_parts = len(Path(absolute.anchor).parts)
+    current = Path(*absolute.parts[:anchor_parts])
+    for component in absolute.parts[anchor_parts:]:
+        current = current / component
+        try:
+            metadata = os.lstat(current)
+        except FileNotFoundError:
+            return
+        if stat.S_ISLNK(metadata.st_mode):
+            raise OSError(f"symlinked path component rejected: {current}")

--- a/src/lh_harness/utils/platform_shell.py
+++ b/src/lh_harness/utils/platform_shell.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import os
 import shlex
 
-IS_WINDOWS = os.name == "nt"
+from .platform_caps import IS_WINDOWS
 
 
 def shell_quote(value: str) -> str:

--- a/src/lh_harness/utils/platform_shell.py
+++ b/src/lh_harness/utils/platform_shell.py
@@ -1,0 +1,47 @@
+"""Platform-aware shell quoting for agent command templates.
+
+Agent command templates are executed through the local default shell
+(``asyncio.create_subprocess_shell``): POSIX ``sh`` on macOS/Linux and
+``cmd.exe`` on Windows.  The historical templates were POSIX-only: single
+quotes, ``VAR=value`` leading assignments, and plain ``cd`` all break under
+cmd.exe.  These helpers emit the right syntax per platform so one template
+works everywhere.
+"""
+
+from __future__ import annotations
+
+import os
+import shlex
+
+IS_WINDOWS = os.name == "nt"
+
+
+def shell_quote(value: str) -> str:
+    """Quote one token for the platform's default shell."""
+
+    text = str(value)
+    if IS_WINDOWS:
+        # cmd.exe has no single-quote escaping; double quotes are literal
+        # delimiters and embedded quotes double per CRT argument rules.
+        return f'"{text.replace(chr(34), chr(34) * 2)}"'
+    return shlex.quote(text)
+
+
+def cd_command(path: str) -> str:
+    """Change into ``path`` before the agent command runs."""
+
+    if IS_WINDOWS:
+        # /d also switches drives (e.g. workspace on D:, harness started from C:).
+        return f"cd /d {shell_quote(path)}"
+    return f"cd {shlex.quote(path)}"
+
+
+def env_prefix(assignments: list[tuple[str, str]]) -> str:
+    """Serialize leading environment assignments for the platform's shell."""
+
+    if not assignments:
+        return ""
+    if IS_WINDOWS:
+        # cmd.exe cannot prefix assignments; `set` them in the same line.
+        return "".join(f'set "{key}={value}"&& ' for key, value in assignments)
+    return " ".join(f"{key}={shlex.quote(value)}" for key, value in assignments) + " "

--- a/src/lh_harness/utils/process_group.py
+++ b/src/lh_harness/utils/process_group.py
@@ -22,9 +22,17 @@ import sys
 import threading
 import time
 
+from . import win_job
+
 _lock = threading.Lock()
 _tracked: set[int] = set()
 _installed = False
+
+# Windows has no SIGKILL constant.  There the pid-based fallback in
+# signal_process_group already terminates hard (TerminateProcess), and the
+# Job Object tree kill covers group semantics, so SIGTERM is the correct
+# stand-in for the escalation constant on that platform.
+SIGKILL = getattr(signal, "SIGKILL", signal.SIGTERM)
 
 
 def track_process_group(pid: int) -> None:
@@ -46,12 +54,17 @@ def signal_process_group(pid: int, sig: int) -> bool:
         except (ProcessLookupError, PermissionError, OSError):
             return False
         return True
-    # Windows: no cross-PID process groups; target the tracked PID directly.
-    try:
-        os.kill(pid, sig)
-    except (ProcessLookupError, PermissionError, OSError):
-        return False
-    return True
+    # Windows: prefer the Job Object recorded for this pid — the handle, not
+    # the pid, selects the victim, so a reused pid can never redirect the
+    # kill.  Without a job (operator-initiated stops of externally launched
+    # workers), fall back to a liveness-checked hard kill of that pid.
+    if sig == 0:
+        # Existence probe: os.kill(pid, 0) terminates on Windows, so answer
+        # from a query-only handle instead.
+        return win_job.pid_alive(pid)
+    if win_job.kill_tree(pid):
+        return True
+    return win_job.kill_pid_tree(pid, sig)
 
 
 def kill_process_group(pid: int, *, grace_seconds: float = 1.0) -> None:
@@ -66,16 +79,29 @@ def kill_process_group(pid: int, *, grace_seconds: float = 1.0) -> None:
     while time.monotonic() < deadline:
         # Signal 0 only probes for existence; once the group is gone the CLI has
         # flushed its trajectory and there is nothing left to escalate against.
-        if not signal_process_group(pid, 0):
+        if os.name == "nt":
+            alive = win_job.pid_alive(pid)
+        else:
+            alive = signal_process_group(pid, 0)
+        if not alive:
             return
         time.sleep(0.05)
-    signal_process_group(pid, signal.SIGKILL)
+    signal_process_group(pid, SIGKILL)
 
 
 def kill_all_tracked() -> None:
     with _lock:
         pids = list(_tracked)
         _tracked.clear()
+    if not pids:
+        return
+    if win_job.supported():
+        # Job Objects terminate whole trees and are immune to pid reuse; any
+        # pid without a recorded job still gets the liveness-checked fallback.
+        for pid in pids:
+            if not win_job.kill_tree(pid):
+                win_job.kill_pid_tree(pid, SIGKILL)
+        return
     for pid in pids:
         kill_process_group(pid)
 

--- a/src/lh_harness/utils/process_group.py
+++ b/src/lh_harness/utils/process_group.py
@@ -40,8 +40,15 @@ def untrack_process_group(pid: int) -> None:
 
 def signal_process_group(pid: int, sig: int) -> bool:
     """Best-effort ``killpg``; False means the group is already gone."""
+    if hasattr(os, "killpg"):
+        try:
+            os.killpg(pid, sig)
+        except (ProcessLookupError, PermissionError, OSError):
+            return False
+        return True
+    # Windows: no cross-PID process groups; target the tracked PID directly.
     try:
-        os.killpg(pid, sig)
+        os.kill(pid, sig)
     except (ProcessLookupError, PermissionError, OSError):
         return False
     return True
@@ -87,7 +94,13 @@ def _install_handlers() -> None:
     if threading.current_thread() is not threading.main_thread():
         return
 
-    for sig in (signal.SIGTERM, signal.SIGHUP):
+    for sig in [
+        getattr(signal, name)
+        for name in ("SIGTERM", "SIGHUP")
+        if hasattr(signal, name)
+    ]:
+        if not sig:
+            continue
         try:
             previous = signal.getsignal(sig)
         except (ValueError, OSError):

--- a/src/lh_harness/utils/win_job.py
+++ b/src/lh_harness/utils/win_job.py
@@ -1,0 +1,229 @@
+"""Windows Job Object helpers for safe child-process tree management.
+
+Terminating processes by raw pid is unsafe on Windows: after a child exits,
+Windows may reuse its pid for an unrelated process, and a pid-based
+``TerminateProcess`` would then kill the victim.  Assigning every spawned
+child to a Job Object with ``JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`` gives
+kernel-guaranteed tree termination instead: closing (or explicitly
+terminating) the job kills every process still inside it, and the job of an
+already-exited child simply has nothing left to kill.
+
+POSIX platforms never import this module's call sites (guards in
+``utils/process_group.py`` and ``environment/local.py`` keep the existing
+``killpg`` behaviour untouched).
+"""
+
+from __future__ import annotations
+
+import atexit
+import ctypes
+import os
+import threading
+from ctypes import wintypes
+
+__all__ = ["supported", "assign", "kill_tree", "kill_pid_tree", "sweep_all"]
+
+_JOB_HANDLE_NONE = 0
+_REGISTRY: dict[int, int] = {}
+_REGISTRY_LOCK = threading.Lock()
+_SWEEP_INSTALLED = False
+
+_JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE = 0x00002000
+_JOB_OBJECT_EXTENDED_LIMIT_INFORMATION_CLASS = 9  # JobObjectExtendedLimitInformation
+_PROCESS_SET_QUOTA = 0x0100
+_PROCESS_TERMINATE = 0x0001
+_PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+_STILL_ACTIVE = 259
+_INVALID_HANDLE_VALUE = -1
+
+
+class _IO_COUNTERS(ctypes.Structure):
+    _fields_ = [(name, ctypes.c_ulonglong) for name in (
+        "ReadOperationCount", "WriteOperationCount", "OtherOperationCount",
+        "ReadTransferCount", "WriteTransferCount", "OtherTransferCount",
+    )]
+
+
+class _JOBOBJECT_BASIC_LIMIT_INFORMATION(ctypes.Structure):
+    _fields_ = [
+        ("PerProcessUserTimeLimit", wintypes.LARGE_INTEGER),
+        ("PerJobUserTimeLimit", wintypes.LARGE_INTEGER),
+        ("LimitFlags", wintypes.DWORD),
+        ("MinimumWorkingSetSize", ctypes.c_size_t),
+        ("MaximumWorkingSetSize", ctypes.c_size_t),
+        ("ActiveProcessLimit", wintypes.DWORD),
+        ("Affinity", ctypes.POINTER(wintypes.ULONG)),
+        ("PriorityClass", wintypes.DWORD),
+        ("SchedulingClass", wintypes.DWORD),
+    ]
+
+
+class _JOBOBJECT_EXTENDED_LIMIT_INFORMATION(ctypes.Structure):
+    _fields_ = [
+        ("BasicLimitInformation", _JOBOBJECT_BASIC_LIMIT_INFORMATION),
+        ("IoInfo", _IO_COUNTERS),
+        ("ProcessMemoryLimit", ctypes.c_size_t),
+        ("JobMemoryLimit", ctypes.c_size_t),
+        ("PeakProcessMemoryUsed", ctypes.c_size_t),
+        ("PeakJobMemoryUsed", ctypes.c_size_t),
+    ]
+
+
+def _kernel32():
+    return ctypes.WinDLL("kernel32", use_last_error=True)
+
+
+def supported() -> bool:
+    """True on Windows where Job Object APIs are available."""
+
+    return os.name == "nt"
+
+
+def _install_sweep() -> None:
+    global _SWEEP_INSTALLED
+    with _REGISTRY_LOCK:
+        if _SWEEP_INSTALLED:
+            return
+        _SWEEP_INSTALLED = True
+    atexit.register(sweep_all)
+
+
+def assign(pid: int) -> int:
+    """Put ``pid`` into a fresh kill-on-close Job; return the job handle.
+
+    Returns 0 when assignment is impossible (non-Windows, the process already
+    exited, or an API failure) — callers treat 0 as "no job", not as an error:
+    the handle-based ``proc.terminate()`` escalation still covers them.
+    """
+
+    if not supported():
+        return _JOB_HANDLE_NONE
+    k32 = _kernel32()
+    job = k32.CreateJobObjectW(None, None)
+    if not job:
+        return _JOB_HANDLE_NONE
+    limit = _JOBOBJECT_EXTENDED_LIMIT_INFORMATION()
+    limit.BasicLimitInformation.LimitFlags = _JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+    if not k32.SetInformationJobObject(
+        job,
+        _JOB_OBJECT_EXTENDED_LIMIT_INFORMATION_CLASS,
+        ctypes.byref(limit),
+        ctypes.sizeof(limit),
+    ):
+        ctypes.windll.kernel32.CloseHandle(job)
+        return _JOB_HANDLE_NONE
+    process = k32.OpenProcess(_PROCESS_SET_QUOTA | _PROCESS_TERMINATE, False, pid)
+    if not process:
+        ctypes.windll.kernel32.CloseHandle(job)
+        return _JOB_HANDLE_NONE
+    try:
+        if not k32.AssignProcessToJobObject(job, process):
+            k32.CloseHandle(process)
+            ctypes.windll.kernel32.CloseHandle(job)
+            return _JOB_HANDLE_NONE
+    finally:
+        # The job keeps its own reference to the member process; our process
+        # handle is only needed for the Assign call itself.
+        k32.CloseHandle(process)
+    _install_sweep()
+    with _REGISTRY_LOCK:
+        _REGISTRY[int(pid)] = job
+    return job
+
+
+def kill_tree(pid: int) -> bool:
+    """Terminate every process still inside the job previously made for ``pid``.
+
+    The job handle — not the pid — selects the victim, so a pid reused after
+    the child exited can never redirect the kill.  The registry entry is
+    consumed: the job is fully closed, whether or not anything was alive.
+    """
+
+    with _REGISTRY_LOCK:
+        job = _REGISTRY.pop(int(pid), _JOB_HANDLE_NONE)
+    if not job:
+        return False
+    k32 = _kernel32()
+    try:
+        k32.TerminateJobObject(job, 1)
+    finally:
+        k32.CloseHandle(job)
+    return True
+
+
+def pid_alive(pid: int) -> bool:
+    """Non-destructive liveness probe.
+
+    ``os.kill(pid, 0)`` is NOT a probe on Windows — CPython routes any signal
+    other than the CTRL_* events through ``TerminateProcess``, so the classic
+    POSIX existence check would kill the target.  This helper opens the
+    process with query rights only and inspects its exit code.
+    """
+
+    if not supported():
+        return False
+    pid = int(pid)
+    if pid <= 0:
+        return False
+    if pid == os.getpid():
+        return True
+    k32 = _kernel32()
+    process = k32.OpenProcess(_PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
+    if not process:
+        return False
+    try:
+        code = wintypes.DWORD(0)
+        if not k32.GetExitCodeProcess(process, ctypes.byref(code)):
+            return False
+        return code.value == _STILL_ACTIVE
+    finally:
+        k32.CloseHandle(process)
+
+
+def kill_pid_tree(pid: int, sig: int | None = None) -> bool:
+    """Best-effort hard kill of ``pid``'s tree when no job handle exists.
+
+    This is inherently exposed to the pid-reuse race (used only for
+    operator-initiated stops where no job was recorded), so it refuses to
+    terminate our own pid and re-checks liveness through a fresh handle
+    immediately before the kill.  ``sig`` is accepted for signature
+    compatibility; on Windows any non-zero value terminates.
+    """
+
+    if not supported():
+        return False
+    pid = int(pid)
+    if pid <= 0 or pid == os.getpid():
+        return False
+    k32 = _kernel32()
+    process = k32.OpenProcess(_PROCESS_TERMINATE, False, pid)
+    if not process:
+        return False
+    try:
+        code = wintypes.DWORD(0)
+        if not k32.GetExitCodeProcess(process, ctypes.byref(code)):
+            return False
+        STILL_ACTIVE = 259
+        if code.value != STILL_ACTIVE:
+            return False
+        return bool(k32.TerminateProcess(process, 1))
+    finally:
+        k32.CloseHandle(process)
+
+
+def sweep_all() -> None:
+    """Terminate and close every job this process ever created."""
+
+    with _REGISTRY_LOCK:
+        items = list(_REGISTRY.items())
+        _REGISTRY.clear()
+    k32 = _kernel32()
+    for _pid, job in items:
+        try:
+            k32.TerminateJobObject(job, 1)
+        except OSError:
+            pass
+        try:
+            k32.CloseHandle(job)
+        except OSError:
+            pass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import os
+import re
+from pathlib import Path
 from urllib.parse import urljoin
 
 import fastapi.testclient as fastapi_testclient
@@ -9,6 +12,74 @@ import starlette.testclient as starlette_testclient
 
 _Orig = starlette_testclient.TestClient
 _Upgrade = starlette_testclient._Upgrade
+
+
+def write_executable_stub(path: Path, body: str) -> str:
+    """Create a fake agent CLI binary for adapter tests.
+
+    POSIX receives an ``sh`` script exactly as before.  Windows cannot exec
+    shebang scripts, so the same small sh grammar the suite uses (``echo``,
+    ``printf ... >&2``, ``exit N``, ``cat <<'EOF'`` heredocs) is translated
+    into a ``.cmd`` batch with equivalent behaviour.
+    """
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if os.name != "nt":
+        path.write_text("#!/bin/sh\n" + body, encoding="utf-8")
+        path.chmod(0o755)
+        return str(path)
+
+    lines = ["@echo off"]
+
+    def cmd_escape(text: str) -> str:
+        """Escape cmd.exe metacharacters so echo prints them literally."""
+
+        for ch in "^&|<>":
+            text = text.replace(ch, "^" + ch)
+        return text
+
+    consumed = body
+    heredoc = re.search(r"cat <<'?EOF'?\n(.*?)\nEOF", body, re.S)
+    if heredoc:
+        for payload_line in heredoc.group(1).splitlines():
+            lines.append("echo " + cmd_escape(payload_line))
+        consumed = consumed.replace(heredoc.group(0), "")
+    for raw in consumed.splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        conditional = re.match(
+            r'if \[ "\$1" = "(.*?)" \]; then echo "(.*?)"; exit 0; fi$', line
+        )
+        if conditional:
+            lines.append(f'if "%~1"=="{conditional.group(1)}" (')
+            lines.append(f"    echo {cmd_escape(conditional.group(2))}")
+            lines.append("    exit /b 0")
+            lines.append(")")
+            continue
+        if line == "printf '%s\\n' \"$*\"":
+            lines.append("echo %*")
+            continue
+        stderr_printf = re.match(r"printf '(.*)\\n' >&2$", line)
+        if stderr_printf:
+            lines.append(f"1>&2 echo {stderr_printf.group(1)}")
+            continue
+        stdout_printf = re.match(r"printf '(.*)\\n'$", line)
+        if stdout_printf:
+            lines.append(f"echo {stdout_printf.group(1)}")
+            continue
+        echo = re.match(r"echo \"?(.*?)\"?$", line)
+        if echo:
+            lines.append(f"echo {echo.group(1)}")
+            continue
+        exit_code = re.match(r"exit (\d+)$", line)
+        if exit_code:
+            lines.append(f"exit /b {exit_code.group(1)}")
+            continue
+        lines.append("rem unsupported stub line: " + line)
+    cmd_path = path.with_suffix(".cmd")
+    cmd_path.write_text("\r\n".join(lines) + "\r\n", encoding="utf-8")
+    return str(cmd_path)
 
 
 class LoopbackTestClient(_Orig):

--- a/tests/supervisor/test_hardening.py
+++ b/tests/supervisor/test_hardening.py
@@ -216,12 +216,20 @@ def test_control_bus_accepts_trusted_macos_var_alias(tmp_path: Path) -> None:
 
 
 def test_control_bus_fails_closed_when_process_lock_breaks(monkeypatch, tmp_path: Path) -> None:
-    import fcntl
+    if os.name == "nt":
+        import msvcrt
 
-    def broken_flock(*_args, **_kwargs):
-        raise OSError("lock unavailable")
+        def broken_locking(*_args, **_kwargs):
+            raise OSError("lock unavailable")
 
-    monkeypatch.setattr(fcntl, "flock", broken_flock)
+        monkeypatch.setattr(msvcrt, "locking", broken_locking)
+    else:
+        import fcntl
+
+        def broken_flock(*_args, **_kwargs):
+            raise OSError("lock unavailable")
+
+        monkeypatch.setattr(fcntl, "flock", broken_flock)
     with pytest.raises(RuntimeError, match="locking is unavailable"):
         ControlBus(tmp_path / "run").append("test")
 
@@ -399,7 +407,9 @@ def test_stop_keeps_stopping_state_while_stale_approval_is_present(
 
     process = _Process()
     monkeypatch.setattr("lh_harness.supervisor.service.subprocess.Popen", lambda *args, **kwargs: process)
-    monkeypatch.setattr("lh_harness.supervisor.service.os.killpg", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        "lh_harness.supervisor.service._signal_worker", lambda *_args, **_kwargs: None
+    )
     supervisor = RunSupervisor(tmp_path / "runs", workspace_root=tmp_path / "workspace")
     created = supervisor.create_run(task="stop me")
     run_dir = tmp_path / "runs" / created["id"]
@@ -425,7 +435,10 @@ def test_abort_escalates_stop_and_cross_action_retries_are_idempotent(
     process = _Process()
     signals: list[object] = []
     monkeypatch.setattr("lh_harness.supervisor.service.subprocess.Popen", lambda *args, **kwargs: process)
-    monkeypatch.setattr("lh_harness.supervisor.service.os.killpg", lambda _pid, sig: signals.append(sig))
+    monkeypatch.setattr(
+        "lh_harness.supervisor.service._signal_worker",
+        lambda _pgid, _pid, sig, **_kwargs: signals.append(sig),
+    )
     supervisor = RunSupervisor(tmp_path / "runs", workspace_root=tmp_path / "workspace")
     created = supervisor.create_run(task="stop then abort")
 
@@ -434,9 +447,9 @@ def test_abort_escalates_stop_and_cross_action_retries_are_idempotent(
     repeated_stop = supervisor.stop(created["id"])
 
     assert stopped["signal"] == "SIGTERM"
-    assert aborted["signal"] == "SIGKILL"
+    assert aborted["signal"] == supervisor_service.SIGKILL.name
     assert repeated_stop["idempotent"] is True
-    assert signals == [supervisor_service.signal.SIGTERM, supervisor_service.signal.SIGKILL]
+    assert signals == [supervisor_service.signal.SIGTERM, supervisor_service.SIGKILL]
     status = supervisor.status(created["id"])
     assert status["status"] == "stopping"
     assert status["requested_action"] == "abort"
@@ -446,7 +459,10 @@ def test_stop_after_abort_returns_abort_receipt_without_conflict(monkeypatch, tm
     process = _Process()
     signals: list[object] = []
     monkeypatch.setattr("lh_harness.supervisor.service.subprocess.Popen", lambda *args, **kwargs: process)
-    monkeypatch.setattr("lh_harness.supervisor.service.os.killpg", lambda _pid, sig: signals.append(sig))
+    monkeypatch.setattr(
+        "lh_harness.supervisor.service._signal_worker",
+        lambda _pgid, _pid, sig, **_kwargs: signals.append(sig),
+    )
     supervisor = RunSupervisor(tmp_path / "runs", workspace_root=tmp_path / "workspace")
     created = supervisor.create_run(task="abort then stop")
 
@@ -454,9 +470,9 @@ def test_stop_after_abort_returns_abort_receipt_without_conflict(monkeypatch, tm
     repeated = supervisor.stop(created["id"])
 
     assert repeated["command_id"] == "lifecycle-abort"
-    assert repeated["signal"] == "SIGKILL"
+    assert repeated["signal"] == supervisor_service.SIGKILL.name
     assert repeated["idempotent"] is True
-    assert signals == [supervisor_service.signal.SIGKILL]
+    assert signals == [supervisor_service.SIGKILL]
 
 
 def test_first_role_event_promotes_starting_worker_to_running(monkeypatch, tmp_path: Path) -> None:
@@ -600,10 +616,10 @@ def test_stop_persists_intent_before_signal(monkeypatch, tmp_path: Path) -> None
     monkeypatch.setattr("lh_harness.supervisor.service.subprocess.Popen", lambda *args, **kwargs: process)
     observed: list[str] = []
 
-    def killpg(_pid: int, _sig: object) -> None:
+    def killpg(_pgid: int, _pid: int, _sig: object, **_kwargs) -> None:
         observed.append(ControlBus(tmp_path / "runs" / created["id"]).read_status().get("status", ""))
 
-    monkeypatch.setattr("lh_harness.supervisor.service.os.killpg", killpg)
+    monkeypatch.setattr("lh_harness.supervisor.service._signal_worker", killpg)
     supervisor = RunSupervisor(tmp_path / "runs", workspace_root=tmp_path / "workspace")
     created = supervisor.create_run(task="ordering")
     supervisor.stop(created["id"])
@@ -613,7 +629,10 @@ def test_stop_persists_intent_before_signal(monkeypatch, tmp_path: Path) -> None
 def test_signal_process_lookup_reconciles_stopping_to_failed(monkeypatch, tmp_path: Path) -> None:
     process = _Process()
     monkeypatch.setattr("lh_harness.supervisor.service.subprocess.Popen", lambda *args, **kwargs: process)
-    monkeypatch.setattr("lh_harness.supervisor.service.os.killpg", lambda *args, **kwargs: (_ for _ in ()).throw(ProcessLookupError()))
+    monkeypatch.setattr(
+        "lh_harness.supervisor.service._signal_worker",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(ProcessLookupError()),
+    )
     supervisor = RunSupervisor(tmp_path / "runs", workspace_root=tmp_path / "workspace")
     created = supervisor.create_run(task="vanish")
 
@@ -629,7 +648,10 @@ def test_signal_process_lookup_reconciles_stopping_to_failed(monkeypatch, tmp_pa
 def test_signal_permission_failure_restores_active_state(monkeypatch, tmp_path: Path) -> None:
     process = _Process()
     monkeypatch.setattr("lh_harness.supervisor.service.subprocess.Popen", lambda *args, **kwargs: process)
-    monkeypatch.setattr("lh_harness.supervisor.service.os.killpg", lambda *args, **kwargs: (_ for _ in ()).throw(PermissionError()))
+    monkeypatch.setattr(
+        "lh_harness.supervisor.service._signal_worker",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(PermissionError()),
+    )
     supervisor = RunSupervisor(tmp_path / "runs", workspace_root=tmp_path / "workspace")
     created = supervisor.create_run(task="permission")
 
@@ -646,7 +668,10 @@ def test_pending_lifecycle_command_is_replayed_after_supervisor_restart(monkeypa
     process = _Process()
     monkeypatch.setattr("lh_harness.supervisor.service.subprocess.Popen", lambda *args, **kwargs: process)
     sent: list[object] = []
-    monkeypatch.setattr("lh_harness.supervisor.service.os.killpg", lambda pid, sig: sent.append((pid, sig)))
+    monkeypatch.setattr(
+        "lh_harness.supervisor.service._signal_worker",
+        lambda _pgid, pid, sig, **_kwargs: sent.append((pid, sig)),
+    )
     supervisor = RunSupervisor(tmp_path / "runs", workspace_root=tmp_path / "workspace")
     created = supervisor.create_run(task="replay stop")
     bus = ControlBus(tmp_path / "runs" / created["id"])
@@ -816,6 +841,10 @@ def test_worker_log_open_rejects_hardlink_alias(tmp_path: Path) -> None:
 def test_worker_log_open_compacts_old_tail_and_tightens_permissions(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    if os.name == "nt":
+        # Windows has no POSIX permission bits to tighten (fchmod does not
+        # exist); the compaction half of this guarantee is covered below.
+        pytest.skip("POSIX permission tightening has no NTFS equivalent")
     monkeypatch.setattr(supervisor_service, "_MAX_WORKER_LOG_BYTES", 64)
     monkeypatch.setattr(supervisor_service, "_WORKER_LOG_KEEP_BYTES", 32)
     run_dir = tmp_path / "run"

--- a/tests/supervisor/test_supervisor.py
+++ b/tests/supervisor/test_supervisor.py
@@ -36,7 +36,7 @@ def test_supervisor_creates_owned_run_without_touching_manager(monkeypatch, tmp_
 def test_web_supervisor_exposes_create_and_lifecycle_routes(monkeypatch, tmp_path: Path) -> None:
     process = FakeProcess()
     monkeypatch.setattr("lh_harness.supervisor.service.subprocess.Popen", lambda *args, **kwargs: process)
-    monkeypatch.setattr("lh_harness.supervisor.service.os.killpg", lambda *args, **kwargs: None)
+    monkeypatch.setattr("lh_harness.supervisor.service._signal_worker", lambda *args, **kwargs: None)
     root = tmp_path / "runs"
     supervisor = RunSupervisor(root, workspace_root=tmp_path / "workspace")
     client = TestClient(create_app(runs_root=root, supervisor=supervisor))
@@ -104,7 +104,7 @@ def test_web_supervisor_creates_deepseek_run_with_role_models(
 def test_websocket_pushes_supervisor_lifecycle_without_role_events(monkeypatch, tmp_path: Path) -> None:
     process = FakeProcess()
     monkeypatch.setattr("lh_harness.supervisor.service.subprocess.Popen", lambda *args, **kwargs: process)
-    monkeypatch.setattr("lh_harness.supervisor.service.os.killpg", lambda *args, **kwargs: None)
+    monkeypatch.setattr("lh_harness.supervisor.service._signal_worker", lambda *args, **kwargs: None)
     root = tmp_path / "runs"
     supervisor = RunSupervisor(root, workspace_root=tmp_path / "workspace")
     client = TestClient(create_app(runs_root=root, supervisor=supervisor))
@@ -213,12 +213,12 @@ def test_supervisor_shutdown_stops_owned_live_workers(monkeypatch, tmp_path: Pat
     process = FakeProcess()
     signals: list[object] = []
 
-    def killpg(_pid: int, sig: object) -> None:
+    def killpg(_pgid: int, _pid: int, sig: object, **_kwargs) -> None:
         signals.append(sig)
         process.returncode = -15
 
     monkeypatch.setattr("lh_harness.supervisor.service.subprocess.Popen", lambda *args, **kwargs: process)
-    monkeypatch.setattr("lh_harness.supervisor.service.os.killpg", killpg)
+    monkeypatch.setattr("lh_harness.supervisor.service._signal_worker", killpg)
     supervisor = RunSupervisor(tmp_path / "runs", workspace_root=tmp_path / "workspace")
     created = supervisor.create_run(task="stop with the Web API")
 

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -30,10 +30,9 @@ def _clear_probe_cache():
 
 
 def _stub(path: Path, body: str) -> str:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text("#!/bin/sh\n" + body, encoding="utf-8")
-    path.chmod(0o755)
-    return str(path)
+    from tests.conftest import write_executable_stub
+
+    return write_executable_stub(path, body)
 
 
 def test_cli_agent_choices_match_the_registry() -> None:

--- a/tests/test_audit_structured.py
+++ b/tests/test_audit_structured.py
@@ -1,0 +1,111 @@
+"""Structured (fenced JSON) audit verdicts: JSON-first parsing with regex fallback."""
+
+from __future__ import annotations
+
+import json
+
+from lh_harness.auditor_agent import parse_audit_report
+
+_HEADER = (
+    "Status: complete\n"
+    "Integrity: clean\n"
+    "Contract audit: aligned\n"
+)
+
+
+def _report(body: str, json_block: dict | None = None, *, valid_json: bool = True) -> str:
+    parts = [_HEADER, body]
+    if json_block is not None:
+        rendered = json.dumps(json_block, ensure_ascii=False, indent=2)
+        parts.append("```json\n" + (rendered if valid_json else rendered[:-4]) + "\n```")
+    return "\n".join(parts) + "\n"
+
+
+def test_json_verdict_is_authoritative_over_header() -> None:
+    # Header claims clean/aligned, but the machine-readable block reports a
+    # violation: the JSON wins and complete is demoted to incomplete.
+    raw = _report(
+        "Audit facts: everything looks fine.",
+        {
+            "status": "complete",
+            "integrity_status": "violation",
+            "contract_audit_status": "aligned",
+            "integrity_findings": [
+                {"type": "fabricated_artifact", "severity": "violation", "evidence": "screenshot not real"}
+            ],
+        },
+    )
+    report = parse_audit_report(raw, 3)
+    assert report.integrity_status == "violation"
+    assert report.status == "incomplete"
+    assert report.integrity_findings[0]["type"] == "fabricated_artifact"
+
+
+def test_contract_mismatch_in_json_demotes_complete() -> None:
+    raw = _report(
+        "Audit facts: fine.",
+        {"status": "complete", "integrity_status": "clean", "contract_audit_status": "needs_revision"},
+    )
+    report = parse_audit_report(raw, 1)
+    assert report.contract_audit_status == "needs_revision"
+    assert report.status == "incomplete"
+
+
+def test_partial_json_falls_back_per_field() -> None:
+    # Only `status` is valid in the block; integrity/contract come from the
+    # control header as before.
+    raw = _report(
+        "Audit facts: fine.",
+        {"status": "blocked", "integrity_status": "nonsense", "contract_audit_status": 42},
+    )
+    report = parse_audit_report(raw, 1)
+    assert report.status == "blocked"
+    assert report.integrity_status == "clean"
+    assert report.contract_audit_status == "aligned"
+
+
+def test_malformed_json_falls_back_to_legacy_parsing() -> None:
+    raw = _report("Audit facts: fine.", {"status": "complete"}, valid_json=False)
+    report = parse_audit_report(raw, 1)
+    assert report.status == "complete"
+    assert report.integrity_status == "clean"
+    assert report.contract_audit_status == "aligned"
+
+
+def test_no_json_block_legacy_reports_unchanged() -> None:
+    raw = _HEADER + "Audit facts: fine.\n"
+    report = parse_audit_report(raw, 2)
+    assert report.status == "complete"
+    assert report.integrity_status == "clean"
+    assert report.contract_audit_status == "aligned"
+    assert report.integrity_findings == []
+
+
+def test_structured_deleted_artifacts_become_ledger_entries() -> None:
+    raw = _report(
+        "Audit facts: executor deleted files.",
+        {
+            "status": "incomplete",
+            "integrity_status": "violation",
+            "contract_audit_status": "unknown",
+            "deleted_artifacts": [
+                {"path": "build/out.png", "reason": "stale artifact"},
+                {"path": "build/out.png", "reason": "duplicate ignored"},
+            ],
+        },
+    )
+    report = parse_audit_report(raw, 4)
+    assert report.integrity_status == "violation"
+    assert [item["path"] for item in report.artifact_actions] == ["build/out.png"]
+    assert report.artifact_actions[0]["action"] == "delete"
+    assert report.artifact_actions[0]["status"] == "delete_declared_unverified"
+
+
+def test_last_json_block_wins_when_multiple_present() -> None:
+    raw = _report(
+        "Audit facts: fine.",
+        {"status": "incomplete", "integrity_status": "clean", "contract_audit_status": "aligned"},
+    )
+    raw += "\n```json\n{\"status\": \"complete\", \"integrity_status\": \"clean\", \"contract_audit_status\": \"aligned\"}\n```\n"
+    report = parse_audit_report(raw, 1)
+    assert report.status == "complete"

--- a/tests/test_codex_adapter.py
+++ b/tests/test_codex_adapter.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import shlex
 from pathlib import Path
 
@@ -10,6 +11,7 @@ from fastapi.testclient import TestClient
 from lh_harness.adapters import codex as codex_adapter_module
 from lh_harness.adapters.codex import CodexAdapter
 from lh_harness.utils import agent_cli
+from lh_harness.utils.platform_shell import shell_quote
 from lh_harness.utils.agent_cli import (
     is_agent_binary_available,
     resolve_agent_binary,
@@ -25,10 +27,9 @@ def _executable(path: Path) -> str:
     like a real CLI; a bare `exit 0` is correctly reported as installed but
     unusable.
     """
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text('#!/bin/sh\necho "codex-cli 1.2.3"\nexit 0\n', encoding="utf-8")
-    path.chmod(0o755)
-    return str(path)
+    from tests.conftest import write_executable_stub
+
+    return write_executable_stub(path, 'echo "codex-cli 1.2.3"\nexit 0\n')
 
 
 @pytest.mark.parametrize(
@@ -101,7 +102,7 @@ def test_codex_adapter_quotes_resolved_binary_with_spaces(monkeypatch, tmp_path:
     monkeypatch.setattr(codex_adapter_module, "resolve_codex_binary", lambda: binary)
 
     adapter = CodexAdapter(model=None)
-    expected_binary = shlex.quote(binary)
+    expected_binary = shell_quote(binary)
 
     assert adapter.command_template.startswith(f"{expected_binary} exec ")
     assert adapter.command_template.endswith(" - < {prompt_path}")
@@ -109,7 +110,10 @@ def test_codex_adapter_quotes_resolved_binary_with_spaces(monkeypatch, tmp_path:
     # Parsing the command without the prompt placeholder confirms the quoted
     # path remains one executable token when handed to a POSIX shell.
     command_without_placeholder = adapter.command_template.removesuffix(" < {prompt_path}")
-    assert shlex.split(command_without_placeholder)[0] == binary
+    if os.name == "nt":
+        assert command_without_placeholder.split(" exec ")[0].strip('"') == binary
+    else:
+        assert shlex.split(command_without_placeholder)[0] == binary
 
 
 def test_web_meta_reports_the_resolved_codex_binary(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_deepseek_harness_adapter.py
+++ b/tests/test_deepseek_harness_adapter.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 import shlex
 from pathlib import Path
 
@@ -21,10 +22,9 @@ from lh_harness.webapi import server as web_server
 
 
 def _executable(path: Path, body: str) -> str:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text("#!/bin/sh\n" + body, encoding="utf-8")
-    path.chmod(0o755)
-    return str(path)
+    from tests.conftest import write_executable_stub
+
+    return write_executable_stub(path, body)
 
 
 def test_dsh_binary_environment_override() -> None:
@@ -57,7 +57,14 @@ def test_deepseek_adapter_quotes_binary_and_configures_isolated_home(
     )
 
     tokens = shlex.split(adapter.command_template.replace("{prompt_path}", "/tmp/prompt.md"))
-    assert tokens[:2] == ["DSH_HOME=/tmp/run with spaces/dsh-home", "DSH_PERMISSION_MODE=read-only"]
+    if os.name == "nt":
+        # cmd.exe cannot prefix assignments; the platform serializer uses
+        # `set "K=V"&& ` segments instead of leading `K=V` tokens.
+        joined = adapter.command_template.replace("{prompt_path}", "/tmp/prompt.md")
+        assert 'set "DSH_HOME=' in joined and "dsh-home" in joined
+        assert 'set "DSH_PERMISSION_MODE=read-only"' in joined
+    else:
+        assert tokens[:2] == ["DSH_HOME=/tmp/run with spaces/dsh-home", "DSH_PERMISSION_MODE=read-only"]
     assert "lh_harness.adapters.deepseek_runner" in tokens
     assert tokens[tokens.index("--binary") + 1] == binary
     assert adapter.permission_mode == "read-only"
@@ -77,7 +84,11 @@ def test_deepseek_runner_passes_headless_patch_and_emits_jsonl(
     assert record["type"] == "dsh.result"
     assert record["is_error"] is False
     assert "--profile headless --patch" in record["text"]
-    assert record["text"].endswith("fix the project")
+    if os.name == "nt":
+        # cmd's `echo %*` preserves the CRT quoting of the spaced argument.
+        assert record["text"].rstrip('"').endswith("fix the project")
+    else:
+        assert record["text"].endswith("fix the project")
     patch_path = prompt_path.with_name(f"{prompt_path.name}.dsh-model-patch.yml")
     assert "provider: deepseek-official" in patch_path.read_text(encoding="utf-8")
     assert 'model: "deepseek-v4-flash"' in patch_path.read_text(encoding="utf-8")

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -61,9 +61,9 @@ def test_codex_catalog_keeps_reasoning_efforts_without_rejecting_new_values() ->
 def test_deepseek_catalog_exposes_default_model_and_cli_availability(tmp_path: Path) -> None:
     # `available` is proven by running `--version`, not by a PATH lookup, so the
     # stub has to answer it the way a real CLI does.
-    binary = tmp_path / "dsh"
-    binary.write_text('#!/bin/sh\necho "dsh 0.9.1"\nexit 0\n', encoding="utf-8")
-    binary.chmod(0o755)
+    from tests.conftest import write_executable_stub
+
+    binary = write_executable_stub(tmp_path / "dsh", 'echo "dsh 0.9.1"' + "\n" + "exit 0" + "\n")
 
     models, discovery = _discover_deepseek_models(str(binary))
     catalog = discover_model_catalog(codex_binary=None, dsh_binary=str(binary))

--- a/tests/test_opencode_adapter.py
+++ b/tests/test_opencode_adapter.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 import shlex
 from pathlib import Path
 
@@ -18,10 +19,9 @@ from lh_harness.webapi import server as web_server
 
 
 def _executable(path: Path, body: str) -> str:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text("#!/bin/sh\n" + body, encoding="utf-8")
-    path.chmod(0o755)
-    return str(path)
+    from tests.conftest import write_executable_stub
+
+    return write_executable_stub(path, body)
 
 
 # Real events captured from `opencode run --format json` on v1.18.18.
@@ -166,7 +166,17 @@ def test_opencode_adapter_writes_endpoint_config_for_base_url(
     )
 
     tokens = shlex.split(adapter.command_template.replace("{prompt_path}", "/tmp/prompt.md"))
-    env = dict(item.split("=", 1) for item in tokens if "=" in item and item.split("=", 1)[0] in {"OPENCODE_API_KEY", "OPENCODE_CONFIG"})
+    template = adapter.command_template.replace("{prompt_path}", "/tmp/prompt.md")
+    if os.name == "nt":
+        # cmd serialization: `set "K=V"&& ` segments instead of leading tokens.
+        import re as _re
+
+        env = dict(
+            (m.group(1), m.group(2))
+            for m in _re.finditer(r'set "(OPENCODE_API_KEY|OPENCODE_CONFIG)=([^"]*)"', template)
+        )
+    else:
+        env = dict(item.split("=", 1) for item in tokens if "=" in item and item.split("=", 1)[0] in {"OPENCODE_API_KEY", "OPENCODE_CONFIG"})
     assert env["OPENCODE_API_KEY"] == "sk-test"
     config_path = env["OPENCODE_CONFIG"]
     config = json.loads(Path(config_path).read_text(encoding="utf-8"))

--- a/tests/test_opencode_mcp.py
+++ b/tests/test_opencode_mcp.py
@@ -1,0 +1,137 @@
+"""OpenCode computer-use wiring: plugin config format, state, adapter merge."""
+
+from __future__ import annotations
+
+import json
+import posixpath
+from pathlib import Path
+
+import pytest
+
+from lh_harness.adapters import opencode as opencode_module
+from lh_harness.adapters.opencode import OpenCodeAdapter
+from lh_harness.plugins import state as plugin_state
+from lh_harness.plugins.community_computer_use import CLAWDCURSOR, OPEN_COMPUTER_USE
+
+
+@pytest.fixture()
+def plugin_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    root = tmp_path / "plugins-home"
+    monkeypatch.setattr(plugin_state, "plugins_root", lambda: root)
+    return root
+
+
+def test_community_plugins_declare_opencode_support() -> None:
+    for plugin in (OPEN_COMPUTER_USE, CLAWDCURSOR):
+        assert plugin.supports("opencode")
+
+
+def test_write_mcp_config_opencode_native_format(plugin_home: Path) -> None:
+    path = plugin_state.write_mcp_config(
+        "open-computer-use",
+        "opencode",
+        server_name="open-computer-use",
+        command="open-computer-use",
+        args=["mcp"],
+    )
+    assert path.name == "open-computer-use.opencode.json"
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    server = payload["mcp"]["open-computer-use"]
+    assert server == {
+        "type": "local",
+        "command": "open-computer-use",
+        "args": ["mcp"],
+        "enabled": True,
+    }
+
+
+def test_active_plugin_for_agent_opencode(plugin_home: Path) -> None:
+    config = plugin_state.write_mcp_config(
+        "clawdcursor",
+        "opencode",
+        server_name="clawdcursor",
+        command="clawdcursor",
+        args=["mcp", "--compact"],
+    )
+    plugin_state.record_install(
+        "clawdcursor",
+        agents=["opencode"],
+        mcp_configs={"opencode": str(config)},
+        mcp_server_name="clawdcursor",
+    )
+    active = plugin_state.active_plugin_for_agent("opencode")
+    assert active == ("clawdcursor", str(config))
+
+
+def test_adapter_merges_mcp_servers_into_runtime_config(tmp_path: Path) -> None:
+    mcp_file = tmp_path / "cu.opencode.json"
+    mcp_file.write_text(
+        json.dumps(
+            {
+                "mcp": {
+                    "open-computer-use": {
+                        "type": "local",
+                        "command": "open-computer-use",
+                        "args": ["mcp"],
+                        "enabled": True,
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    prompt_dir = tmp_path / "run state" / "prompts"
+    OpenCodeAdapter(
+        model="opencode/mimo-v2.5-free",
+        prompt_dir=str(prompt_dir),
+        mcp_config=str(mcp_file),
+    )
+
+    config_path = posixpath.join(str(prompt_dir), "opencode-runtime-opencode.json")
+    payload = json.loads(Path(config_path).read_text(encoding="utf-8"))
+    assert "open-computer-use" in payload["mcp"]
+    assert "provider" not in payload
+
+
+def test_adapter_merges_base_url_and_mcp_together(tmp_path: Path) -> None:
+    mcp_file = tmp_path / "cu.opencode.json"
+    mcp_file.write_text(
+        json.dumps({"mcp": {"clawdcursor": {"type": "local", "command": "clawdcursor", "enabled": True}}}),
+        encoding="utf-8",
+    )
+    prompt_dir = tmp_path / "prompts"
+    OpenCodeAdapter(
+        model="apiyi/mimo-x",
+        base_url="https://api.example.com/v1/",
+        prompt_dir=str(prompt_dir),
+        mcp_config=str(mcp_file),
+    )
+
+    config_path = posixpath.join(str(prompt_dir), "opencode-runtime-apiyi.json")
+    payload = json.loads(Path(config_path).read_text(encoding="utf-8"))
+    assert payload["provider"]["apiyi"]["options"]["baseURL"] == "https://api.example.com/v1"
+    assert "clawdcursor" in payload["mcp"]
+
+
+def test_adapter_rejects_unreadable_mcp_config(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="could not read"):
+        OpenCodeAdapter(
+            prompt_dir=str(tmp_path / "prompts"),
+            mcp_config=str(tmp_path / "missing.opencode.json"),
+        )
+
+
+def test_adapter_rejects_mcp_config_without_servers(tmp_path: Path) -> None:
+    mcp_file = tmp_path / "empty.opencode.json"
+    mcp_file.write_text(json.dumps({"mcp": {}}), encoding="utf-8")
+    with pytest.raises(ValueError, match="holds no `mcp` servers"):
+        OpenCodeAdapter(
+            prompt_dir=str(tmp_path / "prompts"),
+            mcp_config=str(mcp_file),
+        )
+
+
+def test_adapter_without_mcp_and_base_url_writes_no_config(tmp_path: Path) -> None:
+    prompt_dir = tmp_path / "prompts"
+    OpenCodeAdapter(prompt_dir=str(prompt_dir))
+    assert not Path(posixpath.join(str(prompt_dir), "opencode-runtime-opencode.json")).exists()

--- a/tests/test_reasoning_effort_chain.py
+++ b/tests/test_reasoning_effort_chain.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import os
 import shlex
 from pathlib import Path
 
@@ -25,8 +26,13 @@ def test_codex_sends_the_effort_as_a_config_override() -> None:
 
     tokens = shlex.split(adapter.command_template.replace("< {prompt_path}", ""))
 
-    assert 'model_reasoning_effort="xhigh"' in tokens
-    assert tokens[tokens.index('model_reasoning_effort="xhigh"') - 1] == "-c"
+    override = 'model_reasoning_effort="xhigh"'
+    if os.name == "nt":
+        # shell_quote doubles embedded quotes inside the cmd token.
+        assert '-c "model_reasoning_effort=""xhigh"""' in adapter.command_template
+    else:
+        assert override in tokens
+        assert tokens[tokens.index(override) - 1] == "-c"
 
 
 def test_codex_without_an_effort_leaves_the_user_config_in_charge() -> None:
@@ -46,7 +52,7 @@ def test_claude_sends_the_effort_as_a_cli_flag() -> None:
 
     tokens = adapter.command_template.split()
 
-    assert tokens[tokens.index("--effort") + 1] == "max"
+    assert tokens[tokens.index("--effort") + 1].strip('"') == "max"
     assert adapter.reasoning_effort == "max"
 
 
@@ -60,7 +66,7 @@ def test_opencode_sends_the_effort_as_a_variant() -> None:
 
     tokens = adapter.command_template.split()
 
-    assert tokens[tokens.index("--variant") + 1] == "high"
+    assert tokens[tokens.index("--variant") + 1].strip('"') == "high"
 
 
 def test_opencode_still_accepts_the_legacy_effort_keyword() -> None:

--- a/tests/test_resume.py
+++ b/tests/test_resume.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 import time
 from dataclasses import asdict
 from pathlib import Path
@@ -258,7 +259,17 @@ def supervisor(monkeypatch, tmp_path: Path) -> RunSupervisor:
         "lh_harness.supervisor.service.subprocess.Popen",
         lambda *args, **kwargs: FakeProcess(),
     )
-    monkeypatch.setattr("lh_harness.supervisor.service.os.killpg", lambda *args, **kwargs: None)
+    if hasattr(os, "killpg"):
+        monkeypatch.setattr("lh_harness.supervisor.service.os.killpg", lambda *args, **kwargs: None)
+    else:
+        # Windows has no os.killpg; the service falls back to Job Object /
+        # liveness-checked kills, so nothing needs patching here.
+        monkeypatch.setattr(
+            "lh_harness.supervisor.service.win_job.kill_tree", lambda *args, **kwargs: False
+        )
+        monkeypatch.setattr(
+            "lh_harness.supervisor.service.win_job.kill_pid_tree", lambda *args, **kwargs: False
+        )
     workspace = tmp_path / "workspace"
     workspace.mkdir()
     return RunSupervisor(tmp_path / "runs", workspace_root=workspace)

--- a/tests/test_token_usage.py
+++ b/tests/test_token_usage.py
@@ -1,0 +1,89 @@
+"""Provider token usage rollup: trajectory parsing and report aggregation."""
+
+from __future__ import annotations
+
+import json
+
+from lh_harness.agent_logs import token_usage
+from lh_harness.manager import _aggregate_token_usage, _round_token_usage
+from lh_harness.types import EpisodeResult, ManagedRound
+
+
+def test_token_usage_sums_opencode_step_finish_tokens() -> None:
+    raw = "\n".join(
+        json.dumps(record)
+        for record in (
+            {
+                "type": "step_finish",
+                "part": {
+                    "type": "step-finish",
+                    "reason": "stop",
+                    "tokens": {"input": 100, "output": 20, "reasoning": 5, "cache": {"read": 8}},
+                    "cost": 0.25,
+                },
+            },
+            {
+                "type": "step_finish",
+                "part": {
+                    "type": "step-finish",
+                    "reason": "stop",
+                    "tokens": {"input": 30, "output": 6, "cache": {"read": 2}},
+                },
+            },
+        )
+    )
+    usage = token_usage(raw)
+    assert usage["input_tokens"] == 130
+    assert usage["output_tokens"] == 26
+    assert usage["reasoning_tokens"] == 5
+    assert usage["cached_input_tokens"] == 10
+    assert usage["cost_usd"] == 0.25
+
+
+def test_token_usage_understands_codex_usage_records() -> None:
+    raw = json.dumps(
+        {
+            "type": "turn.completed",
+            "usage": {"input_tokens": 50, "cached_input_tokens": 4, "output_tokens": 9},
+        }
+    )
+    usage = token_usage(raw)
+    assert usage["input_tokens"] == 50
+    assert usage["cached_input_tokens"] == 4
+    assert usage["output_tokens"] == 9
+    assert usage["cost_usd"] == 0
+
+
+def test_token_usage_ignores_non_numeric_noise() -> None:
+    raw = json.dumps({"type": "step_finish", "part": {"tokens": {"input": "many"}}})
+    usage = token_usage(raw)
+    assert usage["input_tokens"] == 0
+
+
+def test_round_token_usage_merges_role_episodes() -> None:
+    executor = EpisodeResult(
+        status="done",
+        metadata={"token_usage": {"input_tokens": 100, "output_tokens": 10, "cost_usd": 0.1}},
+    )
+    auditor = EpisodeResult(
+        status="done",
+        metadata={"token_usage": {"input_tokens": 40, "output_tokens": 4}},
+    )
+    merged = _round_token_usage(executor, auditor)
+    assert merged["input_tokens"] == 140
+    assert merged["output_tokens"] == 14
+    assert merged["cost_usd"] == 0.1
+
+
+def test_aggregate_token_usage_sums_rounds_and_skips_empty() -> None:
+    rounds = [
+        ManagedRound(round_index=1, next_step="cli", plan_text="p", token_usage={"input_tokens": 10, "output_tokens": 2}),
+        ManagedRound(round_index=2, next_step="cli", plan_text="p", token_usage={"input_tokens": 5, "cost_usd": 0.3}),
+        ManagedRound(round_index=3, next_step="cli", plan_text="p"),
+    ]
+    totals = _aggregate_token_usage(rounds)
+    assert totals["input_tokens"] == 15
+    assert totals["output_tokens"] == 2
+    assert totals["cost_usd"] == 0.3
+    # A run with zero recorded usage reports an empty block, not zeroes.
+    assert _aggregate_token_usage([ManagedRound(round_index=1, next_step="cli", plan_text="p")]) == {}

--- a/tests/webapi/test_hardening.py
+++ b/tests/webapi/test_hardening.py
@@ -241,6 +241,10 @@ def test_html_artifacts_are_attachments(tmp_path: Path) -> None:
 
 
 def test_non_raster_documents_are_attachments_and_filename_is_header_safe(tmp_path: Path) -> None:
+    if os.name == "nt":
+        # NTFS forbids quote-bearing filenames; the header-encoding half
+        # of this test is covered on POSIX CI.
+        pytest.skip("NTFS forbids quote-bearing filenames")
     root, state = _run(tmp_path)
     round_dir = root / "run-1" / "logs" / "role_management" / "rounds" / "round_001"
     # The filesystem permits both quote-bearing and non-ASCII names.  They

--- a/tests/webapi/test_resume_routes.py
+++ b/tests/webapi/test_resume_routes.py
@@ -29,7 +29,7 @@ class FakeProcess:
 def client(monkeypatch, tmp_path: Path):
     process = FakeProcess()
     monkeypatch.setattr("lh_harness.supervisor.service.subprocess.Popen", lambda *a, **k: process)
-    monkeypatch.setattr("lh_harness.supervisor.service.os.killpg", lambda *a, **k: None)
+    monkeypatch.setattr("lh_harness.supervisor.service._signal_worker", lambda *a, **k: None)
     root = tmp_path / "runs"
     workspace = tmp_path / "workspace"
     workspace.mkdir()


### PR DESCRIPTION
# 修复 Windows 兼容：控制总线、shell 引号与进程组处理

## 背景

在 Windows 11（10.0.22631）上从源码安装 v0.1.7 后，`lh-harness run` 无法启动：引导阶段即报
`unsafe run directory layout: secure control-bus directory creation is unavailable`。
逐层排查后发现，核心循环、事件账本、适配器命令模板、监督锁等多处深度依赖 POSIX 专有能力，
Windows 上均直接失败。本 PR 为这些路径增加**平台感知回退**，不改变 POSIX 平台的任何既有行为。

## 问题与修复对照

| # | 故障点 | 根因 | 修复 |
|---|---|---|---|
| 1 | 启动即拒 | `control_bus` 要求 `O_NOFOLLOW`+`dir_fd` 锚定目录遍历，Windows 无此能力 | 新增 `_SECURE_DIRFD` 能力检测；回退为「路径创建 + 逐级符号链接扫描」 |
| 2 | 控制命令互斥失效风险 | `fcntl.flock` Windows 不存在 | `_process_lock`：msvcrt 字节锁实现等价跨进程互斥 |
| 3 | Manager 首轮崩溃 | 事件追加要求 `O_NOFOLLOW` | `_append_event` 增加「校验后普通追加」分支 |
| 4 | 提示词写入崩溃 | `mkdir -p`/`chmod` 是 POSIX 命令，`create_subprocess_shell` 在 Windows 走 cmd.exe | `LocalEnvironment` 原生 `ensure_dir`/`chmod`；`remote_files` 优先调用并兼容 `\` 路径分隔 |
| 5 | 所有角色 episode 0.1s 失败 | 命令模板用单引号 + `VAR=x cmd` 前缀，cmd.exe 不解析 | 新增 `utils/platform_shell.py`（`shell_quote`/`cd_command`/`env_prefix`），4 个适配器 + `cli_agent` 全部接入 |
| 6 | 进程清理不可用 | `os.killpg`/`SIGHUP` 缺失 | `process_group` 按 PID 回退 + 信号按存在性收集；`service.py` 4 处 `killpg` 加护栏 |

## 改动范围

13 个文件，+379/−79（`git diff --stat` 见 commit）：

```
supervisor/control_bus.py    | 174 +++++++++-   核心兼容层
utils/platform_shell.py      |  47 ++          新增：平台 shell 引号
manager.py                   |  23 +           事件追加回退
supervisor/service.py        |  28 ++-         监督锁 + killpg 护栏
dashboard/state.py           |  33 +-          审批日志回退
adapters/{cli_agent,opencode,codex,claude_code,deepseek_harness}.py
environment/{local,remote_files}.py
utils/process_group.py
```

## 验证

- `python -m compileall src/lh_harness` 通过
- 兼容探针 5 项全过：控制总线原子写+读回、JSONL 追加互斥、ControlBus 命令协议
  （append/commands/conflict 检测）、事件追加、全部改动模块可导入
- **端到端**：opencode 后端 + 免费网关模型，完整跑通
  Manager→Executor→Auditor 多轮闭环（Round 1 规划/执行/审计三角色全绿
  `complete/clean/aligned`，Round 2 判定交付并生成中文最终报告），
  Executor 实际驱动本机 Edge 浏览器完成了 arXiv/GitHub 调研任务并落盘截图证据

## 已知遗留（后续补丁）

Executor episode 超时清理路径仍引用 `signal.SIGKILL`（Windows 无此常量），
超时场景会以 `worker_exception` 终止而非优雅回收——不影响正常运行，将在后续 PR 修复。

🤖 Generated with [opencode](https://github.com/anomalyco/opencode)


---

## 更新（第二阶段 commit c26437b）

首个 commit 解决"能启动"；本阶段把 Windows 推进到**全量测试套件通过**：

- 修复 `SIGKILL` 缺失（6 处超时/停止路径崩溃）、`os.kill(pid, 0)` 探测在
  Windows 语义为 TerminateProcess 导致的 pid 复用误杀（新增 Job Object
  内核级进程树管理 `win_job.py`）、`O_BINARY` 缺失导致 PNG 字节被改写、
  回退分支的符号链接/硬链接防护缺口、`os.scandir(fd)`/目录打开不可用等
  共 7 类问题
- 18 个测试文件平台化（killpg 桩改打 `_signal_worker` 接缝、`#!/bin/sh`
  桩翻译为 .cmd、引号断言感知平台）
- 新增 `.github/workflows/ci.yml`：ubuntu + windows + macos 三平台 pytest
  矩阵（此前仓库无任何测试 CI）
- 结果：Windows 11 + Python 3.12 全量 **402 passed / 4 skipped / 0 failed**

Fixes #70
