### PR TITLE
fix(supervisor): read reports that outgrew the 8 MiB control-record cap

### DIFF
--- a/src/lh_harness/supervisor/service.py
+++ b/src/lh_harness/supervisor/service.py
@@ -420,6 +420,53 @@ def _read_json(path: Path) -> dict[str, Any]:
     return _read_json_file(path, max_bytes=8 * 1024 * 1024)
 
 
+def _read_report(path: Path) -> dict[str, Any]:
+    """Read a worker report, tolerating reports that grew past the cap.
+
+    A report embeds every finished round, so a long run can legally exceed
+    the 8 MiB control-record cap that plain ``_read_json`` enforces.  The
+    lifecycle pollers treat an empty dict as *no report*, and the failure
+    path then overwrites the real report with a synthetic stub, so a report
+    that only looked missing must be read in full.  A hard ceiling keeps a
+    hostile run directory from pinning a parser on a multi-gigabyte file.
+    """
+
+    max_bytes = 256 * 1024 * 1024
+    try:
+        fd = _open_nofollow(path)
+    except OSError:
+        return {}
+    try:
+        metadata = os.fstat(fd)
+        if not stat.S_ISREG(metadata.st_mode) or metadata.st_nlink != 1:
+            return {}
+        size = int(metadata.st_size)
+        if size == 0:
+            return {}
+        if size > max_bytes:
+            return {}
+        raw = b""
+        remaining = size
+        while remaining > 0:
+            chunk = os.read(fd, min(remaining, 1024 * 1024))
+            if not chunk:
+                break
+            raw += chunk
+            remaining -= len(chunk)
+    except OSError:
+        return {}
+    finally:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+    try:
+        value = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return {}
+    return value if isinstance(value, dict) else {}
+
+
 def _pending_approval(path: Path) -> bool:
     latest: dict[str, dict[str, Any]] = {}
     try:
@@ -968,7 +1015,7 @@ class RunSupervisor:
             authority; without one this is a failed/crashed worker.
             """
 
-            report = _read_json(self._run_logs_dir(run_id) / "report.json")
+            report = _read_report(self._run_logs_dir(run_id) / "report.json")
             lifecycle, report_status = _terminal_status_for_exit(
                 report=report,
                 returncode=0 if report else 1,
@@ -1057,7 +1104,7 @@ class RunSupervisor:
             # log/report projection remains readable, but this supervisor must
             # not infer liveness or re-enable process control.
             if status.get("managed") is False:
-                report = _read_json(self._run_logs_dir(run_id) / "report.json")
+                report = _read_report(self._run_logs_dir(run_id) / "report.json")
                 report_status = _report_status(report)
                 lifecycle = canonical_lifecycle_status(status.get("status"), default="idle")
                 if lifecycle not in TERMINAL_STATUSES and report_status in TERMINAL_STATUSES:
@@ -1083,7 +1130,7 @@ class RunSupervisor:
             process = self._processes.get(run_id)
             returncode = process.poll() if process is not None else None
             if process is not None and returncode is not None:
-                report = _read_json(self._run_logs_dir(run_id) / "report.json")
+                report = _read_report(self._run_logs_dir(run_id) / "report.json")
                 requested_action = str(status.get("requested_action") or "")
                 lifecycle, report_status = _terminal_status_for_exit(
                     report=report,
@@ -1153,7 +1200,7 @@ class RunSupervisor:
                 # Reconcile an exited worker from its durable report.  Without a
                 # process handle we cannot obtain an exit code, so a missing
                 # report is still a failure (never an implicit completion).
-                report = _read_json(self._run_logs_dir(run_id) / "report.json")
+                report = _read_report(self._run_logs_dir(run_id) / "report.json")
                 requested_action = str(status.get("requested_action") or "")
                 lifecycle, report_status = _terminal_status_for_exit(
                     report=report,
@@ -1184,7 +1231,7 @@ class RunSupervisor:
                 # Their final manager report is still authoritative for the
                 # audit outcome, but a missing report remains ``idle`` rather
                 # than being guessed as successful.
-                report = _read_json(self._run_logs_dir(run_id) / "report.json")
+                report = _read_report(self._run_logs_dir(run_id) / "report.json")
                 lifecycle, report_status = _terminal_status_for_exit(
                     report=report,
                     returncode=0 if report else 1,
@@ -1258,7 +1305,7 @@ class RunSupervisor:
                 continue
             try:
                 status = self._refresh(run_dir.name)
-                report = _read_json(logs / "report.json")
+                report = _read_report(logs / "report.json")
                 owner = _read_json(run_dir / "control" / "owner.json")
                 mtime = run_dir.stat().st_mtime
             except (OSError, RuntimeError, ValueError):
@@ -1847,7 +1894,7 @@ class RunSupervisor:
 
         self._assert_run_scope(run_id)
         bus = self._bus(run_id)
-        run_report = report if isinstance(report, dict) else _read_json(self._run_logs_dir(run_id) / "report.json")
+        run_report = report if isinstance(report, dict) else _read_report(self._run_logs_dir(run_id) / "report.json")
         with self._lifecycle_lock:
             current = bus.read_status()
             requested_action = str(current.get("requested_action") or "")
@@ -2049,7 +2096,7 @@ class RunSupervisor:
                 # The signal raced with process exit.  Do not leave a durable
                 # ``stopping`` state behind: reconcile from the final report,
                 # or record a crash when the worker vanished without one.
-                report = _read_json(self._run_logs_dir(run_id) / "report.json")
+                report = _read_report(self._run_logs_dir(run_id) / "report.json")
                 lifecycle, report_status = _terminal_status_for_exit(
                     report=report,
                     returncode=0 if report else 1,

--- a/tests/supervisor/test_oversized_report.py
+++ b/tests/supervisor/test_oversized_report.py
@@ -1,0 +1,140 @@
+"""A report that outgrows the control-record cap must still be read.
+
+A finished report embeds every round, so a long run can legally exceed the
+8 MiB cap that the supervisor's generic control-record reader enforces.  The
+lifecycle pollers treat an empty dict as *no report*, and the failure path
+then overwrites the real report with a synthetic stub, so a report that only
+looked missing must be read in full instead of silently dropped.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import lh_harness.supervisor.service as service
+from lh_harness.supervisor.service import RunSupervisor
+
+# 10 MiB comfortably beats the 8 MiB cap but stays a fast test fixture.
+_BLOB_SIZE = 10 * 1024 * 1024
+
+
+class _ExitedProcess:
+    pid = 7777
+    returncode = None
+
+    def poll(self) -> int | None:
+        return self.returncode
+
+
+def _started_run(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> tuple[RunSupervisor, str, Path, _ExitedProcess]:
+    process = _ExitedProcess()
+    monkeypatch.setattr("lh_harness.supervisor.service.subprocess.Popen", lambda *a, **k: process)
+    supervisor = RunSupervisor(tmp_path / "runs", workspace_root=tmp_path / "workspace")
+    created = supervisor.create_run(task="long run")
+    run_dir = tmp_path / "runs" / created["id"]
+    (run_dir / "logs").mkdir(parents=True, exist_ok=True)
+    return supervisor, created["id"], run_dir / "logs", process
+
+
+def _write_report(logs: Path, report: dict[str, object]) -> None:
+    (logs / "report.json").write_text(json.dumps(report, ensure_ascii=False), encoding="utf-8")
+
+
+def _completed_report(extra_bytes: int = 0) -> dict[str, object]:
+    return {
+        "schema_version": 2,
+        "status": "complete",
+        "completion_satisfied": True,
+        "rounds_run": 90,
+        "final_response": "done",
+        # Rounds carry full executor transcripts; this stands in for them.
+        "rounds": [{"round_index": 1, "plan_text": "x" * extra_bytes}],
+    }
+
+
+def test_oversized_completed_report_is_not_discarded_as_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    supervisor, run_id, logs, process = _started_run(tmp_path, monkeypatch)
+    _write_report(logs, _completed_report(_BLOB_SIZE))
+    process.returncode = 0
+
+    status = supervisor.status(run_id)
+
+    assert status["status"] == "completed"
+    assert status["report_status"] == "completed"
+    assert "failure_reason" not in status
+    assert not (logs / "crash_report.json").exists()
+    # The real report must survive untouched: the stub overwrite is the bug.
+    persisted = json.loads((logs / "report.json").read_text(encoding="utf-8"))
+    assert persisted["status"] == "complete"
+    assert persisted["completion_satisfied"] is True
+    assert len(persisted["rounds"][0]["plan_text"]) == _BLOB_SIZE
+
+
+def test_oversized_failure_report_is_still_the_failure_authority(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    supervisor, run_id, logs, process = _started_run(tmp_path, monkeypatch)
+    report = {
+        "schema_version": 2,
+        "status": "failed",
+        "completion_satisfied": False,
+        "failure_reason": "the executor backend timed out",
+        "rounds": [{"round_index": 1, "plan_text": "x" * _BLOB_SIZE}],
+    }
+    _write_report(logs, report)
+    process.returncode = 1
+
+    status = supervisor.status(run_id)
+
+    assert status["status"] == "failed"
+    assert status["report_status"] == "failed"
+    # The report's own reason must win, not the generic exit-code fallback.
+    assert status["failure_reason"] == "the executor backend timed out"
+    persisted = json.loads((logs / "report.json").read_text(encoding="utf-8"))
+    assert persisted == report
+
+
+def test_an_oversized_report_far_beyond_the_cap_is_still_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    supervisor, run_id, logs, process = _started_run(tmp_path, monkeypatch)
+    # Sparse: the cap check happens before any read, so one byte on disk is
+    # enough to stand in for a multi-gigabyte hostile file.
+    with (logs / "report.json").open("wb") as handle:
+        handle.seek(256 * 1024 * 1024 + 4096)
+        handle.write(b"\x00")
+    process.returncode = 0
+
+    status = supervisor.status(run_id)
+
+    assert status["status"] == "failed"
+    assert (logs / "crash_report.json").exists()
+
+
+def test_read_report_parses_beyond_the_control_cap(tmp_path: Path) -> None:
+    path = tmp_path / "report.json"
+    report = _completed_report(9 * 1024 * 1024)
+    path.write_text(json.dumps(report, ensure_ascii=False), encoding="utf-8")
+
+    assert service._read_report(path)["completion_satisfied"] is True
+    assert (
+        service._read_report(path)["rounds"][0]["plan_text"]
+        == "x" * (9 * 1024 * 1024)
+    )
+    assert service._read_report(tmp_path / "missing.json") == {}
+
+
+def test_read_report_rejects_files_beyond_the_hard_ceiling(tmp_path: Path) -> None:
+    path = tmp_path / "report.json"
+    with path.open("wb") as handle:
+        handle.seek(256 * 1024 * 1024 + 1)
+        handle.write(b"\x00")
+
+    assert service._read_report(path) == {}


### PR DESCRIPTION
## What this fixes

`report.json` embeds the full transcript of every finished round, so a long run (up to `MAX_ROUNDS=1000`) can legally grow past the 8 MiB control-record cap that the supervisor uses to read JSON status files. `_read_json` (backed by `control_bus._read_json_file`) **silently returns `{}` for any file larger than 8 MiB** — it never reads the bytes and never complains.

Every lifecycle poller treats `{}` as *no report*. The consequences:

- A **completed** run (exit 0) whose report grew past the cap is reclassified `failed` ("worker exited without a final report"), and
- `_persist_failure_report` sees an empty report and **overwrites the real report on disk with a synthetic failed stub** — the completion evidence is physically destroyed, unrecoverable.
- On a failed run, the report's own `failure_reason` is discarded in favour of the exit-code fallback text.

## Fix

Add `_read_report` in `supervisor/service.py`: the same nofollow-anchored bounded read, with the ceiling raised to a **256 MiB hard cap** (still bounded, so a hostile run directory cannot pin a parser on a multi-gigabyte file). Over-cap, missing, or non-dict files still return `{}`, so the fail-closed behaviour is unchanged for genuinely broken reports.

All nine `report.json` read sites in the lifecycle path switch to `_read_report` (refresh branches, stop/abort race reconciliation, `finalize_attached_run`, run listing, historical scan). The one exception is `_resume_once`'s task-field fallback, which only reads the `task` key while the owner record and ledger remain the authoritative sources — keeping that on the small 8 MiB cap avoids paying for a large JSON parse where the value is never used.

Control records (`owner.json`, `status.json`, …) keep the 8 MiB cap; they are small by design and the cap is there deliberately.

## Tests

New `tests/supervisor/test_oversized_report.py` (5 tests, all red on the previous code):

- A 10 MiB `completed` report with exit 0 → run classified `completed`, no `crash_report.json`, report file byte-for-byte untouched (no stub overwrite).
- A 10 MiB `failed` report with exit 1 → `failure_reason` taken from the report itself, not the exit-code fallback.
- A sparse file past the 256 MiB ceiling (1 byte written, 256 MiB apparent size) → still treated as no report → `failed` + `crash_report.json`, confirming the cap is enforced and fail-closed.
- `_read_report` unit tests: parses a >8 MiB report; returns `{}` for a missing path.
- `_read_report` unit test: past-cap sparse file returns `{}` without reading it.