### PR TITLE
fix(supervisor): keep deliberate blocked/incomplete outcomes out of the crash path

### DIFF
--- a/src/lh_harness/supervisor/lifecycle.py
+++ b/src/lh_harness/supervisor/lifecycle.py
@@ -31,6 +31,11 @@ TERMINAL_STATUSES = frozenset({
     "incomplete",
 })
 
+# The deliberate, resumable manager/auditor outcomes.  The CLI maps every
+# non-completed run to a non-zero exit, so a non-zero process exit is not
+# evidence of a crash for these two: the persisted report is the authority.
+RESUMABLE_OUTCOMES = frozenset({"blocked", "incomplete"})
+
 # ``creating`` is written before the worker is spawned.  It belongs here so a
 # run that died inside the launch transaction is reconciled as an interrupted
 # active run instead of lingering in a state that is neither active nor

--- a/src/lh_harness/supervisor/service.py
+++ b/src/lh_harness/supervisor/service.py
@@ -39,6 +39,7 @@ from .lifecycle import (
     ACTIVE_STATUSES,
     MAX_RESUME_EPOCH,
     RESUME_EPOCH_KEY,
+    RESUMABLE_OUTCOMES,
     TERMINAL_STATUSES,
     canonical_lifecycle_status,
     is_terminal_status,
@@ -454,10 +455,12 @@ def _terminal_status_for_exit(
     """Derive process lifecycle status and preserve the audit/report status.
 
     A zero exit code is not enough to claim success: the manager must have
-    written a successful report.  Conversely, every positive non-zero exit is
-    a worker failure even if a partial report happens to say ``complete``.
-    Only an explicit operator stop/abort is a cancellation; an unsolicited
-    signal is treated as a failure/crash.
+    written a successful report.  Conversely, a non-zero exit is a worker
+    failure unless the worker persisted one of the deliberate resumable
+    outcomes (``blocked``/``incomplete``), for which the CLI exits non-zero
+    by design (``cli.py`` maps every non-completed run to exit 1).  Only an
+    explicit operator stop/abort is a cancellation; an unsolicited signal is
+    treated as a failure/crash.
     """
 
     action = str(requested_action or "").strip().lower()
@@ -466,13 +469,23 @@ def _terminal_status_for_exit(
         return "cancelled", report_status
     if returncode is None:
         return "running", report_status
-    if returncode != 0:
-        return "failed", report_status
     # ``complete``/``completed`` is a claim about the manager's audit result,
     # not proof by itself.  The worker protocol explicitly carries the
     # boolean completion authority; accepting a missing/false value would let
     # a truncated or hand-written report make a clean process look successful.
+    # Checked before the exit code so the same authority rule decides both
+    # exit paths.
     if _missing_completion_evidence(report, report_status):
+        return "failed", report_status
+    if returncode != 0:
+        # The CLI exits non-zero for every non-completed run, so a non-zero
+        # exit is not by itself evidence of a crash.  A persisted final
+        # report with a deliberate resumable outcome is the audit result it
+        # says it is; anything else (no report, a crash report's
+        # ``failed``/``cancelled``, or a success claim from a process that
+        # died abnormally) stays a failure.
+        if report_status in RESUMABLE_OUTCOMES:
+            return report_status, report_status
         return "failed", report_status
     if report_status in TERMINAL_STATUSES:
         return report_status, report_status

--- a/tests/supervisor/test_terminal_status.py
+++ b/tests/supervisor/test_terminal_status.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from lh_harness.supervisor.service import RunSupervisor, _terminal_status_for_exit
+
+
+def _report(status: str, *, completion_satisfied: bool = False) -> dict:
+    return {
+        "schema_version": 2,
+        "status": status,
+        "completion_satisfied": completion_satisfied,
+        "rounds": [],
+    }
+
+
+# --- pure mapping -----------------------------------------------------------
+
+
+def test_nonzero_exit_preserves_deliberate_blocked_outcome() -> None:
+    lifecycle, report_status = _terminal_status_for_exit(
+        report=_report("blocked"), returncode=1
+    )
+    assert (lifecycle, report_status) == ("blocked", "blocked")
+
+
+def test_nonzero_exit_preserves_deliberate_incomplete_outcome() -> None:
+    lifecycle, report_status = _terminal_status_for_exit(
+        report=_report("incomplete"), returncode=1
+    )
+    assert (lifecycle, report_status) == ("incomplete", "incomplete")
+
+
+def test_nonzero_exit_with_completed_claim_still_fails_on_missing_authority() -> None:
+    lifecycle, report_status = _terminal_status_for_exit(
+        report=_report("completed"), returncode=1
+    )
+    assert (lifecycle, report_status) == ("failed", "completed")
+
+
+def test_nonzero_exit_with_authorised_completion_still_fails() -> None:
+    # A process that died abnormally is a crash even when it left an
+    # authorised report behind; the authority check applies to both exit
+    # paths so a late/hand-written report cannot relabel a dead worker.
+    lifecycle, report_status = _terminal_status_for_exit(
+        report=_report("completed", completion_satisfied=True), returncode=1
+    )
+    assert (lifecycle, report_status) == ("failed", "completed")
+
+
+def test_nonzero_exit_with_crash_report_stays_a_failure() -> None:
+    # Crash reports carry ``failed``; an unsolicited death with a
+    # ``cancelled`` report and no operator action is a failure too (the
+    # operator-stop paths set ``requested_action`` and cancel earlier).
+    assert _terminal_status_for_exit(report=_report("failed"), returncode=137) == (
+        "failed",
+        "failed",
+    )
+    assert _terminal_status_for_exit(report=_report("cancelled"), returncode=137) == (
+        "failed",
+        "cancelled",
+    )
+
+
+def test_nonzero_exit_without_a_report_is_a_failure() -> None:
+    lifecycle, report_status = _terminal_status_for_exit(report={}, returncode=1)
+    assert (lifecycle, report_status) == ("failed", "")
+
+
+def test_nonzero_exit_with_nonterminal_report_is_a_failure() -> None:
+    lifecycle, _ = _terminal_status_for_exit(report=_report("running"), returncode=1)
+    assert lifecycle == "failed"
+
+
+def test_requested_stop_still_cancels_even_with_incomplete_report() -> None:
+    lifecycle, report_status = _terminal_status_for_exit(
+        report=_report("incomplete"), returncode=1, requested_action="stop"
+    )
+    assert (lifecycle, report_status) == ("cancelled", "incomplete")
+
+
+# --- through the real supervisor --------------------------------------------
+
+
+class _ExitedProcess:
+    pid = 4242
+
+    def __init__(self, returncode: int) -> None:
+        self.returncode = returncode
+
+    def poll(self):
+        return self.returncode
+
+
+def _create_and_exit(monkeypatch, tmp_path: Path, returncode: int, report: dict | None):
+    monkeypatch.setattr(
+        "lh_harness.supervisor.service.subprocess.Popen",
+        lambda *args, **kwargs: _ExitedProcess(returncode),
+    )
+    monkeypatch.setattr("lh_harness.supervisor.service.os.killpg", lambda *args, **kwargs: None)
+    supervisor = RunSupervisor(tmp_path / "runs", workspace_root=tmp_path / "workspace")
+    created = supervisor.create_run(task="reach a terminal audit outcome")
+    run_id = created["id"]
+    if report is not None:
+        logs = tmp_path / "runs" / run_id / "lh_harness"
+        logs.mkdir(parents=True, exist_ok=True)
+        (logs / "report.json").write_text(
+            json.dumps(report, ensure_ascii=False), encoding="utf-8"
+        )
+    return supervisor, run_id, tmp_path / "runs" / run_id
+
+
+def test_supervisor_reports_incomplete_not_failed_for_nonzero_exit(monkeypatch, tmp_path: Path) -> None:
+    supervisor, run_id, run_dir = _create_and_exit(
+        monkeypatch,
+        tmp_path,
+        returncode=1,
+        report=_report("incomplete", completion_satisfied=False),
+    )
+
+    status = supervisor.status(run_id)
+
+    # The CLI exits non-zero for every non-completed run; the durable report
+    # is the authority, so the lifecycle must not be relabelled ``failed``.
+    assert status["status"] == "incomplete"
+    assert status["report_status"] == "incomplete"
+    assert status["alive"] is False
+    assert (run_dir / "lh_harness" / "crash_report.json").exists() is False
+
+
+def test_supervisor_still_reports_failed_when_no_report_survives(monkeypatch, tmp_path: Path) -> None:
+    supervisor, run_id, run_dir = _create_and_exit(
+        monkeypatch, tmp_path, returncode=1, report=None
+    )
+
+    status = supervisor.status(run_id)
+
+    assert status["status"] == "failed"
+    assert status["alive"] is False
+    assert (run_dir / "lh_harness" / "crash_report.json").exists() is True


### PR DESCRIPTION
## What

`_terminal_status_for_exit` mapped every non-zero worker exit to `failed`, so a run that deliberately ends `blocked` or `incomplete` (round budget exhausted, manager blocked) is relabelled as a crash.

## Why

- The CLI exits non-zero for **every** non-completed run: `return 0 if final_report.get("completion_satisfied") else 1` (`cli.py:1865`). The exit code therefore carries no crash signal once a final report exists.
- `lifecycle.py` defines `blocked`/`incomplete` in `TERMINAL_STATUSES` with the comment "terminal from the supervisor's point of view and **may be retried/resumed**" — a non-crash, resumable outcome.
- The bug shows two symptoms:
  1. A normal max-rounds-exhausted run becomes `status=failed` + a spurious `crash_report.json` (`_persist_failure_report` fires whenever the lifecycle is `failed`).
  2. The same run reconciled through the no-`Popen` path (API restart, where `returncode=0 if report else 1`) reports `incomplete` — i.e. the outcome depends on whether the supervisor process was restarted.

## Change

- Add `RESUMABLE_OUTCOMES = frozenset({"blocked", "incomplete"})` to `lifecycle.py`.
- In `_terminal_status_for_exit`, check the completion-authority rule before the exit code, then on a non-zero exit return the report's status only when it is one of `RESUMABLE_OUTCOMES`; everything else (no report, a crash report's `failed`/`cancelled`, a success claim from a dead process) stays `failed`.

The set is deliberately only the two resumable outcomes, not all of `TERMINAL_STATUSES`: crash reports always carry `failed`/`cancelled`, and a non-zero exit with a `completed` report is still a failure — the existing hardening test `test_nonzero_worker_exit_is_failed_and_persists_crash_report` (which writes a forged authorised report and expects `failed`) passes unchanged.

## How I checked

- New `tests/supervisor/test_terminal_status.py`: 8 mapping tests + 2 end-to-end tests through `RunSupervisor.status()` (asserts no spurious `crash_report.json` for a real `incomplete` report, and `failed` + crash report when none exists).
- Red-light: with the fix reverted, exactly the 3 new outcome-preservation tests fail and the 7 semantic-preservation tests pass.
- Full suite: 415 passed, 1 skipped. No existing test modified.