### PR TITLE
fix: a crashed resume must not report the previous generation's success

### DIFF
--- a/src/lh_harness/cli.py
+++ b/src/lh_harness/cli.py
@@ -1788,7 +1788,13 @@ def _run_command(args: argparse.Namespace) -> int:
             "final_response_agent": build_role_agent("final_response"),
         }
     except BaseException as exc:
-        _write_bootstrap_failure(log_dir, task, exc, max_rounds=max_rounds)
+        _write_bootstrap_failure(
+                log_dir,
+                task,
+                exc,
+                max_rounds=max_rounds,
+                resume=bool(getattr(args, "resume", False)),
+            )
         print(f"Worker failed during agent setup: {exc}", file=sys.stderr)
         _finalize_embedded_supervisor(
             dashboard_supervisor,
@@ -2105,8 +2111,14 @@ def _public_role_configs_from_args(
     return result
 
 
-def _write_bootstrap_failure(log_dir: str, task: str, exc: BaseException, *, max_rounds: int) -> None:
+def _write_bootstrap_failure(
+    log_dir: str, task: str, exc: BaseException, *, max_rounds: int, resume: bool = False
+) -> None:
     """Persist a terminal report when agent construction fails before Manager."""
+
+    # Imported lazily, matching the ``run`` import above: manager pulls in the
+    # adapter stack that the CLI defers until after argument parsing.
+    from .manager import _write_generation_stamp
 
     root = Path(log_dir)
     role_dir = root / "role_orchestration"
@@ -2130,6 +2142,13 @@ def _write_bootstrap_failure(log_dir: str, task: str, exc: BaseException, *, max
             _atomic_bytes_write(target, encoded.encode("utf-8"))
         except OSError:
             pass
+    # A bootstrap crash after an in-place resume replaces the previous
+    # generation's terminal report; the stamp marks the new report as this
+    # generation's authority.  A bootstrap crash on a fresh run must not leave
+    # a stamp, because the crash path treats a matching stamp as proof that an
+    # on-disk report belongs to this process.
+    if resume:
+        _write_generation_stamp(root)
     events = role_dir / "events.jsonl"
     try:
         _append_jsonl_nofollow(events, {

--- a/src/lh_harness/manager.py
+++ b/src/lh_harness/manager.py
@@ -74,6 +74,10 @@ _MAX_SAVED_TRAJECTORY_BYTES = 16 * 1024 * 1024
 _MAX_FAILURE_REPORT_BYTES = 1 * 1024 * 1024
 _MAX_FAILURE_EVENTS_BYTES = 4 * 1024 * 1024
 _MAX_FAILURE_EVENT_RECORDS = 50_000
+# Terminal report statuses.  A worker that resumes in place reuses its run
+# directory, so this is also how the crash path recognises a report that still
+# belongs to the previous generation.
+_TERMINAL_REPORT_STATUSES = {"complete", "completed", "cancelled", "failed", "blocked", "incomplete"}
 
 
 def _invalid_completion_feedback(language: str) -> str:
@@ -149,6 +153,7 @@ async def run(*args: Any, **kwargs: Any) -> dict[str, Any]:
             exc=exc,
             abort_reason="worker_cancelled",
             progress=run_progress,
+            resumed=bool(kwargs.get("resume", False)),
         )
     except BaseException as exc:  # worker boundary: persist even non-Exception failures
         # KeyboardInterrupt/SystemExit are intentionally converted to a
@@ -162,6 +167,7 @@ async def run(*args: Any, **kwargs: Any) -> dict[str, Any]:
             exc=exc,
             abort_reason="worker_exception",
             progress=run_progress,
+            resumed=bool(kwargs.get("resume", False)),
         )
 
 
@@ -998,6 +1004,9 @@ async def _run_impl(
     )
     _write_local(role_dir / "report.json", json.dumps(final, ensure_ascii=False, indent=2) + "\n")
     _write_local(log_dir / "report.json", json.dumps(final, ensure_ascii=False, indent=2) + "\n")
+    # The crash path uses this stamp to tell this generation's report apart
+    # from a terminal report a resumed generation inherited from its run dir.
+    _write_generation_stamp(log_dir)
     transcript = format_management_history(rounds, include_empty=True, max_chars=200_000)
     _write_local(role_dir / "orchestration_transcript.txt", transcript)
     _merge_episode_logs(log_dir)
@@ -1625,6 +1634,34 @@ def _read_local_bounded(path: Path, max_bytes: int, *, tail: bool = False) -> st
                 pass
 
 
+def _write_generation_stamp(log_dir: Path) -> None:
+    """Record this worker's pid beside the report it just wrote.
+
+    A supervised in-place resume reuses the run directory, so a stale
+    ``report.json`` from the previous generation can still be on disk when the
+    new generation crashes.  The stamp is what lets the crash path tell that
+    inherited report apart from one this generation actually produced.
+    """
+
+    try:
+        _write_local(log_dir / "report_generation.txt", str(os.getpid()))
+    except OSError:
+        pass
+
+
+def _report_is_current_generation(log_dir: Path) -> bool:
+    """Whether the on-disk report was produced by this worker process.
+
+    The stamp is only written next to a report this process itself just
+    wrote, so a matching stamp is positive proof of authorship.  A missing or
+    unreadable stamp means the report predates this generation (the run was
+    resumed in place), which on the crash path must be replaced by the crash.
+    """
+
+    stamp = _read_local_bounded(log_dir / "report_generation.txt", 64)
+    return stamp is not None and stamp.strip() == str(os.getpid())
+
+
 def _write_terminal_failure(
     config: HarnessConfig | None,
     task: str,
@@ -1634,6 +1671,7 @@ def _write_terminal_failure(
     exc: BaseException,
     abort_reason: str,
     progress: _RunProgress | None = None,
+    resumed: bool = False,
 ) -> dict[str, Any]:
     """Best-effort local crash report and terminal event for the worker.
 
@@ -1656,10 +1694,15 @@ def _write_terminal_failure(
                 existing = parsed_existing
         except json.JSONDecodeError:
             pass
-    if isinstance(existing, dict) and existing.get("status") in {"complete", "completed", "cancelled", "failed", "blocked", "incomplete"}:
-        # A failure during a post-report remote sync must not erase a valid
-        # local authority.  The supervisor can still use the existing report.
-        return existing
+    if isinstance(existing, dict) and existing.get("status") in _TERMINAL_REPORT_STATUSES:
+        if not resumed or _report_is_current_generation(log_dir):
+            # A failure during a post-report remote sync must not erase a valid
+            # local authority.  The supervisor can still use the existing
+            # report.  On an in-place resume the exception is a terminal report
+            # inherited from the previous generation: reusing it would let a
+            # crashed resume report the predecessor's success, so the crash
+            # must win.
+            return existing
 
     trace = "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
     report: dict[str, Any] = {
@@ -1713,11 +1756,15 @@ def _write_terminal_failure(
             }
         )
     encoded = json.dumps(report, ensure_ascii=False, indent=2) + "\n"
+    wrote_report = False
     for target in (report_path, role_report_path):
         try:
             _atomic_bytes_write(target, encoded.encode("utf-8"))
+            wrote_report = True
         except OSError:
             pass
+    if wrote_report:
+        _write_generation_stamp(log_dir)
     try:
         events_path = role_dir / "events.jsonl"
         if not any(item.get("event") == "role_harness_failed" for item in _read_jsonl_local(events_path)):

--- a/tests/test_resumed_worker_crash.py
+++ b/tests/test_resumed_worker_crash.py
@@ -1,0 +1,190 @@
+"""A crashed resume must be reported as the crash, not the previous success.
+
+A supervised ``resume --continue`` reopens the same run directory.  The report
+of the generation that finished it (``report.json``) is the only source the
+worker and the supervisor fall back to when the new generation dies, so a
+stale ``complete`` report lets a crashed resume leave the run reporting its
+predecessor's success with zero crash evidence.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from lh_harness.cli import _write_bootstrap_failure
+from lh_harness.environment.local import LocalEnvironment
+from lh_harness.manager import run
+from lh_harness.types import EpisodeResult, HarnessConfig, ManagedRound
+
+# The previous generation ended with a durable success.
+_STALE_SUCCESS_REPORT = {
+    "schema_version": 2,
+    "status": "complete",
+    "task": "finish the refactor",
+    "completion_satisfied": True,
+    "rounds_run": 3,
+    "max_rounds": 3,
+}
+
+
+def _clean_audit(summary: str) -> str:
+    return (
+        "Status: complete\n"
+        "Integrity: clean\n"
+        "Contract audit: aligned\n\n"
+        f"Summary:\n{summary}"
+    )
+
+
+def _seed_completed_run(tmp_path: Path) -> Path:
+    """Leave the durable artifacts of a completed generation behind."""
+    role = tmp_path / "logs" / "role_orchestration"
+    role.mkdir(parents=True, exist_ok=True)
+    ledger = ManagedRound(
+        round_index=1,
+        next_step="cli",
+        plan_text="plan 1",
+        executor_output="output 1",
+        auditor_report=_clean_audit("round 1 verified"),
+        harness_feedback="",
+        task_state="state 1",
+        task_contract="contract 1",
+        related_report_refs=[],
+        manager_status={},
+        executor_status={},
+        auditor_status={},
+    )
+    (role / "rounds.jsonl").write_text(
+        json.dumps(asdict(ledger), ensure_ascii=False) + "\n", encoding="utf-8"
+    )
+    report = dict(_STALE_SUCCESS_REPORT)
+    (tmp_path / "logs" / "report.json").write_text(
+        json.dumps(report, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+    )
+    (role / "report.json").write_text(
+        json.dumps(report, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+    )
+    return tmp_path / "logs"
+
+
+# The previous generation's remote copies are irrelevant to the local
+# authority; the resumed run must not spend test time on them.
+async def no_remote_write(*_args: Any, **_kwargs: Any) -> None:
+    return None
+
+
+def _resumed_run(tmp_path: Path, *, monkeypatch: pytest.MonkeyPatch):
+    """Run the management loop as a resumed worker whose first agent call dies."""
+
+    class CrashingAgent:
+        async def run_episode(self, _prompt, _env, _budget, live_trajectory_path=None):
+            raise RuntimeError("provider exploded during resume")
+
+    monkeypatch.setattr("lh_harness.manager._write_remote_text", no_remote_write)
+    monkeypatch.setattr("lh_harness.manager._write_remote_round_text", no_remote_write)
+    return run(
+        task="finish the refactor",
+        env=LocalEnvironment(str(tmp_path / "tmp")),
+        config=HarnessConfig(
+            max_total_episodes=1,
+            workspace_path=str(tmp_path / "workspace"),
+            harness_dir=str(tmp_path / "harness"),
+            log_dir=str(tmp_path / "logs"),
+        ),
+        agent=CrashingAgent(),
+        resume=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_crashed_resume_does_not_report_the_previous_success(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    log_dir = _seed_completed_run(tmp_path)
+
+    report = await _resumed_run(tmp_path, monkeypatch=monkeypatch)
+
+    assert report["status"] == "failed"
+    assert report["abort_reason"] == "worker_exception"
+    assert report["completion_satisfied"] is False
+    assert "provider exploded during resume" in str(report["failure_reason"])
+
+    # The CLI exits from this report: it must be the crash, not the old success.
+    persisted = json.loads((log_dir / "report.json").read_text(encoding="utf-8"))
+    assert persisted == report
+    assert persisted["status"] == "failed"
+    assert (log_dir / "role_orchestration" / "report.json").read_text(encoding="utf-8")
+    role_report = json.loads(
+        (log_dir / "role_orchestration" / "report.json").read_text(encoding="utf-8")
+    )
+    assert role_report["status"] == "failed"
+
+
+def test_a_crashed_bootstrap_after_a_resume_replaces_the_stale_report(
+    tmp_path: Path,
+) -> None:
+    # Agent construction can die before the management loop starts; the CLI's
+    # bootstrap failure writer is the next writer of the same report.
+    log_dir = _seed_completed_run(tmp_path)
+
+    _write_bootstrap_failure(
+        str(log_dir),
+        "finish the refactor",
+        RuntimeError("adapter setup failed"),
+        max_rounds=1,
+        resume=True,
+    )
+
+    persisted = json.loads((log_dir / "report.json").read_text(encoding="utf-8"))
+    assert persisted["status"] == "failed"
+    assert persisted["abort_reason"] == "worker_bootstrap_failure"
+    assert persisted["completion_satisfied"] is False
+    assert persisted["task"] == "finish the refactor"
+
+
+@pytest.mark.asyncio
+async def test_a_crash_after_the_report_still_preserves_a_valid_report(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The original guard: a failure during the post-report remote sync must not
+    # erase a valid local report.  The resumed run above is different only
+    # because it is a *new generation* reopening the run.
+    _seed_completed_run(tmp_path)
+
+    class CompletedAgent:
+        async def run_episode(self, _prompt, _env, _budget, live_trajectory_path=None):
+            return EpisodeResult(
+                status="done",
+                actions_log="Next: done\n\nCurrent Task State:\nall finished",
+            )
+
+    async def crashing_remote_write(env, path: str, text: str) -> None:
+        raise RuntimeError("remote storage fell over after the local report")
+
+    monkeypatch.setattr("lh_harness.manager._write_remote_text", crashing_remote_write)
+    monkeypatch.setattr("lh_harness.manager._write_remote_round_text", crashing_remote_write)
+
+    report = await run(
+        task="finish the refactor",
+        env=LocalEnvironment(str(tmp_path / "tmp")),
+        config=HarnessConfig(
+            max_total_episodes=1,
+            workspace_path=str(tmp_path / "workspace"),
+            harness_dir=str(tmp_path / "harness"),
+            log_dir=str(tmp_path / "logs"),
+        ),
+        agent=CompletedAgent(),
+        resume=False,
+    )
+
+    # No resume: the report on disk belongs to this generation, so the crash
+    # path must leave it untouched.
+    assert report["status"] == "complete"
+    persisted = json.loads((tmp_path / "logs" / "report.json").read_text(encoding="utf-8"))
+    assert persisted["status"] == "complete"
+    assert persisted["task"] == "finish the refactor"

--- a/tests/test_resumed_worker_crash.py
+++ b/tests/test_resumed_worker_crash.py
@@ -117,12 +117,10 @@ async def test_a_crashed_resume_does_not_report_the_previous_success(
     # The CLI exits from this report: it must be the crash, not the old success.
     persisted = json.loads((log_dir / "report.json").read_text(encoding="utf-8"))
     assert persisted == report
-    assert persisted["status"] == "failed"
-    assert (log_dir / "role_orchestration" / "report.json").read_text(encoding="utf-8")
     role_report = json.loads(
         (log_dir / "role_orchestration" / "report.json").read_text(encoding="utf-8")
     )
-    assert role_report["status"] == "failed"
+    assert role_report == report
 
 
 def test_a_crashed_bootstrap_after_a_resume_replaces_the_stale_report(


### PR DESCRIPTION
## What this fixes

A supervised `resume --continue` reuses the run directory of the run it continues. The terminal `report.json` written by the generation that finished that run is therefore still on disk when the *new* generation starts — and it is the fallback the worker's crash path looks for when it dies.

When the new generation crashes, `_write_terminal_failure` (manager) reads `report.json`, finds a valid terminal report (e.g. `status: complete`, `completion_satisfied: true` from the predecessor), and — by design, to protect a failure during the post-report remote sync — returns that existing report instead of writing the crash report. Consequences of a crashed resume today:

- the process exits `0` (CLI decides from `completion_satisfied` in the report),
- the supervisor's exit reconciliation reads the same stale report and reconciles the run to `completed`,
- there is no crash report, no `failure_reason`, no `crash_report.json` — zero evidence that the resume ever failed.

The same hole exists one step earlier: agent construction failing before the loop starts (`_write_bootstrap_failure` in the CLI) overwrites the stale report with a fresh failure — but only because that path does not have the guard. If the guard is ever extended there (or the crash is in the loop and the guard fires), the old success wins.

## Fix

Each worker stamps the report it actually wrote with its own pid (`report_generation.txt` next to `report.json`), in both the happy path and the crash-report path. The crash path's guard now keeps an existing terminal report only when this process demonstrably produced it:

- fresh run, crash after the local report (the original post-report-remote-sync case the guard was added for) → report preserved, exactly as before;
- in-place resume whose new generation crashes → the inherited terminal report from the previous generation loses, and the crash report is written; the process exits non-zero and the supervisor reconciles to `failed` with the real `failure_reason`.

The CLI bootstrap-failure path gets the same treatment for `--resume` (stamp after writing, so a *subsequent* crash path can see the report as this generation's authority); a fresh-run bootstrap crash writes no stamp, so it can never make the guard preserve an unrelated pre-existing report.

Reading a missing/absent stamp on the resumed crash path is the stale-report signal; a matching stamp is positive proof of authorship (the stamp is only ever written right after this process wrote its own report).

## Tests

New `tests/test_resumed_worker_crash.py`:

1. seed a completed generation (clean ledger + `complete` report in both locations), run a resumed worker whose first agent call raises → returned and persisted report is the fresh `failed` crash report in both `report.json` locations (previously `complete`);
2. same seeded run, bootstrap failure with `resume=True` → persisted report is the fresh bootstrap failure, task preserved;
3. regression guard for the original guard's purpose: a run that writes its own report then dies in the post-report remote sync keeps its `complete` report.

Full suite: 408 passed, 1 skipped (baseline 405 + 3 new).